### PR TITLE
fix: prevent ArgoCD repo token leakage in reconcile flow

### DIFF
--- a/scripts/bin/platform/auth/reconcile_argocd_repo_credentials.sh
+++ b/scripts/bin/platform/auth/reconcile_argocd_repo_credentials.sh
@@ -36,6 +36,13 @@ if [[ "${1:-}" == "--help" ]]; then
   exit 0
 fi
 
+if [[ "$-" == *x* ]]; then
+  # This reconcile flow handles repo access credentials; disable xtrace to avoid
+  # leaking secret values through shell command traces.
+  set +x
+  log_warn "shell xtrace disabled for secret-safe ArgoCD credential reconciliation"
+fi
+
 require_command python3
 runtime_identity_contract_cli="$ROOT_DIR/scripts/lib/infra/runtime_identity_contract.py"
 argocd_repo_contract_cli="$ROOT_DIR/scripts/lib/infra/argocd_repo_contract.py"
@@ -129,8 +136,7 @@ EOF
       "$patch_file" \
       "$ARGOCD_REPO_TYPE" \
       "$ARGOCD_REPO_URL" \
-      "$ARGOCD_REPO_USERNAME" \
-      "$ARGOCD_REPO_TOKEN"
+      "$ARGOCD_REPO_USERNAME"
     run_cmd kubectl -n "$namespace" patch secret "$secret_name" --type merge --patch-file "$patch_file"
     SOURCE_SECRET_SYNC_MODE_RESULT="patched-existing-secret"
     return 0

--- a/scripts/lib/platform/auth/argocd_repo_credentials_json.py
+++ b/scripts/lib/platform/auth/argocd_repo_credentials_json.py
@@ -7,17 +7,26 @@ import argparse
 import base64
 import binascii
 import json
+import os
 from pathlib import Path
 import sys
 
 
 def cmd_render_source_patch(args: argparse.Namespace) -> int:
+    repo_token = os.environ.get(args.repo_token_env, "")
+    if repo_token == "":
+        print(
+            f"required repo token env var is empty or unset: {args.repo_token_env}",
+            file=sys.stderr,
+        )
+        return 1
+
     payload = {
         "stringData": {
             "ARGOCD_REPO_TYPE": args.repo_type,
             "ARGOCD_REPO_URL": args.repo_url,
             "ARGOCD_REPO_USERNAME": args.repo_username,
-            "ARGOCD_REPO_TOKEN": args.repo_token,
+            "ARGOCD_REPO_TOKEN": repo_token,
         }
     }
     Path(args.output_path).write_text(json.dumps(payload), encoding="utf-8")
@@ -90,7 +99,11 @@ def main() -> int:
     patch_parser.add_argument("repo_type")
     patch_parser.add_argument("repo_url")
     patch_parser.add_argument("repo_username")
-    patch_parser.add_argument("repo_token")
+    patch_parser.add_argument(
+        "--repo-token-env",
+        default="ARGOCD_REPO_TOKEN",
+        help="Environment variable containing repo token (default: ARGOCD_REPO_TOKEN)",
+    )
     patch_parser.set_defaults(func=cmd_render_source_patch)
 
     validate_parser = subparsers.add_parser("validate-target-secret")

--- a/tests/blueprint/contract_refactor_scripts_cases.py
+++ b/tests/blueprint/contract_refactor_scripts_cases.py
@@ -255,6 +255,22 @@ class ScriptsRefactorCases(RefactorContractBase):
         self.assertIn("SOURCE_SECRET_SYNC_MODE_RESULT", reconcile)
         self.assertIn("if seed_argocd_source_secret_properties", reconcile)
         self.assertNotIn('source_secret_sync_mode="$(seed_argocd_source_secret_properties', reconcile)
+        self.assertIn('log_warn "shell xtrace disabled for secret-safe ArgoCD credential reconciliation"', reconcile)
+        self.assertNotIn("STACKIT_RUNTIME_GITOPS_REPO_TOKEN", reconcile)
+        self.assertNotIn("STACKIT_RUNTIME_GITOPS_REPO_USERNAME", reconcile)
+        self.assertIn(
+            'run_cmd python3 "$argocd_repo_json_helpers" render-source-patch \\',
+            reconcile,
+        )
+        self.assertNotIn(
+            'run_cmd python3 "$argocd_repo_json_helpers" render-source-patch \\\n'
+            '      "$patch_file" \\\n'
+            '      "$ARGOCD_REPO_TYPE" \\\n'
+            '      "$ARGOCD_REPO_URL" \\\n'
+            '      "$ARGOCD_REPO_USERNAME" \\\n'
+            '      "$ARGOCD_REPO_TOKEN"',
+            reconcile,
+        )
 
     def test_bootstrap_preserves_disabled_optional_scaffolding(self) -> None:
         bootstrap = _read("scripts/bin/infra/bootstrap.sh")

--- a/tests/infra/test_python_helper_extractions.py
+++ b/tests/infra/test_python_helper_extractions.py
@@ -160,12 +160,27 @@ class PythonHelperExtractionsTests(unittest.TestCase):
                     "git",
                     "https://github.com/acme/demo.git",
                     "x-access-token",
-                    "github_pat_abc",
-                ]
+                ],
+                {"ARGOCD_REPO_TOKEN": "github_pat_abc"},
             )
             self.assertEqual(render.returncode, 0, msg=render.stdout + render.stderr)
             patch_payload = json.loads(patch_file.read_text(encoding="utf-8"))
             self.assertEqual(patch_payload["stringData"]["ARGOCD_REPO_TYPE"], "git")
+            self.assertEqual(patch_payload["stringData"]["ARGOCD_REPO_TOKEN"], "github_pat_abc")
+
+            missing_token = run(
+                [
+                    sys.executable,
+                    str(script),
+                    "render-source-patch",
+                    str(patch_file),
+                    "git",
+                    "https://github.com/acme/demo.git",
+                    "x-access-token",
+                ]
+            )
+            self.assertEqual(missing_token.returncode, 1)
+            self.assertIn("required repo token env var is empty or unset", missing_token.stderr)
 
             secret = {
                 "metadata": {"labels": {"argocd.argoproj.io/secret-type": "repository"}},

--- a/tests/infra/test_python_helper_extractions.py
+++ b/tests/infra/test_python_helper_extractions.py
@@ -177,7 +177,8 @@ class PythonHelperExtractionsTests(unittest.TestCase):
                     "git",
                     "https://github.com/acme/demo.git",
                     "x-access-token",
-                ]
+                ],
+                {"ARGOCD_REPO_TOKEN": ""},
             )
             self.assertEqual(missing_token.returncode, 1)
             self.assertIn("required repo token env var is empty or unset", missing_token.stderr)

--- a/tests/infra/test_runtime_credentials_eso.py
+++ b/tests/infra/test_runtime_credentials_eso.py
@@ -149,14 +149,48 @@ class RuntimeCredentialsEsoTests(unittest.TestCase):
 
         combined_output = result.stdout + result.stderr
         self.assertNotIn("argocd_repo_contract.py: error: unrecognized arguments", combined_output)
+        self.assertNotIn("ghp_exampletoken", combined_output)
 
         state_path = REPO_ROOT / "artifacts" / "infra" / "argocd_repo_credentials_reconcile.env"
         self.assertTrue(state_path.exists(), msg="argocd repo credentials state artifact was not created")
         state = state_path.read_text(encoding="utf-8")
         self.assertIn("status=success", state)
         self.assertIn("runtime_reconcile_status=success", state)
+        self.assertNotIn("ghp_exampletoken", state)
         state_json_path = REPO_ROOT / "artifacts" / "infra" / "argocd_repo_credentials_reconcile.json"
         self.assertTrue(state_json_path.exists(), msg="argocd repo credentials JSON state artifact was not created")
+        state_json = state_json_path.read_text(encoding="utf-8")
+        self.assertNotIn("ghp_exampletoken", state_json)
+
+    def test_argocd_reconcile_ignores_unrelated_env_vars_and_fails_required_without_argocd_token(self) -> None:
+        env = module_flags_env(profile="local-full")
+        env.update(
+            {
+                "ARGOCD_REPO_CREDENTIALS_REQUIRED": "true",
+                "ARGOCD_REPO_USERNAME": "",
+                "ARGOCD_REPO_TOKEN": "",
+                "UNRELATED_GITOPS_REPO_USERNAME": "x-access-token",
+                "UNRELATED_GITOPS_REPO_TOKEN": "ghp_unrelatedtoken",
+            }
+        )
+
+        result = run_make("auth-reconcile-argocd-repo-credentials", env)
+        self.assertNotEqual(result.returncode, 0, msg="required mode must fail when ARGOCD_REPO_TOKEN is unset")
+
+        combined_output = result.stdout + result.stderr
+        self.assertNotIn("ghp_unrelatedtoken", combined_output)
+        self.assertIn("ARGOCD_REPO_TOKEN is empty", combined_output)
+
+        state_path = REPO_ROOT / "artifacts" / "infra" / "argocd_repo_credentials_reconcile.env"
+        self.assertTrue(state_path.exists(), msg="argocd repo credentials state artifact was not created")
+        state = state_path.read_text(encoding="utf-8")
+        self.assertIn("status=failed-required", state)
+        self.assertNotIn("ghp_unrelatedtoken", state)
+
+        state_json_path = REPO_ROOT / "artifacts" / "infra" / "argocd_repo_credentials_reconcile.json"
+        self.assertTrue(state_json_path.exists(), msg="argocd repo credentials JSON state artifact was not created")
+        state_json = state_json_path.read_text(encoding="utf-8")
+        self.assertNotIn("ghp_unrelatedtoken", state_json)
 
     def test_runtime_identity_orchestrator_writes_plugin_state(self) -> None:
         env = module_flags_env(profile="local-full")


### PR DESCRIPTION
Fixes #113

## Summary
- removes ArgoCD repo token exposure from command-line arguments in the reconcile flow.
- keeps reconcile behavior canonical on ARGOCD_REPO_USERNAME / ARGOCD_REPO_TOKEN only.
- hardens helper behavior so token is read from environment (not argv) and fails fast if missing.
- adds regression coverage to prevent secret leakage in logs and state artifacts.

## What changed
- scripts/bin/platform/auth/reconcile_argocd_repo_credentials.sh
  - stop passing token via argv to Python helper.
  - keep xtrace disabled in this credential-sensitive script path.
- scripts/lib/platform/auth/argocd_repo_credentials_json.py
  - render-source-patch now reads token from env var (ARGOCD_REPO_TOKEN by default).
- tests
  - extend runtime-credentials and helper extraction tests for no-leak and missing-token behavior.
  - extend script contract test to guard against re-introducing token argv usage.

## Validation
- pytest -q tests/blueprint/contract_refactor_scripts_cases.py tests/infra/test_python_helper_extractions.py tests/infra/test_runtime_credentials_eso.py
- make infra-validate

All checks above passed locally.
