### PR TITLE
fix: harden ESO runtime contract loop against nounset regressions

### DIFF
--- a/scripts/bin/platform/auth/reconcile_eso_runtime_secrets.sh
+++ b/scripts/bin/platform/auth/reconcile_eso_runtime_secrets.sh
@@ -184,6 +184,14 @@ register_eso_secret_contract() {
   ESO_SECRET_CONTRACTS+=("${namespace}|${external_secret}|${target_secret}|${target_keys}")
 }
 
+eso_secret_contract_count() {
+  if ! declare -p ESO_SECRET_CONTRACTS >/dev/null 2>&1; then
+    printf '0'
+    return 0
+  fi
+  printf '%s' "${#ESO_SECRET_CONTRACTS[@]}"
+}
+
 RUNTIME_RECONCILE_ISSUES=()
 source_seed_mode="not-requested"
 apply_mode="kustomize-dry-run"
@@ -210,8 +218,9 @@ while IFS='|' read -r contract_id contract_module contract_namespace contract_ex
     "$contract_target_keys"
 done < <(python3 "$runtime_identity_contract_cli" eso-contracts | tr $'\t' '|')
 
+eso_contract_count="$(eso_secret_contract_count)"
 status="success"
-if (( ${#ESO_SECRET_CONTRACTS[@]} == 0 )); then
+if (( eso_contract_count == 0 )); then
   status="noop-empty-contract-set"
   apply_mode="skipped-empty-contract-set"
   source_seed_mode="skipped-empty-contract-set"
@@ -278,7 +287,7 @@ else
     target_missing_keys="none"
     external_secret_checked="none"
     target_secret_checked="none"
-    for contract_entry in "${ESO_SECRET_CONTRACTS[@]}"; do
+    for contract_entry in "${ESO_SECRET_CONTRACTS[@]-}"; do
       IFS='|' read -r contract_namespace contract_external_secret contract_target_secret contract_target_keys <<<"$contract_entry"
 
       if wait_for_external_secret_ready \
@@ -344,7 +353,7 @@ fi
 log_metric \
   "runtime_credentials_eso_reconcile_total" \
   "1" \
-  "profile=$BLUEPRINT_PROFILE mode=$(tooling_execution_mode) status=$status required=$RUNTIME_CREDENTIALS_REQUIRED_NORMALIZED issue_count=${#RUNTIME_RECONCILE_ISSUES[@]} contracts=${#ESO_SECRET_CONTRACTS[@]}"
+  "profile=$BLUEPRINT_PROFILE mode=$(tooling_execution_mode) status=$status required=$RUNTIME_CREDENTIALS_REQUIRED_NORMALIZED issue_count=${#RUNTIME_RECONCILE_ISSUES[@]} contracts=$eso_contract_count"
 
 state_file="$(
   write_state_file "runtime_credentials_eso_reconcile" \

--- a/tests/blueprint/test_quality_contracts.py
+++ b/tests/blueprint/test_quality_contracts.py
@@ -380,6 +380,13 @@ class QualityContractsTests(unittest.TestCase):
         self.assertNotIn("elif is_local_profile; then", rabbitmq_plan)
         self.assertIn('resolve_optional_module_execution "kms" "destroy"', kms_destroy)
 
+    def test_runtime_credentials_reconcile_uses_nounset_safe_contract_iteration(self) -> None:
+        reconcile_script = _read("scripts/bin/platform/auth/reconcile_eso_runtime_secrets.sh")
+        self.assertIn("eso_secret_contract_count()", reconcile_script)
+        self.assertIn('for contract_entry in "${ESO_SECRET_CONTRACTS[@]-}"; do', reconcile_script)
+        self.assertIn("eso_contract_count=\"$(eso_secret_contract_count)\"", reconcile_script)
+        self.assertIn("contracts=$eso_contract_count", reconcile_script)
+
     def test_upgrade_workflow_wrappers_emit_metrics_and_parse_reports(self) -> None:
         upgrade_wrapper = _read("scripts/bin/blueprint/upgrade_consumer.sh")
         validate_wrapper = _read("scripts/bin/blueprint/upgrade_consumer_validate.sh")


### PR DESCRIPTION
## Summary

Hardens `scripts/bin/platform/auth/reconcile_eso_runtime_secrets.sh` against nounset-related array regressions in the ESO contract loop.

Changes:
- Added `eso_secret_contract_count()` helper that safely returns `0` if `ESO_SECRET_CONTRACTS` is unavailable (checked via `declare -p`).
- Captures `eso_contract_count` once and reuses it for both branch logic and the emitted metric label, removing two separate `${#ESO_SECRET_CONTRACTS[@]}` expansions that could fail under `set -u`.
- Switched contract iteration to nounset-safe expansion: `for contract_entry in "${ESO_SECRET_CONTRACTS[@]-}"; do`
- Added regression lock assertions in `tests/blueprint/test_quality_contracts.py` to pin all three nounset-safe patterns and prevent future regressions.

Additive hardening only — no functional contract or output changes for normal paths.

## Contract Impact
- [ ] `blueprint/contract.yaml` changed
- [x] docs/templates/tests were synchronized
- [ ] generated consumer behavior changed

## Validation
- `python3 -m unittest -q tests.infra.test_runtime_credentials_eso tests.blueprint.test_quality_contracts` — 28 tests passed
- `make infra-validate`
- `make infra-smoke`
- `make quality-hooks-run`

## Follow-Up
- No deferred work. Consumers can adopt via normal blueprint upgrade/resync; no rebootstrap required for behavioral compatibility.