### PR TITLE
fix: preserve dot-prefixed ownership paths and clean help text

### DIFF
--- a/docs/reference/generated/core_targets.generated.md
+++ b/docs/reference/generated/core_targets.generated.md
@@ -15,7 +15,7 @@ This file is auto-generated. Do not edit it manually.
 | `blueprint-upgrade-consumer-preflight` | Plan-only generated-consumer upgrade preflight report with auto/manual guidance |
 | `blueprint-upgrade-consumer-validate` | Run post-upgrade validation bundle and strict merge-marker checks |
 | `blueprint-install-codex-skill` | Install/sync bundled Codex upgrade skill into local CODEX_HOME skills directory |
-| `blueprint-ownership-check` | Resolve path ownership classes (set OWNERSHIP_PATHS=\"path/one path/two\") |
+| `blueprint-ownership-check` | Resolve path ownership classes (set OWNERSHIP_PATHS="path/one path/two") |
 | `blueprint-ownership-metadata` | Print machine-readable ownership metadata (pattern -> owner) |
 | `blueprint-check-placeholders` | Verify generated repository identity placeholders are resolved |
 | `blueprint-template-smoke` | Run generated-repo conformance smoke in a temp copy |

--- a/make/blueprint.generated.mk
+++ b/make/blueprint.generated.mk
@@ -46,7 +46,7 @@ blueprint-upgrade-consumer-validate: ## Run post-upgrade validation bundle and s
 blueprint-install-codex-skill: ## Install/sync bundled Codex upgrade skill into local CODEX_HOME skills directory
 	@scripts/bin/blueprint/install_codex_skill.sh
 
-blueprint-ownership-check: ## Resolve path ownership classes (set OWNERSHIP_PATHS=\"path/one path/two\")
+blueprint-ownership-check: ## Resolve path ownership classes (set OWNERSHIP_PATHS="path/one path/two")
 	@if [[ -z "$(strip $(OWNERSHIP_PATHS))" ]]; then \
 		echo "[blueprint] set OWNERSHIP_PATHS to one or more paths (space-separated)" >&2; \
 		exit 1; \

--- a/scripts/bin/blueprint/ownership_check.py
+++ b/scripts/bin/blueprint/ownership_check.py
@@ -30,8 +30,15 @@ class OwnershipRule:
     regex: re.Pattern[str]
 
 
+def _normalize_contract_pattern(pattern: str) -> str:
+    normalized = pattern.strip()
+    if normalized.startswith("./"):
+        normalized = normalized[2:]
+    return normalized
+
+
 def _pattern_to_regex(pattern: str, *, is_directory: bool) -> re.Pattern[str]:
-    normalized = pattern.strip().lstrip("./")
+    normalized = _normalize_contract_pattern(pattern)
     if normalized.endswith("/"):
         normalized = normalized[:-1]
     escaped = re.escape(normalized)
@@ -55,7 +62,7 @@ def _normalize_relative_path(raw_path: str, repo_root: Path) -> tuple[str, bool]
 
 
 def _pattern_is_directory(pattern: str, repo_root: Path) -> bool:
-    normalized = pattern.strip().lstrip("./")
+    normalized = _normalize_contract_pattern(pattern)
     if normalized.endswith("/"):
         return True
 

--- a/scripts/templates/blueprint/bootstrap/make/blueprint.generated.mk.tmpl
+++ b/scripts/templates/blueprint/bootstrap/make/blueprint.generated.mk.tmpl
@@ -46,7 +46,7 @@ blueprint-upgrade-consumer-validate: ## Run post-upgrade validation bundle and s
 blueprint-install-codex-skill: ## Install/sync bundled Codex upgrade skill into local CODEX_HOME skills directory
 	@scripts/bin/blueprint/install_codex_skill.sh
 
-blueprint-ownership-check: ## Resolve path ownership classes (set OWNERSHIP_PATHS=\"path/one path/two\")
+blueprint-ownership-check: ## Resolve path ownership classes (set OWNERSHIP_PATHS="path/one path/two")
 	@if [[ -z "$(strip $(OWNERSHIP_PATHS))" ]]; then \
 		echo "[blueprint] set OWNERSHIP_PATHS to one or more paths (space-separated)" >&2; \
 		exit 1; \

--- a/tests/blueprint/test_ownership_check.py
+++ b/tests/blueprint/test_ownership_check.py
@@ -52,6 +52,12 @@ class OwnershipCheckTests(unittest.TestCase):
         payload = json.loads(result.stdout)
         self.assertEqual(payload["results"][0]["owner"], "source-only")
 
+    def test_checker_resolves_dot_prefixed_consumer_seeded_paths(self) -> None:
+        result = _run_checker("--json", ".github/CODEOWNERS")
+        self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["results"][0]["owner"], "consumer-seeded")
+
     def test_checker_marks_parent_traversal_as_outside_repository(self) -> None:
         result = _run_checker("--json", "../make/platform.mk")
         self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
@@ -69,6 +75,16 @@ class OwnershipCheckTests(unittest.TestCase):
         )
         self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
         self.assertIn("owner=platform-owned", result.stdout)
+
+    def test_ownership_help_text_uses_plain_quotes(self) -> None:
+        makefile_text = (REPO_ROOT / "make" / "blueprint.generated.mk").read_text(encoding="utf-8")
+        self.assertIn('OWNERSHIP_PATHS="path/one path/two"', makefile_text)
+        self.assertNotIn('OWNERSHIP_PATHS=\\"path/one path/two\\"', makefile_text)
+
+        help_result = run_command(["make", "help"], cwd=REPO_ROOT)
+        self.assertEqual(help_result.returncode, 0, msg=help_result.stdout + help_result.stderr)
+        self.assertIn('OWNERSHIP_PATHS="path/one path/two"', help_result.stdout)
+        self.assertNotIn('OWNERSHIP_PATHS=\\"path/one path/two\\"', help_result.stdout)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- fix blueprint ownership matching for dot-prefixed contract paths (for example `.github/**`) by normalizing only a literal `./` prefix instead of stripping all leading `.` and `/`
- fix generated ownership help text to render plain quotes in both `make/blueprint.generated.mk` and its template
- add regression coverage for `.github/CODEOWNERS` classification and help-text rendering in `make help`
- regenerate core target reference docs after template/help updates

## Contract Impact
- [ ] `blueprint/contract.yaml` changed
- [x] docs/templates/tests were synchronized
- [ ] generated consumer behavior changed

## Validation
- `python3 -m pytest -q tests/blueprint/test_ownership_check.py`
- `make infra-validate`
- `make quality-hooks-run`

## Follow-Up
- additive/bug-fix only; no contract behavior change outside correcting previously broken dot-prefixed ownership resolution