### PR TITLE
fix: enforce optional gate in infra-prereqs

### DIFF
--- a/scripts/bin/infra/prereqs.sh
+++ b/scripts/bin/infra/prereqs.sh
@@ -382,7 +382,7 @@ check_or_install_python_module "pytest" "required"
 for tool in "${stackit_tools[@]}"; do
   if [[ "$PREREQS_REQUIRE_STACKIT_TOOLS" == "true" ]]; then
     check_or_install "$tool" "$platform" "required"
-  elif [[ "$PREREQS_INSTALL_OPTIONAL" == "true" || "$PREREQS_AUTO_INSTALL" == "true" ]]; then
+  elif [[ "$PREREQS_INSTALL_OPTIONAL" == "true" ]]; then
     check_or_install "$tool" "$platform" "optional"
   else
     if shell_has_cmd "$tool"; then

--- a/tests/infra/test_tooling_contracts.py
+++ b/tests/infra/test_tooling_contracts.py
@@ -578,6 +578,25 @@ render_optional_module_secret_manifests "messaging" "blueprint-rabbitmq-auth" "r
         self.assertIn('check_or_install_python_module "pytest" "required"', script)
         self.assertIn("python_module_available()", script)
 
+    def test_prereqs_optional_stackit_gate_is_controlled_only_by_install_optional(self) -> None:
+        script = (REPO_ROOT / "scripts/bin/infra/prereqs.sh").read_text(encoding="utf-8")
+        self.assertIn('elif [[ "$PREREQS_INSTALL_OPTIONAL" == "true" ]]; then', script)
+        self.assertNotIn(
+            'elif [[ "$PREREQS_INSTALL_OPTIONAL" == "true" || "$PREREQS_AUTO_INSTALL" == "true" ]]; then',
+            script,
+        )
+
+    def test_prereqs_selected_bucket_still_honors_auto_install_for_missing_tools(self) -> None:
+        script = (REPO_ROOT / "scripts/bin/infra/prereqs.sh").read_text(encoding="utf-8")
+        match = re.search(
+            r"^check_or_install\(\)\s*\{(?P<body>.*?)(?=^\})",
+            script,
+            re.MULTILINE | re.DOTALL,
+        )
+        self.assertIsNotNone(match, msg="check_or_install() definition not found in prereqs.sh")
+        function_body = match.group("body")
+        self.assertIn('if [[ "$PREREQS_AUTO_INSTALL" == "true" ]]; then', function_body)
+
     def test_audit_version_chart_refs_have_known_helm_repo_prefixes(self) -> None:
         chart_repo_prefixes, known_repo_prefixes = audit_helm_chart_repo_prefix_contract()
         missing = sorted(chart_repo_prefixes - known_repo_prefixes)


### PR DESCRIPTION
## Summary
- fix optional STACKIT prereq gating so `PREREQS_AUTO_INSTALL=true` no longer implies optional tool installation
- keep auto-install semantics unchanged for the selected bucket (`required` or `optional`)
- add regression contract tests for gate behavior and required-bucket auto-install path

Fixes #88

## Root cause
`scripts/bin/infra/prereqs.sh` treated `PREREQS_AUTO_INSTALL=true` as a condition to process optional STACKIT tools, even when `PREREQS_INSTALL_OPTIONAL=false`.

## Design
- optional bucket processing now happens only when `PREREQS_INSTALL_OPTIONAL=true`
- `PREREQS_AUTO_INSTALL` remains the install strategy toggle once a bucket is selected

## Backward-compatibility notes
- additive/non-breaking behavior correction
- default behavior with `PREREQS_INSTALL_OPTIONAL=false` now strictly avoids optional install attempts
- required bucket behavior is unchanged (missing required tools/modules still honor `PREREQS_AUTO_INSTALL=true`)
- existing generated repos do not require rebootstrap; update via normal pull/upgrade flow

## Validation
- `pytest -q tests/infra/test_tooling_contracts.py -k 'prereqs_optional_stackit_gate_is_controlled_only_by_install_optional or prereqs_selected_bucket_still_honors_auto_install_for_missing_tools or prereqs_script_enforces_required_pytest_python_module'`
- `make infra-validate`
- `make infra-smoke`
- `make infra-audit-version`
- `make quality-hooks-run`
