### PR TITLE
fix: handle empty preflight args in upgrade preflight wrapper

### DIFF
--- a/scripts/bin/blueprint/upgrade_consumer_preflight.sh
+++ b/scripts/bin/blueprint/upgrade_consumer_preflight.sh
@@ -92,12 +92,20 @@ while [[ "$#" -gt 0 ]]; do
 done
 
 log_info "running blueprint upgrade preflight source=${BLUEPRINT_UPGRADE_SOURCE:-auto} ref=${BLUEPRINT_UPGRADE_REF:-unset}"
-run_cmd "$ROOT_DIR/scripts/bin/blueprint/upgrade_consumer.sh" \
-  --dry-run \
-  --plan-path "$plan_path" \
-  --apply-path "$apply_path" \
-  --summary-path "$summary_path" \
-  "${forward_args[@]}"
+if [[ "${#forward_args[@]}" -gt 0 ]]; then
+  run_cmd "$ROOT_DIR/scripts/bin/blueprint/upgrade_consumer.sh" \
+    --dry-run \
+    --plan-path "$plan_path" \
+    --apply-path "$apply_path" \
+    --summary-path "$summary_path" \
+    "${forward_args[@]}"
+else
+  run_cmd "$ROOT_DIR/scripts/bin/blueprint/upgrade_consumer.sh" \
+    --dry-run \
+    --plan-path "$plan_path" \
+    --apply-path "$apply_path" \
+    --summary-path "$summary_path"
+fi
 
 run_cmd python3 "$ROOT_DIR/scripts/lib/blueprint/upgrade_preflight.py" \
   --repo-root "$ROOT_DIR" \

--- a/tests/blueprint/test_upgrade_preflight.py
+++ b/tests/blueprint/test_upgrade_preflight.py
@@ -11,6 +11,7 @@ from tests._shared.exec import DEFAULT_TEST_COMMAND_TIMEOUT_SECONDS, run_command
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 UPGRADE_PREFLIGHT_SCRIPT = REPO_ROOT / "scripts/lib/blueprint/upgrade_preflight.py"
+UPGRADE_PREFLIGHT_WRAPPER = REPO_ROOT / "scripts/bin/blueprint/upgrade_consumer_preflight.sh"
 
 
 class UpgradePreflightTests(unittest.TestCase):
@@ -133,3 +134,20 @@ class UpgradePreflightTests(unittest.TestCase):
 
             self.assertNotEqual(result.returncode, 0)
             self.assertIn("--plan-path must stay within the repository root", result.stderr)
+
+    def test_preflight_wrapper_handles_empty_forward_args_without_nounset_failure(self) -> None:
+        result = run_command(
+            [str(UPGRADE_PREFLIGHT_WRAPPER)],
+            cwd=REPO_ROOT,
+            env={
+                "BLUEPRINT_UPGRADE_SOURCE": str(REPO_ROOT),
+                "BLUEPRINT_UPGRADE_REF": "HEAD",
+            },
+            timeout_seconds=DEFAULT_TEST_COMMAND_TIMEOUT_SECONDS,
+        )
+
+        combined_output = f"{result.stdout}\n{result.stderr}"
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("running blueprint consumer upgrade", combined_output)
+        self.assertIn("generated-consumer repositories", combined_output)
+        self.assertNotIn("forward_args[@]: unbound variable", combined_output)


### PR DESCRIPTION
## Summary
This PR fixes a bug in `scripts/bin/blueprint/upgrade_consumer_preflight.sh` where calling the wrapper with no positional arguments could trigger `forward_args[@]: unbound variable` under `set -u`.

## Root Cause
The wrapper always expanded `"${forward_args[@]}"` even when no args were provided. In this shell/runtime behavior, that expansion could fail with nounset, causing the wrapper to exit before running the real preflight flow and emitting misleading success telemetry.

## Changes
- Guarded forwarding logic in `upgrade_consumer_preflight.sh`:
  - When `forward_args` is non-empty, pass them through.
  - When empty, invoke `upgrade_consumer.sh` without array expansion.
- Added regression test in `tests/blueprint/test_upgrade_preflight.py`:
  - `test_preflight_wrapper_handles_empty_forward_args_without_nounset_failure`
  - Verifies no nounset error appears, and the expected generated-consumer diagnostic is surfaced instead.

## Backward Compatibility
- Additive and non-breaking fix.
- No contract changes.
- Existing consumers are unaffected except that preflight wrapper behavior is now correct when invoked without extra args.

## Validation Evidence
Commands run locally:
- `python3 -m unittest -q tests.blueprint.test_upgrade_preflight`
- `make quality-hooks-run`

Both passed.

Fixes #33