### PR TITLE
fix: keep apps versions.lock EOF newline deterministic

### DIFF
--- a/scripts/bin/platform/apps/bootstrap.sh
+++ b/scripts/bin/platform/apps/bootstrap.sh
@@ -43,7 +43,11 @@ fi
 versions_content=$'PYTHON_RUNTIME_BASE_IMAGE_VERSION='"$PYTHON_RUNTIME_BASE_IMAGE_VERSION"$'\nNODE_RUNTIME_BASE_IMAGE_VERSION='"$NODE_RUNTIME_BASE_IMAGE_VERSION"$'\nNGINX_RUNTIME_BASE_IMAGE_VERSION='"$NGINX_RUNTIME_BASE_IMAGE_VERSION"$'\nFASTAPI_VERSION='"$FASTAPI_VERSION"$'\nPYDANTIC_VERSION='"$PYDANTIC_VERSION"$'\nVUE_VERSION='"$VUE_VERSION"$'\nVUE_ROUTER_VERSION='"$VUE_ROUTER_VERSION"$'\nPINIA_VERSION='"$PINIA_VERSION"$'\n'
 
 # Keep lockfile EOF deterministic for quality hooks and downstream generated repos.
-versions_content="${versions_content%$'\n'}"$'\n'
+# Normalize to exactly one trailing newline.
+while [[ "$versions_content" == *$'\n' ]]; do
+  versions_content="${versions_content%$'\n'}"
+done
+versions_content+=$'\n'
 
 printf '%s' "$manifest_content" >"$ROOT_DIR/apps/catalog/manifest.yaml"
 printf '%s' "$versions_content" >"$ROOT_DIR/apps/catalog/versions.lock"

--- a/tests/infra/test_tooling_contracts.py
+++ b/tests/infra/test_tooling_contracts.py
@@ -599,20 +599,26 @@ render_optional_module_secret_manifests "messaging" "blueprint-rabbitmq-auth" "r
         self.assertIn("touchpoints-test-e2e", script)
 
     def test_apps_bootstrap_versions_lock_keeps_trailing_newline(self) -> None:
-        result = run(
-            ["make", "apps-bootstrap"],
-            {
-                "BLUEPRINT_PROFILE": "local-lite",
-                "OBSERVABILITY_ENABLED": "false",
-            },
-        )
-        self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
         versions_lock = REPO_ROOT / "apps" / "catalog" / "versions.lock"
-        self.assertTrue(versions_lock.exists(), msg="apps/catalog/versions.lock should be created by apps-bootstrap")
-        self.assertTrue(
-            versions_lock.read_bytes().endswith(b"\n"),
-            msg="apps/catalog/versions.lock must end with a trailing newline",
-        )
+        original = versions_lock.read_bytes() if versions_lock.exists() else None
+        try:
+            result = run(
+                ["make", "apps-bootstrap"],
+                {
+                    "BLUEPRINT_PROFILE": "local-lite",
+                    "OBSERVABILITY_ENABLED": "false",
+                },
+            )
+            self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+            self.assertTrue(versions_lock.exists(), msg="apps/catalog/versions.lock should be created by apps-bootstrap")
+            content = versions_lock.read_bytes()
+            self.assertTrue(
+                content.endswith(b"\n") and not content.endswith(b"\n\n"),
+                msg="apps/catalog/versions.lock must end with exactly one trailing newline",
+            )
+        finally:
+            if original is not None:
+                versions_lock.write_bytes(original)
 
     def test_argocd_local_overlay_resolves_with_default_kustomize_load_restrictions(self) -> None:
         kubectl_check = run(["bash", "-lc", "command -v kubectl >/dev/null 2>&1"])


### PR DESCRIPTION
## Summary
- normalize `versions_content` before writing `apps/catalog/versions.lock` so the lockfile always ends with exactly one trailing newline
- add regression test `test_apps_bootstrap_versions_lock_keeps_trailing_newline` that runs `make apps-bootstrap` and asserts lockfile EOF newline

## Contract Impact
- [ ] `blueprint/contract.yaml` changed
- [ ] docs/templates/tests were synchronized
- [ ] generated consumer behavior changed

## Validation
- `pytest -q tests/infra/test_tooling_contracts.py -k 'versions_lock_keeps_trailing_newline or e2e_aggregate_script_supports_scope_and_budget_contract'`
- `make infra-validate`
- `make infra-smoke`
- `make infra-audit-version`
- `make quality-hooks-run`

## Follow-Up
- `versions.lock` is generated by shell string assembly; `%$'\n'` strips only a single trailing newline, so the guard is not fully idempotent against multiple trailing newlines — acceptable for the current controlled input, but worth revisiting if the assembly logic grows more complex.
- The regression test modifies the tracked `apps/catalog/versions.lock` without restoring it in a `finally` block; low-risk given deterministic regeneration, but inconsistent with other mutating tests in the suite.
- Consider tightening the test assertion to exclude double trailing newlines (`not content.endswith(b"\n\n")`).