### PR TITLE
fix: hard-fail missing infra templates and include source-contract template assets in upgrade plans

### DIFF
--- a/scripts/lib/blueprint/bootstrap_templates.sh
+++ b/scripts/lib/blueprint/bootstrap_templates.sh
@@ -25,7 +25,8 @@ bootstrap_template_content() {
   local template_path
   template_path="$(bootstrap_template_path "$namespace" "$template_rel")"
   if [[ ! -f "$template_path" ]]; then
-    log_fatal "missing bootstrap template ($namespace): $template_path"
+    log_error "missing bootstrap template ($namespace): $template_path"
+    return 1
   fi
   cat "$template_path"
 }
@@ -52,7 +53,16 @@ ensure_file_from_template() {
   local target_path="$1"
   local namespace="$2"
   local template_rel="$3"
-  ensure_file_with_content "$target_path" "$(bootstrap_template_content "$namespace" "$template_rel")"
+  local content
+  if ! content="$(bootstrap_template_content "$namespace" "$template_rel")"; then
+    log_fatal "cannot render bootstrap target without template ($namespace): $template_rel"
+  fi
+  if [[ -f "$target_path" && ! -s "$target_path" ]]; then
+    printf '%s' "$content" >"$target_path"
+    log_warn "rewrote empty bootstrap target from template: $target_path"
+    return 0
+  fi
+  ensure_file_with_content "$target_path" "$content"
 }
 
 ensure_file_from_rendered_template() {
@@ -60,5 +70,14 @@ ensure_file_from_rendered_template() {
   local namespace="$2"
   local template_rel="$3"
   shift 3 || true
-  ensure_file_with_content "$target_path" "$(render_bootstrap_template_content "$namespace" "$template_rel" "$@")"
+  local content
+  if ! content="$(render_bootstrap_template_content "$namespace" "$template_rel" "$@")"; then
+    log_fatal "cannot render bootstrap target without template ($namespace): $template_rel"
+  fi
+  if [[ -f "$target_path" && ! -s "$target_path" ]]; then
+    printf '%s' "$content" >"$target_path"
+    log_warn "rewrote empty bootstrap target from template: $target_path"
+    return 0
+  fi
+  ensure_file_with_content "$target_path" "$content"
 }

--- a/scripts/lib/blueprint/upgrade_consumer.py
+++ b/scripts/lib/blueprint/upgrade_consumer.py
@@ -260,41 +260,55 @@ def _contract_paths(contract: BlueprintContract) -> tuple[set[str], set[str], se
     return required_files, source_only, consumer_seeded, init_managed, conditional
 
 
-def _protected_roots(contract: BlueprintContract) -> set[str]:
-    ownership = contract.make_contract.ownership
-    roots = set(contract.script_contract.platform_editable_roots)
-    roots.add(ownership.platform_editable_file)
-    roots.add(ownership.platform_editable_include_dir)
-    roots.add(contract.docs_contract.platform_docs.root)
-    return {root.rstrip("/") for root in roots}
+def _managed_roots(contract: BlueprintContract) -> set[str]:
+    return {root.rstrip("/") for root in contract.script_contract.blueprint_managed_roots}
+
+
+def _merge_path_sets(*path_sets: set[str]) -> set[str]:
+    merged: set[str] = set()
+    for path_set in path_sets:
+        merged.update(path_set)
+    return merged
+
+
+def _protected_roots(contract: BlueprintContract, source_contract: BlueprintContract | None = None) -> set[str]:
+    def roots_for(value: BlueprintContract) -> set[str]:
+        ownership = value.make_contract.ownership
+        roots = set(value.script_contract.platform_editable_roots)
+        roots.add(ownership.platform_editable_file)
+        roots.add(ownership.platform_editable_include_dir)
+        roots.add(value.docs_contract.platform_docs.root)
+        return {root.rstrip("/") for root in roots}
+
+    roots = roots_for(contract)
+    if source_contract is not None:
+        roots.update(roots_for(source_contract))
+    return roots
 
 
 def _collect_candidate_paths(
     repo_root: Path,
     source_repo: Path,
-    contract: BlueprintContract,
+    managed_dir_roots: set[str],
     required_files: set[str],
     init_managed: set[str],
     conditional_entries: set[str],
 ) -> tuple[set[str], set[str], set[str]]:
     explicit_file_paths: set[str] = set(required_files | init_managed)
-    managed_dir_roots: set[str] = {
-        root.rstrip("/")
-        for root in contract.script_contract.blueprint_managed_roots
-    }
+    managed_roots = set(managed_dir_roots)
 
     for entry in conditional_entries:
         normalized = entry.rstrip("/")
         source_candidate = source_repo / normalized
         target_candidate = repo_root / normalized
         if source_candidate.is_dir() or target_candidate.is_dir() or _entry_looks_like_dir(entry):
-            managed_dir_roots.add(normalized)
+            managed_roots.add(normalized)
         else:
             explicit_file_paths.add(normalized)
 
     source_files: set[str] = set()
     target_files: set[str] = set()
-    for root in sorted(managed_dir_roots):
+    for root in sorted(managed_roots):
         source_files.update(_collect_files_under(source_repo, root))
         target_files.update(_collect_files_under(repo_root, root))
 
@@ -306,7 +320,7 @@ def _collect_candidate_paths(
         if target_path.is_file():
             target_files.add(relative)
 
-    return source_files, target_files, managed_dir_roots
+    return source_files, target_files, managed_roots
 
 
 def _ownership_class(
@@ -1041,12 +1055,45 @@ def main() -> int:
             )
             return 1
 
+        source_contract: BlueprintContract | None = None
+        source_contract_path = source_repo / "blueprint/contract.yaml"
+        if source_contract_path.is_file():
+            try:
+                source_contract = load_blueprint_contract(source_contract_path)
+            except Exception as exc:  # pragma: no cover - defensive fallback for malformed source snapshots
+                print(
+                    f"warning: unable to load source contract at {source_contract_path}: {exc}; "
+                    "falling back to target repository contract scope",
+                    file=sys.stderr,
+                )
+
         required_files, source_only, consumer_seeded, init_managed, conditional = _contract_paths(contract)
+        managed_dir_roots = _managed_roots(contract)
+        if source_contract is not None:
+            (
+                source_required_files,
+                source_source_only,
+                source_consumer_seeded,
+                source_init_managed,
+                source_conditional,
+            ) = _contract_paths(source_contract)
+            required_files = _merge_path_sets(required_files, source_required_files)
+            source_only = _merge_path_sets(source_only, source_source_only)
+            consumer_seeded = _merge_path_sets(consumer_seeded, source_consumer_seeded)
+            init_managed = _merge_path_sets(init_managed, source_init_managed)
+            conditional = _merge_path_sets(conditional, source_conditional)
+            managed_dir_roots = _merge_path_sets(managed_dir_roots, _managed_roots(source_contract))
+
         source_files, target_files, managed_dir_roots = _collect_candidate_paths(
-            repo_root, source_repo, contract, required_files, init_managed, conditional
+            repo_root,
+            source_repo,
+            managed_dir_roots,
+            required_files,
+            init_managed,
+            conditional,
         )
         all_paths = sorted(source_files | target_files)
-        protected_roots = _protected_roots(contract)
+        protected_roots = _protected_roots(contract, source_contract)
 
         baseline_cache: dict[str, str | None] = {}
         entries = _classify_entries(

--- a/scripts/lib/quality/test_pyramid_contract.json
+++ b/scripts/lib/quality/test_pyramid_contract.json
@@ -17,6 +17,7 @@
         "tests/blueprint/test_init_repo_env.py",
         "tests/blueprint/test_upgrade_consumer.py",
         "tests/blueprint/test_upgrade_preflight.py",
+        "tests/blueprint/test_bootstrap_templates.py",
         "tests/blueprint/test_resync_consumer_seeds.py",
         "tests/blueprint/test_quality_contracts.py",
         "tests/blueprint/test_optional_runtime_contract_validation.py",

--- a/tests/blueprint/test_bootstrap_templates.py
+++ b/tests/blueprint/test_bootstrap_templates.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from pathlib import Path
+import shlex
+import tempfile
+import unittest
+
+from tests._shared.exec import DEFAULT_TEST_COMMAND_TIMEOUT_SECONDS, run_command
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+class BootstrapTemplateTests(unittest.TestCase):
+    def _run_bootstrap_snippet(self, snippet: str):
+        return run_command(
+            ["bash", "-lc", snippet],
+            cwd=REPO_ROOT,
+            timeout_seconds=DEFAULT_TEST_COMMAND_TIMEOUT_SECONDS,
+        )
+
+    def test_missing_template_fails_without_creating_empty_target(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_root = Path(tmpdir)
+            target = repo_root / "infra/local/helm/core/cert-manager.values.yaml"
+            snippet = "\n".join(
+                [
+                    "set -euo pipefail",
+                    f"ROOT_DIR={shlex.quote(str(repo_root))}",
+                    f"source {shlex.quote(str(REPO_ROOT / 'scripts/lib/shell/bootstrap.sh'))}",
+                    f"source {shlex.quote(str(REPO_ROOT / 'scripts/lib/blueprint/bootstrap_templates.sh'))}",
+                    'ensure_file_from_template "$ROOT_DIR/infra/local/helm/core/cert-manager.values.yaml" infra "infra/local/helm/core/cert-manager.values.yaml"',
+                ]
+            )
+            result = self._run_bootstrap_snippet(snippet)
+
+            combined = f"{result.stdout}\n{result.stderr}"
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("missing bootstrap template (infra)", combined)
+            self.assertFalse(target.exists())
+
+    def test_existing_empty_target_is_repaired_from_template(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_root = Path(tmpdir)
+            template = repo_root / "scripts/templates/infra/bootstrap/infra/local/helm/core/cert-manager.values.yaml"
+            template.parent.mkdir(parents=True, exist_ok=True)
+            template.write_text("crds:\n  enabled: true\n", encoding="utf-8")
+
+            target = repo_root / "infra/local/helm/core/cert-manager.values.yaml"
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text("", encoding="utf-8")
+
+            snippet = "\n".join(
+                [
+                    "set -euo pipefail",
+                    f"ROOT_DIR={shlex.quote(str(repo_root))}",
+                    f"source {shlex.quote(str(REPO_ROOT / 'scripts/lib/shell/bootstrap.sh'))}",
+                    f"source {shlex.quote(str(REPO_ROOT / 'scripts/lib/blueprint/bootstrap_templates.sh'))}",
+                    'ensure_file_from_template "$ROOT_DIR/infra/local/helm/core/cert-manager.values.yaml" infra "infra/local/helm/core/cert-manager.values.yaml"',
+                ]
+            )
+            result = self._run_bootstrap_snippet(snippet)
+
+            self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+            self.assertEqual(target.read_text(encoding="utf-8"), "crds:\n  enabled: true")
+            self.assertIn("rewrote empty bootstrap target from template", f"{result.stdout}\n{result.stderr}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/blueprint/test_upgrade_consumer.py
+++ b/tests/blueprint/test_upgrade_consumer.py
@@ -54,12 +54,15 @@ def _commit_all(repo: Path, message: str) -> None:
     _require_success(_git(repo, "commit", "-m", message), f"git commit -m {message}")
 
 
-def _generated_contract_text() -> str:
-    return (REPO_ROOT / "blueprint/contract.yaml").read_text(encoding="utf-8").replace(
+def _generated_contract_text(*, drop_paths: tuple[str, ...] = ()) -> str:
+    content = (REPO_ROOT / "blueprint/contract.yaml").read_text(encoding="utf-8").replace(
         "repo_mode: template-source",
         "repo_mode: generated-consumer",
         1,
     )
+    for path in drop_paths:
+        content = content.replace(f"      - {path}\n", "")
+    return content
 
 
 def _template_version() -> str:
@@ -79,10 +82,10 @@ def _create_source_repo(root: Path, relative_path: str, base_content: str, head_
     return source_repo
 
 
-def _create_generated_repo(root: Path, relative_path: str, content: str) -> Path:
+def _create_generated_repo(root: Path, relative_path: str, content: str, *, contract_text: str | None = None) -> Path:
     target_repo = root / "target"
     _init_git_repo(target_repo)
-    _write(target_repo / "blueprint/contract.yaml", _generated_contract_text())
+    _write(target_repo / "blueprint/contract.yaml", contract_text or _generated_contract_text())
     _write(target_repo / ".gitignore", "artifacts/\n")
     _write(target_repo / relative_path, content)
     _commit_all(target_repo, "initial generated")
@@ -377,6 +380,60 @@ class UpgradeConsumerTests(unittest.TestCase):
             self.assertNotIn("required-manual-action", str(dependency_entry.get("reason", "")))
             self.assertEqual(plan.get("required_manual_actions"), [])
             self.assertEqual(plan.get("summary", {}).get("required_manual_action_count"), 0)
+
+    def test_upgrade_plan_includes_new_template_assets_from_source_contract_when_target_contract_lags(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_root = Path(tmpdir)
+            source_repo = tmp_root / "source"
+            _init_git_repo(source_repo)
+
+            template_a = "scripts/templates/infra/bootstrap/infra/local/helm/core/cert-manager.values.yaml"
+            template_b = "scripts/templates/infra/bootstrap/infra/gitops/platform/base/extensions/kustomization.yaml"
+            _write(source_repo / "blueprint/contract.yaml", (REPO_ROOT / "blueprint/contract.yaml").read_text(encoding="utf-8"))
+            _write(source_repo / template_a, "crds:\n  enabled: true\n")
+            _write(source_repo / template_b, "apiVersion: kustomize.config.k8s.io/v1beta1\nkind: Kustomization\n")
+            _write(source_repo / MANAGED_TEST_PATH, "baseline\n")
+            _commit_all(source_repo, "baseline")
+            _require_success(_git(source_repo, "tag", f"v{_template_version()}"), "git tag template version")
+            _write(source_repo / MANAGED_TEST_PATH, "baseline\nhead\n")
+            _commit_all(source_repo, "head")
+
+            lagging_contract = _generated_contract_text(
+                drop_paths=(
+                    template_a,
+                    template_b,
+                )
+            )
+            target_repo = _create_generated_repo(
+                tmp_root,
+                MANAGED_TEST_PATH,
+                "baseline\n",
+                contract_text=lagging_contract,
+            )
+            result = _run(
+                [
+                    sys.executable,
+                    str(UPGRADE_SCRIPT),
+                    "--repo-root",
+                    str(target_repo),
+                    "--source",
+                    str(source_repo),
+                    "--ref",
+                    "HEAD",
+                ],
+                cwd=REPO_ROOT,
+            )
+            self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+
+            plan = _load_json(target_repo / "artifacts/blueprint/upgrade_plan.json")
+            first_entry = _plan_entry(plan, template_a)
+            self.assertEqual(first_entry.get("action"), "create")
+            self.assertEqual(first_entry.get("source_exists"), True)
+            self.assertEqual(first_entry.get("target_exists"), False)
+            second_entry = _plan_entry(plan, template_b)
+            self.assertEqual(second_entry.get("action"), "create")
+            self.assertEqual(second_entry.get("source_exists"), True)
+            self.assertEqual(second_entry.get("target_exists"), False)
 
     def test_apply_runs_three_way_merge_for_diverged_blueprint_managed_file(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary
This PR fixes the local bootstrap/upgrade drift described in issue #34.

### Root causes addressed
1. **Bootstrap template failure was non-fatal in practice**
- `ensure_file_from_template` and `ensure_file_from_rendered_template` used command substitution directly.
- Missing templates could fail in a subshell while the caller continued and created **empty target files**.

2. **Upgrade planning could miss newly introduced template assets**
- `upgrade_consumer.py` scoped candidate paths primarily from the target repo contract.
- When a generated consumer contract lagged behind source, newly added template assets could be omitted from plan/apply.

## Design
### Bootstrap template handling
- `scripts/lib/blueprint/bootstrap_templates.sh`
  - `bootstrap_template_content` now returns non-zero on missing templates.
  - Callers now explicitly check template resolution and `log_fatal` in parent shell.
  - Added empty-file repair behavior: if an existing template-backed target is zero bytes, rewrite it from template content and warn.

### Upgrade planning scope
- `scripts/lib/blueprint/upgrade_consumer.py`
  - Load source contract (when available) and merge source + target contract scopes for:
    - `required_files`
    - `source_only_paths`
    - `consumer_seeded_paths`
    - `init_managed_paths`
    - `conditional_scaffold_paths`
    - blueprint-managed roots
  - Union protected roots from both contracts for safety.
  - Result: lagging generated-consumer contracts still pick up newly introduced blueprint-managed template assets in upgrade plans.

## Tests
- Added `tests/blueprint/test_bootstrap_templates.py`
  - missing-template path now fails and does not create empty target file
  - existing zero-byte target is repaired from template content
- Extended `tests/blueprint/test_upgrade_consumer.py`
  - verifies upgrade plan includes new template assets from source contract when target contract is lagging
- Updated `scripts/lib/quality/test_pyramid_contract.json` to classify the new test file as unit.

## Backward-Compatibility Notes
- **Additive vs behavior-changing**
  - Additive: source+target contract scope merge for upgrade planning.
  - Behavior-changing (bug fix): missing bootstrap templates now stop execution instead of silently continuing.
- **Default behavior with features disabled**
  - No feature toggles changed.
- **Impact on existing generated repos**
  - Positive/safe: upgrade planning captures missing template assets more reliably.
  - Existing zero-byte template-backed files can now self-repair during bootstrap.
- **Upgrade/rebootstrap required?**
  - No full rebootstrap required.
- **Migration steps for already-generated repos**
  1. `make blueprint-resync-consumer-seeds`
  2. `BLUEPRINT_RESYNC_APPLY_SAFE=true make blueprint-resync-consumer-seeds`
  3. `make blueprint-upgrade-consumer-preflight`
  4. `BLUEPRINT_UPGRADE_APPLY=true make blueprint-upgrade-consumer`
  5. `make blueprint-upgrade-consumer-validate`
  6. `make infra-validate`

## Validation Evidence
- `python3 -m unittest -q tests.blueprint.test_bootstrap_templates`
- `python3 -m unittest -q tests.blueprint.test_upgrade_consumer`
- `make quality-hooks-run`

Fixes #34