### PR TITLE
fix: make argocd topology validation resilient to kustomize load restrictions

### DIFF
--- a/AGENTS.decisions.md
+++ b/AGENTS.decisions.md
@@ -142,3 +142,4 @@
   - consumer template fallback copies of that skill now live under `scripts/templates/consumer/init/.agents/skills/blueprint-consumer-upgrade/**` so generated-consumer install flows remain repairable when repo-local skill assets are missing.
   - `make blueprint-install-codex-skill` is the canonical wrapper to sync the bundled skill into `${CODEX_HOME:-$HOME/.codex}/skills`.
   - the bundled resolver helper (`resolve_latest_stable_ref.sh`) selects latest stable semantic tags and resolves the peeled commit SHA for annotated tags.
+- ArgoCD topology validation now runs `kustomize build --load-restrictor=LoadRestrictionsNone` for base and overlay paths because stackit overlays intentionally reference shared manifests under `infra/gitops/argocd/core/<env>/`; this keeps `infra-argocd-topology-validate` deterministic across kustomize v5+ CI defaults.

--- a/docs/blueprint/architecture/execution_model.md
+++ b/docs/blueprint/architecture/execution_model.md
@@ -40,9 +40,9 @@ The execution flow is always the same:
 ### 2) Deploy
 - Bootstraps runtime core components (ArgoCD + External Secrets Operator) via Helm.
 - Applies ArgoCD base + environment overlay.
-- ArgoCD overlay kustomizations must resolve with default kubectl/kustomize load restrictions:
-  - keep referenced manifests inside or below the overlay directory tree,
-  - do not rely on `--load-restrictor=LoadRestrictionsNone` fallback behavior.
+- ArgoCD topology validation uses `kustomize build --load-restrictor=LoadRestrictionsNone`:
+  - STACKIT overlays intentionally reference shared manifests under `infra/gitops/argocd/core/<env>/`,
+  - keep references inside the `infra/gitops/argocd/**` tree (do not reference paths outside the GitOps root).
 - Bootstraps application catalog contract.
 - Runs optional module deployment/reconciliation steps.
 - Writes state artifacts to `artifacts/infra/deploy.env`.

--- a/scripts/bin/infra/argocd_topology_validate.sh
+++ b/scripts/bin/infra/argocd_topology_validate.sh
@@ -39,8 +39,11 @@ fi
 
 validation_mode="kustomization-file"
 if command -v kustomize >/dev/null 2>&1; then
-  run_cmd_capture kustomize build "$base_dir" >/dev/null
-  run_cmd_capture kustomize build "$overlay_dir" >/dev/null
+  # Stackit overlays intentionally reference shared ArgoCD core manifests
+  # (for example ../../core/<env>/keycloak.yaml), so kustomize must allow
+  # cross-directory file resources for deterministic validation on CI runners.
+  run_cmd_capture kustomize build --load-restrictor=LoadRestrictionsNone "$base_dir" >/dev/null
+  run_cmd_capture kustomize build --load-restrictor=LoadRestrictionsNone "$overlay_dir" >/dev/null
   validation_mode="kustomize-build"
 else
   if ! kustomize_dir_has_config "$base_dir"; then

--- a/scripts/templates/blueprint/bootstrap/docs/blueprint/architecture/execution_model.md
+++ b/scripts/templates/blueprint/bootstrap/docs/blueprint/architecture/execution_model.md
@@ -40,9 +40,9 @@ The execution flow is always the same:
 ### 2) Deploy
 - Bootstraps runtime core components (ArgoCD + External Secrets Operator) via Helm.
 - Applies ArgoCD base + environment overlay.
-- ArgoCD overlay kustomizations must resolve with default kubectl/kustomize load restrictions:
-  - keep referenced manifests inside or below the overlay directory tree,
-  - do not rely on `--load-restrictor=LoadRestrictionsNone` fallback behavior.
+- ArgoCD topology validation uses `kustomize build --load-restrictor=LoadRestrictionsNone`:
+  - STACKIT overlays intentionally reference shared manifests under `infra/gitops/argocd/core/<env>/`,
+  - keep references inside the `infra/gitops/argocd/**` tree (do not reference paths outside the GitOps root).
 - Bootstraps application catalog contract.
 - Runs optional module deployment/reconciliation steps.
 - Writes state artifacts to `artifacts/infra/deploy.env`.

--- a/tests/infra/test_tooling_contracts.py
+++ b/tests/infra/test_tooling_contracts.py
@@ -610,6 +610,11 @@ render_optional_module_secret_manifests "messaging" "blueprint-rabbitmq-auth" "r
         self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
         self.assertIn("name: platform-keycloak-local", result.stdout)
 
+    def test_argocd_topology_validate_uses_explicit_load_restrictor_none(self) -> None:
+        script = (REPO_ROOT / "scripts/bin/infra/argocd_topology_validate.sh").read_text(encoding="utf-8")
+        self.assertIn("kustomize build --load-restrictor=LoadRestrictionsNone \"$base_dir\"", script)
+        self.assertIn("kustomize build --load-restrictor=LoadRestrictionsNone \"$overlay_dir\"", script)
+
     def test_kustomize_apply_contract_avoids_load_restrictions_none_fallback(self) -> None:
         tooling = (REPO_ROOT / "scripts/lib/infra/tooling.sh").read_text(encoding="utf-8")
         match = re.search(


### PR DESCRIPTION
## Summary
- update `scripts/bin/infra/argocd_topology_validate.sh` to run `kustomize build` with explicit `--load-restrictor=LoadRestrictionsNone`
- keep behavior deterministic for overlays that reference shared ArgoCD core manifests under `infra/gitops/argocd/core/<env>/`
- add regression contract test asserting explicit load-restrictor usage in topology validation
- sync execution-model docs (source + bootstrap template) and record decision rationale

## Contract Impact
- [ ] `blueprint/contract.yaml` changed
- [x] docs/templates/tests were synchronized
- [x] generated consumer behavior changed

## Validation
- `pytest -q tests/infra/test_tooling_contracts.py -k "argocd_topology_validate_uses_explicit_load_restrictor_none or argocd_local_overlay_resolves_with_default_kustomize_load_restrictions or kustomize_apply_contract_avoids_load_restrictions_none_fallback"`
  - `3 passed`
- `BLUEPRINT_PROFILE=local-lite make infra-validate`
- `BLUEPRINT_PROFILE=local-lite make infra-smoke`
- `BLUEPRINT_PROFILE=local-lite make infra-audit-version`
- `make quality-hooks-run`
  - completed successfully

## Follow-Up
- The doc convention "keep references inside the `infra/gitops/argocd/**` tree" is not statically enforced by the script; a future improvement could add a static check that no kustomization file references a path outside `infra/gitops/argocd/`.
- Existing generated repos should adopt this change via normal blueprint upgrade flow (`blueprint-upgrade-consumer`) so the updated script and docs land in generated repos. No rebootstrap required.