### PR TITLE
fix: make local aggregate e2e dry-run mode explicit

### DIFF
--- a/scripts/bin/platform/test/e2e_all_local.sh
+++ b/scripts/bin/platform/test/e2e_all_local.sh
@@ -95,8 +95,8 @@ if [[ "$execute_mode" == "true" ]]; then
   log_info "running local execute-mode infra chain before aggregate e2e test lanes"
   run_cmd make -C "$ROOT_DIR" DRY_RUN=false BLUEPRINT_PROFILE="$BLUEPRINT_PROFILE" OBSERVABILITY_ENABLED="$OBSERVABILITY_ENABLED" infra-provision-deploy
 else
-  log_info "running local dry-run-state infra chain before aggregate e2e test lanes"
-  run_cmd make -C "$ROOT_DIR" BLUEPRINT_PROFILE="$BLUEPRINT_PROFILE" OBSERVABILITY_ENABLED="$OBSERVABILITY_ENABLED" infra-provision-deploy
+  log_info "running local dry-run infra chain before aggregate e2e test lanes"
+  run_cmd make -C "$ROOT_DIR" DRY_RUN=true BLUEPRINT_PROFILE="$BLUEPRINT_PROFILE" OBSERVABILITY_ENABLED="$OBSERVABILITY_ENABLED" infra-provision-deploy
 fi
 
 run_cmd make -C "$ROOT_DIR" backend-test-e2e

--- a/tests/infra/test_tooling_contracts.py
+++ b/tests/infra/test_tooling_contracts.py
@@ -616,6 +616,14 @@ render_optional_module_secret_manifests "messaging" "blueprint-rabbitmq-auth" "r
         self.assertIn("E2E_FULL_BUDGET_SECONDS", script)
         self.assertIn("aggregate_e2e_budget_total", script)
         self.assertIn("touchpoints-test-e2e", script)
+        self.assertIn(
+            'run_cmd make -C "$ROOT_DIR" DRY_RUN=true BLUEPRINT_PROFILE="$BLUEPRINT_PROFILE" OBSERVABILITY_ENABLED="$OBSERVABILITY_ENABLED" infra-provision-deploy',
+            script,
+        )
+        self.assertIn(
+            'run_cmd make -C "$ROOT_DIR" DRY_RUN=false BLUEPRINT_PROFILE="$BLUEPRINT_PROFILE" OBSERVABILITY_ENABLED="$OBSERVABILITY_ENABLED" infra-provision-deploy',
+            script,
+        )
 
     def test_apps_bootstrap_versions_lock_keeps_trailing_newline(self) -> None:
         versions_lock = REPO_ROOT / "apps" / "catalog" / "versions.lock"


### PR DESCRIPTION
## Summary
- make dry-run/execute split explicit in aggregate local E2E lane
- `test-e2e-all-local-full` path now propagates `DRY_RUN=true` into `infra-provision-deploy`
- `test-e2e-all-local-execute` path keeps propagating `DRY_RUN=false`
- add regression assertions that both distinct mode propagations remain present in script contract tests

Fixes #87

## Root cause
The lane already split on `--execute`, but dry-run behavior depended on implicit defaults instead of explicit mode propagation, which made the contract unclear and fragile.

## Backward-compatibility notes
- additive/non-breaking clarification of existing intent
- default `test-e2e-all-local-full` now explicitly enforces dry-run mode
- execute lane behavior remains unchanged
- no rebootstrap required; generated repos can adopt via normal upgrade/resync

## Validation
- `pytest -q tests/infra/test_tooling_contracts.py -k 'e2e_aggregate_script_supports_scope_and_budget_contract'`
- `make infra-validate`
- `make infra-smoke`
- `make infra-audit-version`
- `make quality-hooks-run`
