### PR TITLE
fix: no-op ESO reconcile when runtime contract set is empty

### DIFF
--- a/docs/platform/consumer/runtime_credentials_eso.md
+++ b/docs/platform/consumer/runtime_credentials_eso.md
@@ -79,6 +79,7 @@ make auth-reconcile-eso-runtime-secrets
 Defaults live in `blueprint/repo.init.env`.
 `KEYCLOAK_OPTIONAL_MODULE_RECONCILIATION_ENABLED` gates optional-module Keycloak reconciliation (Workflows/Langfuse) during module deploy flows.
 `RUNTIME_CREDENTIALS_REQUIRED` does not disable reconciliation; it only switches reconcile failures from warning mode (`false`) to hard-fail mode (`true`).
+If the effective contract set resolves to empty (`contracts=0`), reconciliation exits as a no-op success (`status=noop-empty-contract-set`) and skips source-secret checks.
 
 Additional reconcile knobs:
 - `RUNTIME_CREDENTIALS_SOURCE_SECRET_NAME` (default `runtime-credentials-source`)

--- a/scripts/bin/platform/auth/reconcile_eso_runtime_secrets.sh
+++ b/scripts/bin/platform/auth/reconcile_eso_runtime_secrets.sh
@@ -196,7 +196,7 @@ external_secret_checked=""
 target_secret_checked=""
 declare -a ESO_SECRET_CONTRACTS=()
 
-while IFS=$'\t' read -r contract_id contract_module contract_namespace contract_external_secret contract_target_secret contract_target_keys; do
+while IFS='|' read -r contract_id contract_module contract_namespace contract_external_secret contract_target_secret contract_target_keys; do
   [[ -n "$contract_id" ]] || continue
 
   if [[ -n "$contract_module" ]] && ! is_module_enabled "$contract_module"; then
@@ -208,122 +208,136 @@ while IFS=$'\t' read -r contract_id contract_module contract_namespace contract_
     "$contract_external_secret" \
     "$contract_target_secret" \
     "$contract_target_keys"
-done < <(python3 "$runtime_identity_contract_cli" eso-contracts)
+done < <(python3 "$runtime_identity_contract_cli" eso-contracts | tr $'\t' '|')
 
-if tooling_is_execution_enabled; then
-  apply_mode="kubectl-apply-kustomize"
-fi
-run_kustomize_apply "$ROOT_DIR/infra/gitops/platform/base/security"
-
-source_literals=()
-if literal_output="$(parse_literal_pairs "$RUNTIME_CREDENTIALS_SOURCE_SECRET_LITERALS")"; then
-  if [[ -n "$literal_output" ]]; then
-    while IFS= read -r literal_pair; do
-      [[ -n "$literal_pair" ]] || continue
-      source_literals+=("$literal_pair")
-    done <<<"$literal_output"
-  fi
-else
-  record_reconcile_issue "invalid RUNTIME_CREDENTIALS_SOURCE_SECRET_LITERALS format; expected key=value,key2=value2"
-fi
-
-if (( ${#source_literals[@]} > 0 )); then
-  source_seed_mode="manifest-rendered"
-  if tooling_is_execution_enabled; then
-    source_seed_mode="kubectl-apply"
-  fi
-  apply_optional_module_secret_from_literals \
-    "$RUNTIME_CREDENTIALS_SOURCE_NAMESPACE" \
-    "$RUNTIME_CREDENTIALS_SOURCE_SECRET_NAME" \
-    "${source_literals[@]}"
-elif tooling_is_execution_enabled; then
-  if kubectl -n "$RUNTIME_CREDENTIALS_SOURCE_NAMESPACE" get secret "$RUNTIME_CREDENTIALS_SOURCE_SECRET_NAME" >/dev/null 2>&1; then
-    source_seed_mode="existing-source-secret"
-    source_secret_present="true"
-  else
-    source_seed_mode="missing-source-secret"
-    source_secret_present="false"
-    record_reconcile_issue \
-      "source secret ${RUNTIME_CREDENTIALS_SOURCE_NAMESPACE}/${RUNTIME_CREDENTIALS_SOURCE_SECRET_NAME} missing and no literals provided"
-  fi
-fi
-
-if tooling_is_execution_enabled; then
-  require_command kubectl
-
-  if wait_for_crd_established "clustersecretstores.external-secrets.io" "$runtime_wait_timeout" \
-    && wait_for_crd_established "externalsecrets.external-secrets.io" "$runtime_wait_timeout"; then
-    crd_status="ready"
-  else
-    crd_status="timeout"
-    record_reconcile_issue "ESO CRDs did not report Established=True within ${runtime_wait_timeout}s"
-  fi
-
-  external_secret_status="ready"
-  target_secret_status="ready"
+status="success"
+if (( ${#ESO_SECRET_CONTRACTS[@]} == 0 )); then
+  status="noop-empty-contract-set"
+  apply_mode="skipped-empty-contract-set"
+  source_seed_mode="skipped-empty-contract-set"
+  source_secret_present="not-applicable"
+  crd_status="not-applicable"
+  external_secret_status="not-applicable"
+  target_secret_status="not-applicable"
   target_missing_keys="none"
   external_secret_checked="none"
   target_secret_checked="none"
-  for contract_entry in "${ESO_SECRET_CONTRACTS[@]}"; do
-    IFS='|' read -r contract_namespace contract_external_secret contract_target_secret contract_target_keys <<<"$contract_entry"
+  log_info "runtime credential contract set empty; skipping source secret checks"
+else
+  if tooling_is_execution_enabled; then
+    apply_mode="kubectl-apply-kustomize"
+  fi
+  run_kustomize_apply "$ROOT_DIR/infra/gitops/platform/base/security"
 
-    if wait_for_external_secret_ready \
-      "$contract_namespace" \
-      "$contract_external_secret" \
-      "$runtime_wait_timeout"; then
-      if [[ "$external_secret_checked" == "none" ]]; then
-        external_secret_checked="${contract_namespace}/${contract_external_secret}"
-      else
-        external_secret_checked+=",${contract_namespace}/${contract_external_secret}"
-      fi
-    else
-      external_secret_status="timeout"
-      record_reconcile_issue \
-        "ExternalSecret ${contract_namespace}/${contract_external_secret} not Ready within ${runtime_wait_timeout}s"
+  source_literals=()
+  if literal_output="$(parse_literal_pairs "$RUNTIME_CREDENTIALS_SOURCE_SECRET_LITERALS")"; then
+    if [[ -n "$literal_output" ]]; then
+      while IFS= read -r literal_pair; do
+        [[ -n "$literal_pair" ]] || continue
+        source_literals+=("$literal_pair")
+      done <<<"$literal_output"
     fi
-
-    target_check_output="$(verify_target_secret_keys \
-      "$contract_namespace" \
-      "$contract_target_secret" \
-      "$contract_target_keys" || true)"
-    if [[ "$target_check_output" == "ok" ]]; then
-      if [[ "$target_secret_checked" == "none" ]]; then
-        target_secret_checked="${contract_namespace}/${contract_target_secret}"
-      else
-        target_secret_checked+=",${contract_namespace}/${contract_target_secret}"
-      fi
-      continue
-    fi
-
-    if [[ "$target_check_output" == "__missing_secret__" ]]; then
-      target_secret_status="missing"
-      if [[ "$target_missing_keys" == "none" ]]; then
-        target_missing_keys="${contract_namespace}/${contract_target_secret}:missing"
-      else
-        target_missing_keys+=",${contract_namespace}/${contract_target_secret}:missing"
-      fi
-      record_reconcile_issue \
-        "target secret ${contract_namespace}/${contract_target_secret} is missing"
-      continue
-    fi
-
-    target_secret_status="missing-keys"
-    if [[ "$target_missing_keys" == "none" ]]; then
-      target_missing_keys="${contract_namespace}/${contract_target_secret}:${target_check_output}"
-    else
-      target_missing_keys+=",${contract_namespace}/${contract_target_secret}:${target_check_output}"
-    fi
-    record_reconcile_issue \
-      "target secret ${contract_namespace}/${contract_target_secret} missing key(s): $target_check_output"
-  done
-fi
-
-status="success"
-if (( ${#RUNTIME_RECONCILE_ISSUES[@]} > 0 )); then
-  if [[ "$RUNTIME_CREDENTIALS_REQUIRED_NORMALIZED" == "true" ]]; then
-    status="failed-required"
   else
-    status="warn-and-skip"
+    record_reconcile_issue "invalid RUNTIME_CREDENTIALS_SOURCE_SECRET_LITERALS format; expected key=value,key2=value2"
+  fi
+
+  if (( ${#source_literals[@]} > 0 )); then
+    source_seed_mode="manifest-rendered"
+    if tooling_is_execution_enabled; then
+      source_seed_mode="kubectl-apply"
+    fi
+    apply_optional_module_secret_from_literals \
+      "$RUNTIME_CREDENTIALS_SOURCE_NAMESPACE" \
+      "$RUNTIME_CREDENTIALS_SOURCE_SECRET_NAME" \
+      "${source_literals[@]}"
+  elif tooling_is_execution_enabled; then
+    if kubectl -n "$RUNTIME_CREDENTIALS_SOURCE_NAMESPACE" get secret "$RUNTIME_CREDENTIALS_SOURCE_SECRET_NAME" >/dev/null 2>&1; then
+      source_seed_mode="existing-source-secret"
+      source_secret_present="true"
+    else
+      source_seed_mode="missing-source-secret"
+      source_secret_present="false"
+      record_reconcile_issue \
+        "source secret ${RUNTIME_CREDENTIALS_SOURCE_NAMESPACE}/${RUNTIME_CREDENTIALS_SOURCE_SECRET_NAME} missing and no literals provided"
+    fi
+  fi
+
+  if tooling_is_execution_enabled; then
+    require_command kubectl
+
+    if wait_for_crd_established "clustersecretstores.external-secrets.io" "$runtime_wait_timeout" \
+      && wait_for_crd_established "externalsecrets.external-secrets.io" "$runtime_wait_timeout"; then
+      crd_status="ready"
+    else
+      crd_status="timeout"
+      record_reconcile_issue "ESO CRDs did not report Established=True within ${runtime_wait_timeout}s"
+    fi
+
+    external_secret_status="ready"
+    target_secret_status="ready"
+    target_missing_keys="none"
+    external_secret_checked="none"
+    target_secret_checked="none"
+    for contract_entry in "${ESO_SECRET_CONTRACTS[@]}"; do
+      IFS='|' read -r contract_namespace contract_external_secret contract_target_secret contract_target_keys <<<"$contract_entry"
+
+      if wait_for_external_secret_ready \
+        "$contract_namespace" \
+        "$contract_external_secret" \
+        "$runtime_wait_timeout"; then
+        if [[ "$external_secret_checked" == "none" ]]; then
+          external_secret_checked="${contract_namespace}/${contract_external_secret}"
+        else
+          external_secret_checked+=",${contract_namespace}/${contract_external_secret}"
+        fi
+      else
+        external_secret_status="timeout"
+        record_reconcile_issue \
+          "ExternalSecret ${contract_namespace}/${contract_external_secret} not Ready within ${runtime_wait_timeout}s"
+      fi
+
+      target_check_output="$(verify_target_secret_keys \
+        "$contract_namespace" \
+        "$contract_target_secret" \
+        "$contract_target_keys" || true)"
+      if [[ "$target_check_output" == "ok" ]]; then
+        if [[ "$target_secret_checked" == "none" ]]; then
+          target_secret_checked="${contract_namespace}/${contract_target_secret}"
+        else
+          target_secret_checked+=",${contract_namespace}/${contract_target_secret}"
+        fi
+        continue
+      fi
+
+      if [[ "$target_check_output" == "__missing_secret__" ]]; then
+        target_secret_status="missing"
+        if [[ "$target_missing_keys" == "none" ]]; then
+          target_missing_keys="${contract_namespace}/${contract_target_secret}:missing"
+        else
+          target_missing_keys+=",${contract_namespace}/${contract_target_secret}:missing"
+        fi
+        record_reconcile_issue \
+          "target secret ${contract_namespace}/${contract_target_secret} is missing"
+        continue
+      fi
+
+      target_secret_status="missing-keys"
+      if [[ "$target_missing_keys" == "none" ]]; then
+        target_missing_keys="${contract_namespace}/${contract_target_secret}:${target_check_output}"
+      else
+        target_missing_keys+=",${contract_namespace}/${contract_target_secret}:${target_check_output}"
+      fi
+      record_reconcile_issue \
+        "target secret ${contract_namespace}/${contract_target_secret} missing key(s): $target_check_output"
+    done
+  fi
+
+  if (( ${#RUNTIME_RECONCILE_ISSUES[@]} > 0 )); then
+    if [[ "$RUNTIME_CREDENTIALS_REQUIRED_NORMALIZED" == "true" ]]; then
+      status="failed-required"
+    else
+      status="warn-and-skip"
+    fi
   fi
 fi
 

--- a/scripts/templates/blueprint/bootstrap/docs/platform/consumer/runtime_credentials_eso.md
+++ b/scripts/templates/blueprint/bootstrap/docs/platform/consumer/runtime_credentials_eso.md
@@ -79,6 +79,7 @@ make auth-reconcile-eso-runtime-secrets
 Defaults live in `blueprint/repo.init.env`.
 `KEYCLOAK_OPTIONAL_MODULE_RECONCILIATION_ENABLED` gates optional-module Keycloak reconciliation (Workflows/Langfuse) during module deploy flows.
 `RUNTIME_CREDENTIALS_REQUIRED` does not disable reconciliation; it only switches reconcile failures from warning mode (`false`) to hard-fail mode (`true`).
+If the effective contract set resolves to empty (`contracts=0`), reconciliation exits as a no-op success (`status=noop-empty-contract-set`) and skips source-secret checks.
 
 Additional reconcile knobs:
 - `RUNTIME_CREDENTIALS_SOURCE_SECRET_NAME` (default `runtime-credentials-source`)

--- a/tests/infra/test_runtime_credentials_eso.py
+++ b/tests/infra/test_runtime_credentials_eso.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+import os
+from pathlib import Path
+import shlex
+import sys
+import tempfile
 import unittest
 
 from tests._shared.helpers import REPO_ROOT, module_flags_env, run_make
@@ -62,6 +67,57 @@ class RuntimeCredentialsEsoTests(unittest.TestCase):
         state = state_path.read_text(encoding="utf-8")
         self.assertIn("required=true", state)
         self.assertIn("status=failed-required", state)
+
+    def test_empty_contract_set_is_noop_without_source_secret_warning(self) -> None:
+        env = module_flags_env(profile="local-full")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            shim_dir = Path(tmpdir)
+            python_shim = shim_dir / "python3"
+            python_shim.write_text(
+                "\n".join(
+                    [
+                        "#!/usr/bin/env bash",
+                        "set -euo pipefail",
+                        f'target_contract_cli="{REPO_ROOT}/scripts/lib/infra/runtime_identity_contract.py"',
+                        'if [[ "${1:-}" == "$target_contract_cli" ]]; then',
+                        '  case "${2:-}" in',
+                        "    runtime-env-defaults)",
+                        "      cat <<'EOF'",
+                        "KEYCLOAK_OPTIONAL_MODULE_RECONCILIATION_ENABLED\ttrue",
+                        "RUNTIME_CREDENTIALS_SOURCE_NAMESPACE\tsecurity",
+                        "RUNTIME_CREDENTIALS_TARGET_NAMESPACE\tapps",
+                        "RUNTIME_CREDENTIALS_ESO_WAIT_TIMEOUT\t180",
+                        "RUNTIME_CREDENTIALS_REQUIRED\tfalse",
+                        "EOF",
+                        "      exit 0",
+                        "      ;;",
+                        "    eso-contracts)",
+                        "      exit 0",
+                        "      ;;",
+                        "  esac",
+                        "fi",
+                        f"exec {shlex.quote(sys.executable)} \"$@\"",
+                        "",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            python_shim.chmod(0o755)
+            env["PATH"] = f"{shim_dir}:{os.environ.get('PATH', '')}"
+
+            result = run_make("auth-reconcile-eso-runtime-secrets", env)
+
+        self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+        combined_output = result.stdout + result.stderr
+        self.assertIn("runtime credential contract set empty; skipping source secret checks", combined_output)
+        self.assertNotIn("missing and no literals provided", combined_output)
+
+        state_path = REPO_ROOT / "artifacts" / "infra" / "runtime_credentials_eso_reconcile.env"
+        self.assertTrue(state_path.exists(), msg="runtime credentials state artifact was not created")
+        state = state_path.read_text(encoding="utf-8")
+        self.assertIn("status=noop-empty-contract-set", state)
+        self.assertIn("source_secret_seed_mode=skipped-empty-contract-set", state)
+        self.assertIn("issue_count=0", state)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Fixes noisy runtime ESO reconciliation output when the effective runtime credential contract set is empty (`contracts=0`). Reconciliation now exits cleanly as an explicit no-op success instead of warning about a missing source secret.

## Root Cause
Two issues combined in this path:
1. The reconcile flow always proceeded into source-secret checks even when no effective contracts were enabled.
2. Tab-split parsing of `runtime_identity_contract.py eso-contracts` collapsed empty module fields, which could incorrectly drop mandatory contracts in shell parsing.

## What Changed
- `scripts/bin/platform/auth/reconcile_eso_runtime_secrets.sh`
  - Added early short-circuit after effective contract resolution:
    - logs info: `runtime credential contract set empty; skipping source secret checks`
    - records no-op success state: `status=noop-empty-contract-set`
    - skips source-secret warnings/checks for empty contract sets
  - Fixed ESO contract row parsing to preserve empty module fields by converting tab-delimited rows to non-whitespace delimiters before shell parsing.
- `tests/infra/test_runtime_credentials_eso.py`
  - Added deterministic regression test for empty contract set path (shimmed `python3` contract output):
    - verifies no source-secret warning is emitted
    - verifies no-op status is written to state artifact
- Docs updated (source + bootstrap template mirror):
  - `docs/platform/consumer/runtime_credentials_eso.md`
  - `scripts/templates/blueprint/bootstrap/docs/platform/consumer/runtime_credentials_eso.md`
  - Added explicit note for `contracts=0` no-op success behavior.

## Backward-Compatibility Notes
- **Additive vs behavior-changing**
  - Behavior improves for empty contract sets: warning path is replaced by explicit no-op success.
- **Default behavior when features are disabled**
  - Unchanged for non-empty contract sets; existing warning/fail-fast behavior still applies based on `RUNTIME_CREDENTIALS_REQUIRED`.
- **Impact on existing generated repos**
  - Safe improvement; no consumer-owned paths are overwritten by this PR directly.
- **Upgrade/rebootstrap requirement**
  - Existing generated repos should resync/upgrade to receive the script and docs update.

## Migration Steps (Already-Generated Repos)
1. `make blueprint-resync-consumer-seeds`
2. `BLUEPRINT_RESYNC_APPLY_SAFE=true make blueprint-resync-consumer-seeds`
3. `make blueprint-upgrade-consumer-preflight`
4. `BLUEPRINT_UPGRADE_APPLY=true make blueprint-upgrade-consumer`
5. `make blueprint-upgrade-consumer-validate`
6. `make infra-validate`

## Validation Evidence
Executed locally:
- `python3 -m unittest -q tests.infra.test_runtime_credentials_eso`
- `make infra-validate`
- `make quality-hooks-run`

Fixes #40
