### PR TITLE
fix: prevent local-lite smoke failures from eager Keycloak auto-sync

### DIFF
--- a/AGENTS.decisions.md
+++ b/AGENTS.decisions.md
@@ -77,6 +77,7 @@
   - Core ESO reconciliation is mandatory; there is no feature toggle to disable `auth-reconcile-eso-runtime-secrets`.
 - Keycloak is a mandatory runtime identity baseline:
   - ArgoCD overlays always include environment-specific `infra/gitops/argocd/core/<env>/keycloak.yaml` applications.
+  - Local profile keeps Keycloak Argo application sync manual by default (`infra/gitops/argocd/core|overlays/local/keycloak.yaml`) so local-lite smoke remains stable until runtime credentials are reconciled.
   - Keycloak deploys in namespace `security` and consumes ESO-issued `security/keycloak-runtime-credentials`.
   - Keycloak realm model is module-scoped (`iap`, `workflows`, `langfuse`) so each auth consumer has a dedicated realm contract.
   - STACKIT profiles always provision a dedicated managed PostgreSQL instance for Keycloak (no toggle); local profiles always use the shared local Postgres instance.

--- a/docs/platform/consumer/quickstart.md
+++ b/docs/platform/consumer/quickstart.md
@@ -102,6 +102,8 @@ For local live execution, the blueprint prefers the `docker-desktop` Kubernetes 
 Set `LOCAL_KUBE_CONTEXT` before running `infra-provision-deploy` if you want to override that default.
 Use `make auth-reconcile-eso-runtime-secrets` whenever you need an explicit runtime credential
 source-to-target ESO reconciliation pass (including readiness and target-secret verification).
+For local profiles, Keycloak Argo sync is manual by default; after a successful reconcile run,
+sync `platform-keycloak-local` explicitly from ArgoCD UI/CLI when you want to activate browser login.
 See [Runtime Credentials (ESO)](runtime_credentials_eso.md) for local seeding and managed-store wiring.
 
 Before publishing hosts or API routes, review [Endpoint Exposure Model](endpoint_exposure_model.md)

--- a/docs/platform/consumer/runtime_credentials_eso.md
+++ b/docs/platform/consumer/runtime_credentials_eso.md
@@ -65,6 +65,8 @@ make auth-reconcile-eso-runtime-secrets
   - `infra/gitops/argocd/core/<env>/keycloak.yaml`
 - Keycloak admin and DB bootstrap credentials come from ESO target:
   - `security/keycloak-runtime-credentials`
+- Local overlay keeps Keycloak Argo sync manual by default (`infra/gitops/argocd/overlays/local/keycloak.yaml`)
+  so local-lite smoke does not fail before runtime credentials are available.
 - Module-scoped realms are used by default:
   - IAP realm: `KEYCLOAK_REALM_IAP` (default `iap`)
   - Workflows realm: `KEYCLOAK_REALM_WORKFLOWS` (default `workflows`)
@@ -97,6 +99,11 @@ make auth-reconcile-eso-runtime-secrets
 
 Resulting state artifact:
 - `artifacts/infra/runtime_credentials_eso_reconcile.env`
+
+After local runtime credentials are ready, manually sync the local Keycloak Argo application (UI or CLI):
+```bash
+argocd app sync platform-keycloak-local
+```
 
 ## Managed Profile Flow
 

--- a/infra/gitops/argocd/core/local/keycloak.yaml
+++ b/infra/gitops/argocd/core/local/keycloak.yaml
@@ -80,9 +80,6 @@ spec:
           existingSecretKey: KEYCLOAK_DATABASE_PASSWORD
         extraManifests: []
   syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
     syncOptions:
       - CreateNamespace=true
       - PrunePropagationPolicy=foreground

--- a/infra/gitops/argocd/overlays/local/keycloak.yaml
+++ b/infra/gitops/argocd/overlays/local/keycloak.yaml
@@ -80,9 +80,6 @@ spec:
           existingSecretKey: KEYCLOAK_DATABASE_PASSWORD
         extraManifests: []
   syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
     syncOptions:
       - CreateNamespace=true
       - PrunePropagationPolicy=foreground

--- a/scripts/bin/blueprint/validate_contract.py
+++ b/scripts/bin/blueprint/validate_contract.py
@@ -185,6 +185,31 @@ def _kustomization_resources(path: Path) -> set[str]:
     return resources
 
 
+def _manifest_sync_policy_has_automated(content: str) -> bool:
+    lines = content.splitlines()
+    for idx, line in enumerate(lines):
+        if line.strip() != "syncPolicy:":
+            continue
+
+        parent_indent = len(line) - len(line.lstrip(" "))
+        cursor = idx + 1
+        while cursor < len(lines):
+            candidate = lines[cursor]
+            stripped = candidate.strip()
+            if not stripped or stripped.startswith("#"):
+                cursor += 1
+                continue
+
+            candidate_indent = len(candidate) - len(candidate.lstrip(" "))
+            if candidate_indent <= parent_indent:
+                break
+            if stripped.startswith("automated:"):
+                return True
+            cursor += 1
+        return False
+    return False
+
+
 def _validate_core_chart_values_contract(repo_root: Path) -> list[str]:
     errors: list[str] = []
 
@@ -257,9 +282,11 @@ def _validate_runtime_credentials_contract(repo_root: Path) -> list[str]:
         "infra/gitops/argocd/core/dev/keycloak.yaml",
         "infra/gitops/argocd/core/stage/keycloak.yaml",
         "infra/gitops/argocd/core/prod/keycloak.yaml",
+        "infra/gitops/argocd/overlays/local/keycloak.yaml",
         "scripts/bin/platform/auth/reconcile_eso_runtime_secrets.sh",
         "scripts/templates/blueprint/bootstrap/docs/platform/consumer/runtime_credentials_eso.md",
         "scripts/templates/infra/bootstrap/infra/gitops/argocd/core/keycloak.application.yaml.tmpl",
+        "scripts/templates/infra/bootstrap/infra/gitops/argocd/overlays/local/keycloak.yaml",
         "scripts/templates/blueprint/bootstrap/blueprint/runtime_identity_contract.yaml",
         "scripts/templates/infra/bootstrap/infra/gitops/platform/base/security/runtime-external-secrets-core.yaml",
     )
@@ -329,6 +356,30 @@ def _validate_runtime_credentials_contract(repo_root: Path) -> list[str]:
             errors.append(
                 f"infra/gitops/argocd/overlays/{env_name}/kustomization.yaml missing mandatory keycloak resource: "
                 f"{resource_path}"
+            )
+
+    keycloak_sync_policy_contract = {
+        "infra/gitops/argocd/core/local/keycloak.yaml": False,
+        "infra/gitops/argocd/overlays/local/keycloak.yaml": False,
+        "infra/gitops/argocd/core/dev/keycloak.yaml": True,
+        "infra/gitops/argocd/core/stage/keycloak.yaml": True,
+        "infra/gitops/argocd/core/prod/keycloak.yaml": True,
+    }
+    for relative_path, expected_automated in keycloak_sync_policy_contract.items():
+        manifest_path = repo_root / relative_path
+        if not manifest_path.is_file():
+            continue
+        has_automated = _manifest_sync_policy_has_automated(manifest_path.read_text(encoding="utf-8"))
+        if has_automated == expected_automated:
+            continue
+        if expected_automated:
+            errors.append(
+                f"{relative_path} must keep syncPolicy.automated enabled for managed profile convergence"
+            )
+        else:
+            errors.append(
+                f"{relative_path} must keep syncPolicy manual (syncPolicy.automated absent) "
+                "until runtime credentials are reconciled"
             )
 
     for consumer_path, dependency_path in RUNTIME_DEPENDENCY_EDGES:

--- a/scripts/bin/infra/bootstrap.sh
+++ b/scripts/bin/infra/bootstrap.sh
@@ -480,7 +480,9 @@ bootstrap_optional_manifest() {
   keycloak)
     keycloak_seed_env_defaults
     local keycloak_extra_manifests
+    local keycloak_sync_automated_block
     keycloak_extra_manifests="$(keycloak_extra_manifests_block)"
+    keycloak_sync_automated_block="$(keycloak_sync_automated_block "$env")"
     # Keycloak is a mandatory identity baseline; render under argocd/core even
     # though other modules continue using argocd/optional.
     ensure_file_from_rendered_template \
@@ -499,6 +501,7 @@ bootstrap_optional_manifest() {
       "KEYCLOAK_GATEWAY_NAME=$KEYCLOAK_GATEWAY_NAME" \
       "KEYCLOAK_GATEWAY_CLASS_NAME=$KEYCLOAK_GATEWAY_CLASS_NAME" \
       "KEYCLOAK_TLS_SECRET_NAME=$KEYCLOAK_TLS_SECRET_NAME" \
+      "KEYCLOAK_SYNC_AUTOMATED_BLOCK=$keycloak_sync_automated_block" \
       "KEYCLOAK_EXTRA_MANIFESTS_BLOCK=$keycloak_extra_manifests"
     if [[ "$env" == "local" ]]; then
       local keycloak_core_manifest="$ROOT_DIR/infra/gitops/argocd/core/local/keycloak.yaml"

--- a/scripts/lib/infra/keycloak.sh
+++ b/scripts/lib/infra/keycloak.sh
@@ -50,6 +50,23 @@ keycloak_public_endpoints_enabled() {
   [[ "$(normalize_bool "${PUBLIC_ENDPOINTS_ENABLED:-false}")" == "true" ]]
 }
 
+keycloak_sync_automated_block() {
+  local environment="${1:-$(profile_environment)}"
+
+  if [[ "$environment" == "local" ]]; then
+    # Keep local Keycloak manual by default until runtime credentials are
+    # reconciled, avoiding local-lite smoke regressions from missing secrets.
+    printf ''
+    return 0
+  fi
+
+  cat <<'EOF'
+    automated:
+      prune: true
+      selfHeal: true
+EOF
+}
+
 keycloak_extra_manifests_block() {
   if ! keycloak_public_endpoints_enabled; then
     printf '%s' "        extraManifests: []"

--- a/scripts/templates/blueprint/bootstrap/docs/platform/consumer/quickstart.md
+++ b/scripts/templates/blueprint/bootstrap/docs/platform/consumer/quickstart.md
@@ -102,6 +102,8 @@ For local live execution, the blueprint prefers the `docker-desktop` Kubernetes 
 Set `LOCAL_KUBE_CONTEXT` before running `infra-provision-deploy` if you want to override that default.
 Use `make auth-reconcile-eso-runtime-secrets` whenever you need an explicit runtime credential
 source-to-target ESO reconciliation pass (including readiness and target-secret verification).
+For local profiles, Keycloak Argo sync is manual by default; after a successful reconcile run,
+sync `platform-keycloak-local` explicitly from ArgoCD UI/CLI when you want to activate browser login.
 See [Runtime Credentials (ESO)](runtime_credentials_eso.md) for local seeding and managed-store wiring.
 
 Before publishing hosts or API routes, review [Endpoint Exposure Model](endpoint_exposure_model.md)

--- a/scripts/templates/blueprint/bootstrap/docs/platform/consumer/runtime_credentials_eso.md
+++ b/scripts/templates/blueprint/bootstrap/docs/platform/consumer/runtime_credentials_eso.md
@@ -65,6 +65,8 @@ make auth-reconcile-eso-runtime-secrets
   - `infra/gitops/argocd/core/<env>/keycloak.yaml`
 - Keycloak admin and DB bootstrap credentials come from ESO target:
   - `security/keycloak-runtime-credentials`
+- Local overlay keeps Keycloak Argo sync manual by default (`infra/gitops/argocd/overlays/local/keycloak.yaml`)
+  so local-lite smoke does not fail before runtime credentials are available.
 - Module-scoped realms are used by default:
   - IAP realm: `KEYCLOAK_REALM_IAP` (default `iap`)
   - Workflows realm: `KEYCLOAK_REALM_WORKFLOWS` (default `workflows`)
@@ -97,6 +99,11 @@ make auth-reconcile-eso-runtime-secrets
 
 Resulting state artifact:
 - `artifacts/infra/runtime_credentials_eso_reconcile.env`
+
+After local runtime credentials are ready, manually sync the local Keycloak Argo application (UI or CLI):
+```bash
+argocd app sync platform-keycloak-local
+```
 
 ## Managed Profile Flow
 

--- a/scripts/templates/infra/bootstrap/infra/gitops/argocd/core/keycloak.application.yaml.tmpl
+++ b/scripts/templates/infra/bootstrap/infra/gitops/argocd/core/keycloak.application.yaml.tmpl
@@ -80,9 +80,7 @@ spec:
           existingSecretKey: KEYCLOAK_DATABASE_PASSWORD
 {{KEYCLOAK_EXTRA_MANIFESTS_BLOCK}}
   syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
+{{KEYCLOAK_SYNC_AUTOMATED_BLOCK}}
     syncOptions:
       - CreateNamespace=true
       - PrunePropagationPolicy=foreground

--- a/scripts/templates/infra/bootstrap/infra/gitops/argocd/overlays/local/keycloak.yaml
+++ b/scripts/templates/infra/bootstrap/infra/gitops/argocd/overlays/local/keycloak.yaml
@@ -80,9 +80,6 @@ spec:
           existingSecretKey: KEYCLOAK_DATABASE_PASSWORD
         extraManifests: []
   syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
     syncOptions:
       - CreateNamespace=true
       - PrunePropagationPolicy=foreground

--- a/tests/blueprint/test_quality_contracts.py
+++ b/tests/blueprint/test_quality_contracts.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib.util
 from pathlib import Path
 import re
+import shutil
 import sys
 import tempfile
 import unittest
@@ -189,6 +190,86 @@ class QualityContractsTests(unittest.TestCase):
 
         self.assertIn(
             "infra/local/helm/core/cert-manager.values.yaml missing required values key mapping: crds.enabled",
+            errors,
+        )
+
+    def test_keycloak_local_manifest_defaults_to_manual_sync_policy(self) -> None:
+        local_core_manifest = _read("infra/gitops/argocd/core/local/keycloak.yaml")
+        local_overlay_manifest = _read("infra/gitops/argocd/overlays/local/keycloak.yaml")
+        local_overlay_template = _read("scripts/templates/infra/bootstrap/infra/gitops/argocd/overlays/local/keycloak.yaml")
+        keycloak_template = _read("scripts/templates/infra/bootstrap/infra/gitops/argocd/core/keycloak.application.yaml.tmpl")
+        infra_bootstrap = _read("scripts/bin/infra/bootstrap.sh")
+        keycloak_lib = _read("scripts/lib/infra/keycloak.sh")
+
+        for content in (local_core_manifest, local_overlay_manifest, local_overlay_template):
+            self.assertIn("syncPolicy:", content)
+            self.assertNotIn("\n    automated:\n", content)
+            self.assertIn("\n    syncOptions:\n", content)
+
+        for env_name in ("dev", "stage", "prod"):
+            non_local_manifest = _read(f"infra/gitops/argocd/core/{env_name}/keycloak.yaml")
+            self.assertIn("\n    automated:\n", non_local_manifest)
+
+        self.assertIn("{{KEYCLOAK_SYNC_AUTOMATED_BLOCK}}", keycloak_template)
+        self.assertIn("KEYCLOAK_SYNC_AUTOMATED_BLOCK=$keycloak_sync_automated_block", infra_bootstrap)
+        self.assertIn("keycloak_sync_automated_block()", keycloak_lib)
+
+    def test_validate_contract_rejects_local_keycloak_automated_sync(self) -> None:
+        validate_script = REPO_ROOT / "scripts/bin/blueprint/validate_contract.py"
+        spec = importlib.util.spec_from_file_location("validate_contract_module", validate_script)
+        self.assertIsNotNone(spec)
+        self.assertIsNotNone(spec.loader)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)  # type: ignore[union-attr]
+
+        required_files = [
+            "blueprint/runtime_identity_contract.yaml",
+            "docs/platform/consumer/runtime_credentials_eso.md",
+            "infra/gitops/platform/base/extensions/kustomization.yaml",
+            "infra/gitops/platform/base/security/kustomization.yaml",
+            "infra/gitops/platform/base/security/runtime-source-store.yaml",
+            "infra/gitops/platform/base/security/runtime-external-secrets-core.yaml",
+            "infra/gitops/platform/base/kustomization.yaml",
+            "infra/gitops/argocd/core/local/keycloak.yaml",
+            "infra/gitops/argocd/core/dev/keycloak.yaml",
+            "infra/gitops/argocd/core/stage/keycloak.yaml",
+            "infra/gitops/argocd/core/prod/keycloak.yaml",
+            "infra/gitops/argocd/overlays/local/keycloak.yaml",
+            "infra/gitops/argocd/overlays/local/kustomization.yaml",
+            "infra/gitops/argocd/overlays/dev/kustomization.yaml",
+            "infra/gitops/argocd/overlays/stage/kustomization.yaml",
+            "infra/gitops/argocd/overlays/prod/kustomization.yaml",
+            "scripts/bin/platform/auth/reconcile_eso_runtime_secrets.sh",
+            "scripts/templates/blueprint/bootstrap/docs/platform/consumer/runtime_credentials_eso.md",
+            "scripts/templates/infra/bootstrap/infra/gitops/argocd/core/keycloak.application.yaml.tmpl",
+            "scripts/templates/infra/bootstrap/infra/gitops/argocd/overlays/local/keycloak.yaml",
+            "scripts/templates/blueprint/bootstrap/blueprint/runtime_identity_contract.yaml",
+            "scripts/templates/infra/bootstrap/infra/gitops/platform/base/security/runtime-external-secrets-core.yaml",
+        ]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_root = Path(tmpdir)
+            for relative in required_files:
+                destination = tmp_root / relative
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(REPO_ROOT / relative, destination)
+
+            local_manifest = tmp_root / "infra/gitops/argocd/core/local/keycloak.yaml"
+            local_content = local_manifest.read_text(encoding="utf-8")
+            local_manifest.write_text(
+                local_content.replace(
+                    "  syncPolicy:\n    syncOptions:\n",
+                    "  syncPolicy:\n    automated:\n      prune: true\n      selfHeal: true\n    syncOptions:\n",
+                    1,
+                ),
+                encoding="utf-8",
+            )
+
+            errors = module._validate_runtime_credentials_contract(tmp_root)
+
+        self.assertIn(
+            "infra/gitops/argocd/core/local/keycloak.yaml must keep syncPolicy manual (syncPolicy.automated absent) "
+            "until runtime credentials are reconciled",
             errors,
         )
 


### PR DESCRIPTION
Fixes #39

## Design Summary
This change fixes local-lite instability where ArgoCD auto-synced Keycloak before ESO runtime credentials were ready, producing unhealthy pods (`CreateContainerConfigError` on missing `security/keycloak-runtime-credentials`) and failing smoke workload health.

What changed:
- Local Keycloak Argo `Application` now defaults to manual sync (no `syncPolicy.automated`).
- Dev/stage/prod Keycloak apps remain auto-synced (`syncPolicy.automated` unchanged).
- Bootstrap/template rendering is now contract-driven with an env-aware sync-policy block:
  - `scripts/lib/infra/keycloak.sh` adds `keycloak_sync_automated_block()`
  - `scripts/bin/infra/bootstrap.sh` injects `KEYCLOAK_SYNC_AUTOMATED_BLOCK`
  - `scripts/templates/infra/bootstrap/infra/gitops/argocd/core/keycloak.application.yaml.tmpl` consumes the new token
- Contract validation now enforces Keycloak sync-policy expectations:
  - local core/overlay must remain manual
  - non-local core manifests must remain automated
- Docs updated (source + template mirror) to clarify local flow: reconcile ESO runtime credentials first, then explicitly sync local Keycloak app when browser login is needed.
- Added regression tests for rendering + validation diagnostics.

## Root Cause
Local Keycloak manifest was rendered with `syncPolicy.automated` for all envs. In local-lite defaults, runtime credential secret readiness can lag/precede deploy differently, so Keycloak could start before `keycloak-runtime-credentials` existed.

## Backward-Compatibility Notes
- Additive vs behavior-changing:
  - Additive: validation/tests/docs/template wiring.
  - Behavior-changing (local only): `infra/gitops/argocd/core/local/keycloak.yaml` and `infra/gitops/argocd/overlays/local/keycloak.yaml` no longer auto-sync by default.
- Default behavior when optional features are disabled:
  - unchanged; this fix is independent of optional module toggles.
- Impact on existing generated repos:
  - No impact for stackit-dev/stage/prod profiles.
  - Local profile behavior changes to safer default (manual Keycloak sync).
- Upgrade/rebootstrap needed:
  - Existing generated repos should adopt blueprint-managed manifest/template updates via upgrade/resync workflow.
- Migration steps for already-generated repos:
  1. Run blueprint upgrade/resync workflow to pull this change.
  2. Run `make infra-bootstrap` and `make infra-validate`.
  3. Run `make auth-reconcile-eso-runtime-secrets`.
  4. Sync local Keycloak app explicitly when needed: `argocd app sync platform-keycloak-local`.

## Validation Evidence
Executed locally and passed:
- `python3 -m unittest -q tests.blueprint.test_quality_contracts`
- `make infra-bootstrap`
- `make infra-validate`
- `make infra-smoke`
- `make infra-audit-version`
- `make quality-hooks-run`

Notable results:
- quality hooks fast + strict lanes passed
- infra contract validation passed
- smoke passed in dry-run mode
- infra/apps version audits passed
