### PR TITLE
fix: run consumer upgrade engine from pinned source ref by default

### DIFF
--- a/AGENTS.decisions.md
+++ b/AGENTS.decisions.md
@@ -33,6 +33,8 @@
   - Diverged blueprint-managed files use 3-way merge against the template-version baseline; unresolved merges emit conflict artifacts under `artifacts/blueprint/conflicts/**` and fail apply.
   - Upgrade planning fails fast when the resolved baseline ref points to the same commit as the selected upgrade target (`upgrade baseline collision`) to prevent no-op merge plans and mixed upgrade states.
   - `make blueprint-upgrade-consumer-validate` runs the required post-upgrade validation bundle and writes `artifacts/blueprint/upgrade_validate.json`, failing on any target error or unresolved merge markers.
+  - upgrade wrapper execution defaults to `BLUEPRINT_UPGRADE_ENGINE_MODE=source-ref`, so consumer upgrades execute the engine script resolved from `BLUEPRINT_UPGRADE_SOURCE@BLUEPRINT_UPGRADE_REF` instead of a potentially stale local engine copy.
+  - troubleshooting now includes a one-time source-driven recovery command for legacy generated-consumer repositories still failing with empty-detail `RuntimeError: git merge-file failed:` from older local engines.
 - Upgrade/report validation internals are shared and contract-typed:
   - unresolved merge-marker detection is centralized in `scripts/lib/blueprint/merge_markers.py`.
   - wrapper metric extraction for plan/apply/validate reports is centralized in `scripts/lib/blueprint/upgrade_report_metrics.py` (no inline Python heredocs in shell wrappers).

--- a/docs/README.md
+++ b/docs/README.md
@@ -61,6 +61,9 @@ BLUEPRINT_UPGRADE_REF=<tag|branch|commit> BLUEPRINT_UPGRADE_APPLY=true make blue
 make blueprint-upgrade-consumer-validate
 ```
 `BLUEPRINT_UPGRADE_SOURCE` defaults to `remote.upstream.url` when configured, then `remote.origin.url`.
+`BLUEPRINT_UPGRADE_ENGINE_MODE` defaults to `source-ref`, so upgrade runs execute the engine script resolved
+from `BLUEPRINT_UPGRADE_SOURCE@BLUEPRINT_UPGRADE_REF` (instead of a potentially stale local engine copy).
+Set `BLUEPRINT_UPGRADE_ENGINE_MODE=local` only for explicit local debugging.
 Install/sync the bundled Codex consumer-upgrade skill locally when you want repeatable AI-driven upgrade runs:
 ```bash
 make blueprint-install-codex-skill

--- a/docs/platform/consumer/troubleshooting.md
+++ b/docs/platform/consumer/troubleshooting.md
@@ -86,6 +86,27 @@ Common first-day issues for generated repositories.
   make blueprint-install-codex-skill
   ```
 
+## `make blueprint-upgrade-consumer` fails with `RuntimeError: git merge-file failed:` (empty detail)
+- This usually means the repository is still executing a stale local upgrade engine from an older consumer baseline.
+- Current blueprint upgrade wrappers default to `BLUEPRINT_UPGRADE_ENGINE_MODE=source-ref`, which runs the engine script resolved from `BLUEPRINT_UPGRADE_SOURCE@BLUEPRINT_UPGRADE_REF`.
+- If your repository still has the legacy wrapper behavior, run a one-time source-driven upgrade engine call, then rerun validation:
+  ```bash
+  TMP_DIR="$(mktemp -d)"
+  git clone --quiet --no-checkout "${BLUEPRINT_UPGRADE_SOURCE}" "${TMP_DIR}/source"
+  git -C "${TMP_DIR}/source" checkout --quiet "${BLUEPRINT_UPGRADE_REF}"
+  python3 "${TMP_DIR}/source/scripts/lib/blueprint/upgrade_consumer.py" \
+    --repo-root "$PWD" \
+    --source "${BLUEPRINT_UPGRADE_SOURCE}" \
+    --ref "${BLUEPRINT_UPGRADE_REF}" \
+    --apply \
+    --plan-path artifacts/blueprint/upgrade_plan.json \
+    --apply-path artifacts/blueprint/upgrade_apply.json \
+    --summary-path artifacts/blueprint/upgrade_summary.md
+  rm -rf "${TMP_DIR}"
+  make blueprint-upgrade-consumer-validate
+  ```
+- After the upgrade lands, keep using `make blueprint-upgrade-consumer` with the default engine mode (`source-ref`) for deterministic future runs.
+
 ## Pull requests are not auto-requesting reviewers
 - Generated repositories seed `.github/CODEOWNERS` as a starter file with commented examples only.
 - Replace the example owners with your real team handles before relying on GitHub review assignment.

--- a/scripts/bin/blueprint/upgrade_consumer.sh
+++ b/scripts/bin/blueprint/upgrade_consumer.sh
@@ -26,6 +26,10 @@ Environment variables:
   BLUEPRINT_UPGRADE_PLAN_PATH             Default: artifacts/blueprint/upgrade_plan.json
   BLUEPRINT_UPGRADE_APPLY_PATH            Default: artifacts/blueprint/upgrade_apply.json
   BLUEPRINT_UPGRADE_SUMMARY_PATH          Default: artifacts/blueprint/upgrade_summary.md
+  BLUEPRINT_UPGRADE_ENGINE_MODE           Default: source-ref
+                                          local: run repository-local upgrade engine.
+                                          source-ref: run upgrade engine resolved from
+                                          BLUEPRINT_UPGRADE_SOURCE@BLUEPRINT_UPGRADE_REF.
 
 Notes:
   - Apply mode enforces non-destructive 3-way merge behavior for diverged blueprint-managed files.
@@ -147,12 +151,36 @@ resolve_default_upgrade_source() {
   printf '%s\n' "$origin"
 }
 
+resolve_upgrade_engine_from_source_ref() {
+  local source="$1"
+  local ref="$2"
+  local temp_checkout
+  temp_checkout="$(mktemp -d "${TMPDIR:-/tmp}/blueprint-upgrade-engine-XXXXXX")"
+
+  if ! git clone --quiet --no-checkout "$source" "$temp_checkout" >/dev/null 2>&1; then
+    rm -rf "$temp_checkout"
+    log_fatal "failed to clone BLUEPRINT_UPGRADE_SOURCE for source-ref upgrade engine mode: $source"
+  fi
+  if ! git -C "$temp_checkout" checkout --quiet "$ref" >/dev/null 2>&1; then
+    rm -rf "$temp_checkout"
+    log_fatal "failed to resolve BLUEPRINT_UPGRADE_REF in source checkout: $ref"
+  fi
+
+  local engine_script="$temp_checkout/scripts/lib/blueprint/upgrade_consumer.py"
+  if [[ ! -f "$engine_script" ]]; then
+    rm -rf "$temp_checkout"
+    log_fatal "missing upgrade engine in source checkout: scripts/lib/blueprint/upgrade_consumer.py"
+  fi
+  printf '%s\n' "$engine_script"
+}
+
 set_default_env BLUEPRINT_UPGRADE_APPLY false
 set_default_env BLUEPRINT_UPGRADE_ALLOW_DIRTY false
 set_default_env BLUEPRINT_UPGRADE_ALLOW_DELETE false
 set_default_env BLUEPRINT_UPGRADE_PLAN_PATH "artifacts/blueprint/upgrade_plan.json"
 set_default_env BLUEPRINT_UPGRADE_APPLY_PATH "artifacts/blueprint/upgrade_apply.json"
 set_default_env BLUEPRINT_UPGRADE_SUMMARY_PATH "artifacts/blueprint/upgrade_summary.md"
+set_default_env BLUEPRINT_UPGRADE_ENGINE_MODE "source-ref"
 
 upgrade_source="${BLUEPRINT_UPGRADE_SOURCE:-}"
 if [[ -z "$upgrade_source" ]]; then
@@ -175,6 +203,7 @@ allow_delete="false"
 if is_truthy "${BLUEPRINT_UPGRADE_ALLOW_DELETE:-false}"; then
   allow_delete="true"
 fi
+upgrade_engine_mode="${BLUEPRINT_UPGRADE_ENGINE_MODE:-source-ref}"
 
 while [[ "$#" -gt 0 ]]; do
   case "$1" in
@@ -235,6 +264,12 @@ fi
 if [[ -z "$upgrade_ref" ]]; then
   log_fatal "BLUEPRINT_UPGRADE_REF is required (set env var or pass --ref)"
 fi
+case "$upgrade_engine_mode" in
+local | source-ref) ;;
+*)
+  log_fatal "unsupported BLUEPRINT_UPGRADE_ENGINE_MODE: $upgrade_engine_mode (expected: local|source-ref)"
+  ;;
+esac
 
 upgrade_args=(
   --repo-root "$ROOT_DIR"
@@ -259,14 +294,26 @@ log_info "running blueprint consumer upgrade source=${upgrade_source} ref=${upgr
 log_metric "blueprint_upgrade_apply_enabled" "$apply_enabled"
 log_metric "blueprint_upgrade_allow_dirty" "$allow_dirty"
 log_metric "blueprint_upgrade_allow_delete" "$allow_delete"
+log_metric "blueprint_upgrade_engine_mode" "$upgrade_engine_mode"
 
 plan_report="$(resolve_report_path "$plan_path")"
 apply_report="$(resolve_report_path "$apply_path")"
+upgrade_engine_script="$ROOT_DIR/scripts/lib/blueprint/upgrade_consumer.py"
+upgrade_engine_checkout=""
 
-if run_cmd "$ROOT_DIR/scripts/lib/blueprint/upgrade_consumer.py" "${upgrade_args[@]}"; then
+if [[ "$upgrade_engine_mode" == "source-ref" ]]; then
+  upgrade_engine_script="$(resolve_upgrade_engine_from_source_ref "$upgrade_source" "$upgrade_ref")"
+  upgrade_engine_checkout="${upgrade_engine_script%/scripts/lib/blueprint/upgrade_consumer.py}"
+fi
+
+if run_cmd python3 "$upgrade_engine_script" "${upgrade_args[@]}"; then
   upgrade_rc=0
 else
   upgrade_rc=$?
+fi
+
+if [[ -n "$upgrade_engine_checkout" ]]; then
+  rm -rf "$upgrade_engine_checkout"
 fi
 
 emit_upgrade_report_metrics "$plan_report" "$apply_report"

--- a/scripts/lib/quality/test_pyramid_contract.json
+++ b/scripts/lib/quality/test_pyramid_contract.json
@@ -16,6 +16,7 @@
         "tests/blueprint/test_contract_init_governance.py",
         "tests/blueprint/test_init_repo_env.py",
         "tests/blueprint/test_upgrade_consumer.py",
+        "tests/blueprint/test_upgrade_consumer_wrapper.py",
         "tests/blueprint/test_upgrade_preflight.py",
         "tests/blueprint/test_bootstrap_templates.py",
         "tests/blueprint/test_install_codex_skill.py",

--- a/scripts/templates/blueprint/bootstrap/docs/README.md
+++ b/scripts/templates/blueprint/bootstrap/docs/README.md
@@ -61,6 +61,9 @@ BLUEPRINT_UPGRADE_REF=<tag|branch|commit> BLUEPRINT_UPGRADE_APPLY=true make blue
 make blueprint-upgrade-consumer-validate
 ```
 `BLUEPRINT_UPGRADE_SOURCE` defaults to `remote.upstream.url` when configured, then `remote.origin.url`.
+`BLUEPRINT_UPGRADE_ENGINE_MODE` defaults to `source-ref`, so upgrade runs execute the engine script resolved
+from `BLUEPRINT_UPGRADE_SOURCE@BLUEPRINT_UPGRADE_REF` (instead of a potentially stale local engine copy).
+Set `BLUEPRINT_UPGRADE_ENGINE_MODE=local` only for explicit local debugging.
 Install/sync the bundled Codex consumer-upgrade skill locally when you want repeatable AI-driven upgrade runs:
 ```bash
 make blueprint-install-codex-skill

--- a/scripts/templates/blueprint/bootstrap/docs/platform/consumer/troubleshooting.md
+++ b/scripts/templates/blueprint/bootstrap/docs/platform/consumer/troubleshooting.md
@@ -86,6 +86,27 @@ Common first-day issues for generated repositories.
   make blueprint-install-codex-skill
   ```
 
+## `make blueprint-upgrade-consumer` fails with `RuntimeError: git merge-file failed:` (empty detail)
+- This usually means the repository is still executing a stale local upgrade engine from an older consumer baseline.
+- Current blueprint upgrade wrappers default to `BLUEPRINT_UPGRADE_ENGINE_MODE=source-ref`, which runs the engine script resolved from `BLUEPRINT_UPGRADE_SOURCE@BLUEPRINT_UPGRADE_REF`.
+- If your repository still has the legacy wrapper behavior, run a one-time source-driven upgrade engine call, then rerun validation:
+  ```bash
+  TMP_DIR="$(mktemp -d)"
+  git clone --quiet --no-checkout "${BLUEPRINT_UPGRADE_SOURCE}" "${TMP_DIR}/source"
+  git -C "${TMP_DIR}/source" checkout --quiet "${BLUEPRINT_UPGRADE_REF}"
+  python3 "${TMP_DIR}/source/scripts/lib/blueprint/upgrade_consumer.py" \
+    --repo-root "$PWD" \
+    --source "${BLUEPRINT_UPGRADE_SOURCE}" \
+    --ref "${BLUEPRINT_UPGRADE_REF}" \
+    --apply \
+    --plan-path artifacts/blueprint/upgrade_plan.json \
+    --apply-path artifacts/blueprint/upgrade_apply.json \
+    --summary-path artifacts/blueprint/upgrade_summary.md
+  rm -rf "${TMP_DIR}"
+  make blueprint-upgrade-consumer-validate
+  ```
+- After the upgrade lands, keep using `make blueprint-upgrade-consumer` with the default engine mode (`source-ref`) for deterministic future runs.
+
 ## Pull requests are not auto-requesting reviewers
 - Generated repositories seed `.github/CODEOWNERS` as a starter file with commented examples only.
 - Replace the example owners with your real team handles before relying on GitHub review assignment.

--- a/tests/blueprint/test_quality_contracts.py
+++ b/tests/blueprint/test_quality_contracts.py
@@ -479,6 +479,8 @@ class QualityContractsTests(unittest.TestCase):
         self.assertIn("blueprint_upgrade_plan_entries_total", upgrade_wrapper)
         self.assertIn("blueprint_upgrade_apply_status_total", upgrade_wrapper)
         self.assertIn("blueprint_upgrade_required_manual_action_total", upgrade_wrapper)
+        self.assertIn("BLUEPRINT_UPGRADE_ENGINE_MODE", upgrade_wrapper)
+        self.assertIn("source-ref", upgrade_wrapper)
         self.assertIn("upgrade_report_metrics.py", upgrade_wrapper)
         self.assertNotIn("python3 - \"$plan_report_path\" \"$apply_report_path\" <<'PY'", upgrade_wrapper)
         self.assertIn("remote.upstream.url", upgrade_wrapper)

--- a/tests/blueprint/test_upgrade_consumer_wrapper.py
+++ b/tests/blueprint/test_upgrade_consumer_wrapper.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import shutil
+import tempfile
+import unittest
+
+from tests._shared.exec import run_command
+from tests._shared.helpers import REPO_ROOT
+
+
+UPGRADE_WRAPPER_REL = Path("scripts/bin/blueprint/upgrade_consumer.sh")
+SHELL_LIB_DIR_REL = Path("scripts/lib/shell")
+CONTRACT_RUNTIME_REL = Path("scripts/lib/blueprint/contract_runtime.sh")
+UPGRADE_REPORT_METRICS_REL = Path("scripts/lib/blueprint/upgrade_report_metrics.py")
+LOCAL_ENGINE_REL = Path("scripts/lib/blueprint/upgrade_consumer.py")
+
+
+def _copy_file(relative_path: Path, destination_root: Path) -> None:
+    source_path = REPO_ROOT / relative_path
+    target_path = destination_root / relative_path
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(source_path, target_path)
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _assert_success(result, *, context: str) -> None:
+    if result.returncode == 0:
+        return
+    raise AssertionError(
+        f"{context} failed with exit={result.returncode}\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+
+
+def _init_git_repo(repo_root: Path) -> None:
+    _assert_success(run_command(["git", "init"], cwd=repo_root), context="git init")
+    _assert_success(
+        run_command(["git", "config", "user.email", "tests@example.com"], cwd=repo_root),
+        context="git config user.email",
+    )
+    _assert_success(
+        run_command(["git", "config", "user.name", "Blueprint Tests"], cwd=repo_root),
+        context="git config user.name",
+    )
+
+
+def _commit_all(repo_root: Path, message: str) -> None:
+    _assert_success(run_command(["git", "add", "."], cwd=repo_root), context="git add")
+    _assert_success(
+        run_command(["git", "commit", "-m", message], cwd=repo_root),
+        context=f"git commit {message}",
+    )
+
+
+class UpgradeConsumerWrapperTests(unittest.TestCase):
+    def test_source_ref_engine_mode_is_default_and_avoids_stale_local_engine(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_root = Path(tmpdir)
+            consumer_repo = tmp_root / "consumer"
+            consumer_repo.mkdir(parents=True, exist_ok=True)
+
+            _copy_file(UPGRADE_WRAPPER_REL, consumer_repo)
+            _copy_file(CONTRACT_RUNTIME_REL, consumer_repo)
+            _copy_file(UPGRADE_REPORT_METRICS_REL, consumer_repo)
+            for shell_lib_path in sorted((REPO_ROOT / SHELL_LIB_DIR_REL).glob("*.sh")):
+                _copy_file(shell_lib_path.relative_to(REPO_ROOT), consumer_repo)
+
+            local_engine_marker = consumer_repo / "artifacts/local_engine_invoked"
+            _write(
+                consumer_repo / LOCAL_ENGINE_REL,
+                """#!/usr/bin/env python3
+from pathlib import Path
+import sys
+Path("artifacts/local_engine_invoked").parent.mkdir(parents=True, exist_ok=True)
+Path("artifacts/local_engine_invoked").write_text("invoked\\n", encoding="utf-8")
+print("RuntimeError: git merge-file failed:", file=sys.stderr)
+raise SystemExit(1)
+""",
+            )
+
+            source_repo = tmp_root / "source"
+            source_repo.mkdir(parents=True, exist_ok=True)
+            _init_git_repo(source_repo)
+            _write(
+                source_repo / LOCAL_ENGINE_REL,
+                """#!/usr/bin/env python3
+import argparse
+import json
+from pathlib import Path
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--repo-root", required=True)
+parser.add_argument("--source", required=True)
+parser.add_argument("--ref", required=True)
+parser.add_argument("--plan-path", required=True)
+parser.add_argument("--apply-path", required=True)
+parser.add_argument("--summary-path", required=True)
+parser.add_argument("--apply", action="store_true")
+parser.add_argument("--allow-dirty", action="store_true")
+parser.add_argument("--allow-delete", action="store_true")
+args = parser.parse_args()
+
+repo_root = Path(args.repo_root)
+
+def resolve(path_value: str) -> Path:
+    path = Path(path_value)
+    if path.is_absolute():
+        return path
+    return repo_root / path
+
+plan_path = resolve(args.plan_path)
+apply_path = resolve(args.apply_path)
+summary_path = resolve(args.summary_path)
+plan_path.parent.mkdir(parents=True, exist_ok=True)
+apply_path.parent.mkdir(parents=True, exist_ok=True)
+summary_path.parent.mkdir(parents=True, exist_ok=True)
+plan_path.write_text(json.dumps({"entries": [], "required_manual_actions": [], "summary": {"total": 0, "required_manual_action_count": 0}}) + "\\n", encoding="utf-8")
+apply_path.write_text(json.dumps({"results": [], "required_manual_actions": [], "summary": {"total": 0, "required_manual_action_count": 0}, "status": "success"}) + "\\n", encoding="utf-8")
+summary_path.write_text("source-engine\\n", encoding="utf-8")
+print("source-engine-executed")
+""",
+            )
+            _commit_all(source_repo, "source engine")
+
+            local_mode_result = run_command(
+                [str(consumer_repo / UPGRADE_WRAPPER_REL), "--apply"],
+                cwd=consumer_repo,
+                env={
+                    "BLUEPRINT_CONTRACT_RUNTIME_ALLOW_DEFAULTS": "true",
+                    "BLUEPRINT_UPGRADE_SOURCE": str(source_repo),
+                    "BLUEPRINT_UPGRADE_REF": "HEAD",
+                    "BLUEPRINT_UPGRADE_ENGINE_MODE": "local",
+                },
+            )
+            local_mode_output = f"{local_mode_result.stdout}\n{local_mode_result.stderr}"
+            self.assertNotEqual(local_mode_result.returncode, 0, msg=local_mode_output)
+            self.assertIn("RuntimeError: git merge-file failed:", local_mode_output)
+            self.assertTrue(local_engine_marker.exists())
+            local_engine_marker.unlink()
+
+            result = run_command(
+                [str(consumer_repo / UPGRADE_WRAPPER_REL), "--apply"],
+                cwd=consumer_repo,
+                env={
+                    "BLUEPRINT_CONTRACT_RUNTIME_ALLOW_DEFAULTS": "true",
+                    "BLUEPRINT_UPGRADE_SOURCE": str(source_repo),
+                    "BLUEPRINT_UPGRADE_REF": "HEAD",
+                },
+            )
+
+            combined_output = f"{result.stdout}\n{result.stderr}"
+            self.assertEqual(result.returncode, 0, msg=combined_output)
+            self.assertIn("source-engine-executed", combined_output)
+            self.assertIn("blueprint_upgrade_engine_mode value=source-ref", combined_output)
+            self.assertFalse(local_engine_marker.exists())
+
+            plan_report = json.loads((consumer_repo / "artifacts/blueprint/upgrade_plan.json").read_text(encoding="utf-8"))
+            apply_report = json.loads((consumer_repo / "artifacts/blueprint/upgrade_apply.json").read_text(encoding="utf-8"))
+            self.assertEqual(plan_report.get("summary", {}).get("total"), 0)
+            self.assertEqual(apply_report.get("status"), "success")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Makes consumer upgrade execution use the upgrade engine resolved from the pinned source ref by default (`source-ref` mode), instead of relying on the repository-local engine copy.

The regression was reproducible when generated-consumer repos still executed a stale local `scripts/lib/blueprint/upgrade_consumer.py` implementation during apply. Even when upgrading **to** a fixed blueprint ref, the old local engine could fail before it could merge itself.

- `scripts/bin/blueprint/upgrade_consumer.sh` now supports and validates `BLUEPRINT_UPGRADE_ENGINE_MODE`:
  - `source-ref` (default): clone `BLUEPRINT_UPGRADE_SOURCE`, checkout `BLUEPRINT_UPGRADE_REF`, run `scripts/lib/blueprint/upgrade_consumer.py` from that checkout
  - `local`: explicit local-engine override for debugging
- Emits `blueprint_upgrade_engine_mode` metric for observability.
- Keeps plan/apply report metric parsing unchanged.
- Documented `BLUEPRINT_UPGRADE_ENGINE_MODE` in `docs/README.md` and the bootstrap template.
- Added troubleshooting entry for legacy empty-detail `RuntimeError: git merge-file failed:` errors.
- Recorded decision update in `AGENTS.decisions.md`.
- Added `tests/blueprint/test_upgrade_consumer_wrapper.py` reproducing stale-local-engine failure in `local` mode and verifying `source-ref` mode bypasses it.
- Added quality contract assertions and categorized the new test in `scripts/lib/quality/test_pyramid_contract.json`.

Default upgrade engine execution mode changes from local to `source-ref`; explicit opt-out via `BLUEPRINT_UPGRADE_ENGINE_MODE=local` remains available. No contract schema changes. No rebootstrap required for existing generated repositories.

## Contract Impact
- [ ] `blueprint/contract.yaml` changed
- [x] docs/templates/tests were synchronized
- [x] generated consumer behavior changed

## Validation
- `pytest -q tests/blueprint/test_upgrade_consumer_wrapper.py tests/blueprint/test_quality_contracts.py tests/blueprint/test_upgrade_consumer.py`
- `BLUEPRINT_PROFILE=local-lite make infra-validate`
- `BLUEPRINT_PROFILE=local-lite make infra-smoke`
- `BLUEPRINT_PROFILE=local-lite make infra-audit-version`
- `make quality-hooks-run`

## Follow-Up
- Repositories with stale local wrappers may still require the one-time troubleshooting recovery command documented in `docs/platform/consumer/troubleshooting.md`.
- Consider adding a `trap EXIT` cleanup handler in `upgrade_consumer.sh` for signal-resilient temp directory cleanup (low-risk gap identified in review).