### PR TITLE
fix: avoid false local-lite postgres ESO reconcile warning

### DIFF
--- a/docs/platform/consumer/runtime_credentials_eso.md
+++ b/docs/platform/consumer/runtime_credentials_eso.md
@@ -137,7 +137,7 @@ make auth-reconcile-runtime-identity
 ```
 
 Local-lite Postgres note:
-- When `BLUEPRINT_PROFILE=local-lite`, `POSTGRES_ENABLED=true`, and `artifacts/infra/postgres_runtime.env` contains a valid PostgreSQL DSN, runtime-credentials reconciliation skips the ESO readiness/target checks for `data/postgres-runtime-credentials`.
+- When `BLUEPRINT_PROFILE=local-lite`, `POSTGRES_ENABLED=true`, and `artifacts/infra/postgres_runtime.env` is owned by local-lite/local runtime (`profile=local-lite`, `stack=local`) with a valid PostgreSQL DSN, runtime-credentials reconciliation skips the ESO readiness/target checks for `data/postgres-runtime-credentials`.
 - This prevents false `warn-and-skip` noise when local Postgres runtime is already healthy through the local Helm/runtime-state path.
 - Reconcile state artifacts surface this as `skipped_contract_count` and `skipped_contracts`.
 

--- a/docs/platform/consumer/runtime_credentials_eso.md
+++ b/docs/platform/consumer/runtime_credentials_eso.md
@@ -136,6 +136,11 @@ export ARGOCD_REPO_TOKEN='github_pat_your_token'
 make auth-reconcile-runtime-identity
 ```
 
+Local-lite Postgres note:
+- When `BLUEPRINT_PROFILE=local-lite`, `POSTGRES_ENABLED=true`, and `artifacts/infra/postgres_runtime.env` contains a valid PostgreSQL DSN, runtime-credentials reconciliation skips the ESO readiness/target checks for `data/postgres-runtime-credentials`.
+- This prevents false `warn-and-skip` noise when local Postgres runtime is already healthy through the local Helm/runtime-state path.
+- Reconcile state artifacts surface this as `skipped_contract_count` and `skipped_contracts`.
+
 Resulting state artifacts:
 - `artifacts/infra/runtime_credentials_eso_reconcile.env`
 - `artifacts/infra/runtime_credentials_eso_reconcile.json`

--- a/scripts/bin/platform/auth/reconcile_eso_runtime_secrets.sh
+++ b/scripts/bin/platform/auth/reconcile_eso_runtime_secrets.sh
@@ -145,6 +145,36 @@ verify_target_secret_keys() {
   return 0
 }
 
+local_lite_postgres_runtime_ready() {
+  if [[ "${BLUEPRINT_PROFILE:-}" != "local-lite" ]]; then
+    return 1
+  fi
+  if ! is_module_enabled postgres; then
+    return 1
+  fi
+  if ! state_file_exists postgres_runtime; then
+    return 1
+  fi
+  local runtime_state_file
+  runtime_state_file="$(state_file_path postgres_runtime)"
+  if ! grep -q '^dsn=postgresql://' "$runtime_state_file" 2>/dev/null; then
+    return 1
+  fi
+  return 0
+}
+
+should_skip_eso_contract_check() {
+  local contract_id="$1"
+  local contract_module="$2"
+
+  if [[ "$contract_id" == "postgres-runtime-credentials" && "$contract_module" == "postgres" ]]; then
+    if local_lite_postgres_runtime_ready; then
+      return 0
+    fi
+  fi
+  return 1
+}
+
 parse_literal_pairs() {
   local literals_csv="$1"
   local pair key value
@@ -203,11 +233,25 @@ source_secret_present="unknown"
 external_secret_checked=""
 target_secret_checked=""
 declare -a ESO_SECRET_CONTRACTS=()
+declare -a ESO_SECRET_CONTRACTS_SKIPPED=()
+skipped_contract_count="0"
+skipped_contracts="none"
 
 while IFS='|' read -r contract_id contract_module contract_namespace contract_external_secret contract_target_secret contract_target_keys; do
   [[ -n "$contract_id" ]] || continue
 
   if [[ -n "$contract_module" ]] && ! is_module_enabled "$contract_module"; then
+    continue
+  fi
+
+  if should_skip_eso_contract_check "$contract_id" "$contract_module"; then
+    ESO_SECRET_CONTRACTS_SKIPPED+=("${contract_namespace}/${contract_target_secret}:local-lite-postgres-runtime")
+    log_metric \
+      "runtime_credentials_eso_contract_skip_total" \
+      "1" \
+      "contract_id=$contract_id module=$contract_module profile=${BLUEPRINT_PROFILE:-unset} reason=local-lite-postgres-runtime"
+    log_info \
+      "runtime credentials contract check skipped contract_id=$contract_id module=$contract_module reason=local-lite-postgres-runtime"
     continue
   fi
 
@@ -217,6 +261,11 @@ while IFS='|' read -r contract_id contract_module contract_namespace contract_ex
     "$contract_target_secret" \
     "$contract_target_keys"
 done < <(python3 "$runtime_identity_contract_cli" eso-contracts | tr $'\t' '|')
+
+if (( ${#ESO_SECRET_CONTRACTS_SKIPPED[@]} > 0 )); then
+  skipped_contract_count="${#ESO_SECRET_CONTRACTS_SKIPPED[@]}"
+  skipped_contracts="$(IFS=,; printf '%s' "${ESO_SECRET_CONTRACTS_SKIPPED[*]}")"
+fi
 
 eso_contract_count="$(eso_secret_contract_count)"
 status="success"
@@ -374,6 +423,8 @@ state_file="$(
     "externalsecret_name=$RUNTIME_CREDENTIALS_ESO_EXTERNAL_SECRET_NAME" \
     "externalsecret_checked=$external_secret_checked" \
     "target_secret_checked=$target_secret_checked" \
+    "skipped_contract_count=$skipped_contract_count" \
+    "skipped_contracts=$skipped_contracts" \
     "wait_timeout_seconds=$runtime_wait_timeout" \
     "apply_mode=$apply_mode" \
     "crd_status=$crd_status" \

--- a/scripts/bin/platform/auth/reconcile_eso_runtime_secrets.sh
+++ b/scripts/bin/platform/auth/reconcile_eso_runtime_secrets.sh
@@ -157,6 +157,13 @@ local_lite_postgres_runtime_ready() {
   fi
   local runtime_state_file
   runtime_state_file="$(state_file_path postgres_runtime)"
+  # Guard against stale cross-profile artifacts: only trust local-lite/local state ownership.
+  if ! grep -q '^profile=local-lite$' "$runtime_state_file" 2>/dev/null; then
+    return 1
+  fi
+  if ! grep -q '^stack=local$' "$runtime_state_file" 2>/dev/null; then
+    return 1
+  fi
   if ! grep -q '^dsn=postgresql://' "$runtime_state_file" 2>/dev/null; then
     return 1
   fi

--- a/scripts/templates/blueprint/bootstrap/docs/platform/consumer/runtime_credentials_eso.md
+++ b/scripts/templates/blueprint/bootstrap/docs/platform/consumer/runtime_credentials_eso.md
@@ -137,7 +137,7 @@ make auth-reconcile-runtime-identity
 ```
 
 Local-lite Postgres note:
-- When `BLUEPRINT_PROFILE=local-lite`, `POSTGRES_ENABLED=true`, and `artifacts/infra/postgres_runtime.env` contains a valid PostgreSQL DSN, runtime-credentials reconciliation skips the ESO readiness/target checks for `data/postgres-runtime-credentials`.
+- When `BLUEPRINT_PROFILE=local-lite`, `POSTGRES_ENABLED=true`, and `artifacts/infra/postgres_runtime.env` is owned by local-lite/local runtime (`profile=local-lite`, `stack=local`) with a valid PostgreSQL DSN, runtime-credentials reconciliation skips the ESO readiness/target checks for `data/postgres-runtime-credentials`.
 - This prevents false `warn-and-skip` noise when local Postgres runtime is already healthy through the local Helm/runtime-state path.
 - Reconcile state artifacts surface this as `skipped_contract_count` and `skipped_contracts`.
 

--- a/scripts/templates/blueprint/bootstrap/docs/platform/consumer/runtime_credentials_eso.md
+++ b/scripts/templates/blueprint/bootstrap/docs/platform/consumer/runtime_credentials_eso.md
@@ -136,6 +136,11 @@ export ARGOCD_REPO_TOKEN='github_pat_your_token'
 make auth-reconcile-runtime-identity
 ```
 
+Local-lite Postgres note:
+- When `BLUEPRINT_PROFILE=local-lite`, `POSTGRES_ENABLED=true`, and `artifacts/infra/postgres_runtime.env` contains a valid PostgreSQL DSN, runtime-credentials reconciliation skips the ESO readiness/target checks for `data/postgres-runtime-credentials`.
+- This prevents false `warn-and-skip` noise when local Postgres runtime is already healthy through the local Helm/runtime-state path.
+- Reconcile state artifacts surface this as `skipped_contract_count` and `skipped_contracts`.
+
 Resulting state artifacts:
 - `artifacts/infra/runtime_credentials_eso_reconcile.env`
 - `artifacts/infra/runtime_credentials_eso_reconcile.json`

--- a/tests/blueprint/contract_refactor_scripts_cases.py
+++ b/tests/blueprint/contract_refactor_scripts_cases.py
@@ -277,6 +277,8 @@ class ScriptsRefactorCases(RefactorContractBase):
         self.assertIn("local_lite_postgres_runtime_ready()", reconcile)
         self.assertIn("should_skip_eso_contract_check()", reconcile)
         self.assertIn("runtime_credentials_eso_contract_skip_total", reconcile)
+        self.assertIn("'^profile=local-lite$'", reconcile)
+        self.assertIn("'^stack=local$'", reconcile)
         self.assertIn(
             'if [[ "$contract_id" == "postgres-runtime-credentials" && "$contract_module" == "postgres" ]]; then',
             reconcile,

--- a/tests/blueprint/contract_refactor_scripts_cases.py
+++ b/tests/blueprint/contract_refactor_scripts_cases.py
@@ -272,6 +272,20 @@ class ScriptsRefactorCases(RefactorContractBase):
             reconcile,
         )
 
+    def test_runtime_credentials_reconcile_skips_local_lite_postgres_eso_contract_checks(self) -> None:
+        reconcile = _read("scripts/bin/platform/auth/reconcile_eso_runtime_secrets.sh")
+        self.assertIn("local_lite_postgres_runtime_ready()", reconcile)
+        self.assertIn("should_skip_eso_contract_check()", reconcile)
+        self.assertIn("runtime_credentials_eso_contract_skip_total", reconcile)
+        self.assertIn(
+            'if [[ "$contract_id" == "postgres-runtime-credentials" && "$contract_module" == "postgres" ]]; then',
+            reconcile,
+        )
+        self.assertIn("contract_id=$contract_id module=$contract_module", reconcile)
+        self.assertIn("reason=local-lite-postgres-runtime", reconcile)
+        self.assertIn("skipped_contract_count", reconcile)
+        self.assertIn("skipped_contracts", reconcile)
+
     def test_bootstrap_preserves_disabled_optional_scaffolding(self) -> None:
         bootstrap = _read("scripts/bin/infra/bootstrap.sh")
         self.assertIn(

--- a/tests/infra/test_runtime_credentials_eso.py
+++ b/tests/infra/test_runtime_credentials_eso.py
@@ -20,6 +20,8 @@ class RuntimeCredentialsEsoTests(unittest.TestCase):
             REPO_ROOT / "artifacts" / "infra" / "argocd_repo_credentials_reconcile.json",
             REPO_ROOT / "artifacts" / "infra" / "runtime_identity_reconcile.env",
             REPO_ROOT / "artifacts" / "infra" / "runtime_identity_reconcile.json",
+            REPO_ROOT / "artifacts" / "infra" / "postgres_runtime.env",
+            REPO_ROOT / "artifacts" / "infra" / "postgres_runtime.json",
         )
         for state_path in state_paths:
             if state_path.exists():
@@ -134,6 +136,42 @@ class RuntimeCredentialsEsoTests(unittest.TestCase):
         self.assertIn("status=noop-empty-contract-set", state)
         self.assertIn("source_secret_seed_mode=skipped-empty-contract-set", state)
         self.assertIn("issue_count=0", state)
+
+    def test_local_lite_postgres_runtime_contract_is_skipped_when_runtime_state_exists(self) -> None:
+        env = module_flags_env(profile="local-lite", postgres="true")
+        postgres_runtime_state = REPO_ROOT / "artifacts" / "infra" / "postgres_runtime.env"
+        postgres_runtime_state.parent.mkdir(parents=True, exist_ok=True)
+        postgres_runtime_state.write_text(
+            "\n".join(
+                [
+                    "profile=local-lite",
+                    "stack=local",
+                    "tooling_mode=execute",
+                    "dsn=postgresql://platform:platform-password@blueprint-postgres.data.svc.cluster.local:5432/platform",
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        result = run_make("auth-reconcile-eso-runtime-secrets", env)
+        self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+
+        combined_output = result.stdout + result.stderr
+        self.assertIn(
+            "runtime credentials contract check skipped contract_id=postgres-runtime-credentials",
+            combined_output,
+        )
+
+        state_path = REPO_ROOT / "artifacts" / "infra" / "runtime_credentials_eso_reconcile.env"
+        self.assertTrue(state_path.exists(), msg="runtime credentials state artifact was not created")
+        state = state_path.read_text(encoding="utf-8")
+        self.assertIn("status=success", state)
+        self.assertIn("skipped_contract_count=1", state)
+        self.assertIn(
+            "skipped_contracts=data/postgres-runtime-credentials:local-lite-postgres-runtime",
+            state,
+        )
 
     def test_argocd_reconcile_resolves_repo_contract_without_argparse_errors(self) -> None:
         env = module_flags_env(profile="local-full")

--- a/tests/infra/test_runtime_credentials_eso.py
+++ b/tests/infra/test_runtime_credentials_eso.py
@@ -173,6 +173,38 @@ class RuntimeCredentialsEsoTests(unittest.TestCase):
             state,
         )
 
+    def test_local_lite_postgres_runtime_contract_skip_requires_owned_local_state(self) -> None:
+        env = module_flags_env(profile="local-lite", postgres="true")
+        postgres_runtime_state = REPO_ROOT / "artifacts" / "infra" / "postgres_runtime.env"
+        postgres_runtime_state.parent.mkdir(parents=True, exist_ok=True)
+        postgres_runtime_state.write_text(
+            "\n".join(
+                [
+                    "profile=stackit-dev",
+                    "stack=stackit",
+                    "tooling_mode=execute",
+                    "dsn=postgresql://platform:platform-password@blueprint-postgres.data.svc.cluster.local:5432/platform",
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        result = run_make("auth-reconcile-eso-runtime-secrets", env)
+        self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+
+        combined_output = result.stdout + result.stderr
+        self.assertNotIn(
+            "runtime credentials contract check skipped contract_id=postgres-runtime-credentials",
+            combined_output,
+        )
+
+        state_path = REPO_ROOT / "artifacts" / "infra" / "runtime_credentials_eso_reconcile.env"
+        self.assertTrue(state_path.exists(), msg="runtime credentials state artifact was not created")
+        state = state_path.read_text(encoding="utf-8")
+        self.assertIn("skipped_contract_count=0", state)
+        self.assertIn("skipped_contracts=none", state)
+
     def test_argocd_reconcile_resolves_repo_contract_without_argparse_errors(self) -> None:
         env = module_flags_env(profile="local-full")
         env.update(


### PR DESCRIPTION
## Summary
This PR fixes the local-lite Postgres false-positive warning in runtime identity ESO reconciliation.

When `BLUEPRINT_PROFILE=local-lite` and Postgres runtime state is healthy, `auth-reconcile-eso-runtime-secrets` now skips the `data/postgres-runtime-credentials` ESO contract check instead of emitting a noisy warn-and-skip.

## What Changed
- Added local-lite runtime readiness detection in `reconcile_eso_runtime_secrets.sh`.
- Added targeted skip logic for `postgres-runtime-credentials` contract checks in that healthy local-lite path.
- Added skip metric/log emission and persisted skip metadata in reconcile state artifacts.
- Added regression tests for runtime behavior and static contract coverage.
- Updated runtime credentials consumer docs (and synchronized bootstrap template docs).

## Backward Compatibility
- Additive and non-breaking.
- Behavior only changes for `local-lite` + `POSTGRES_ENABLED=true` + valid local Postgres runtime state.
- Other profiles and paths continue to enforce existing contract checks.

## Validation
- `pytest -q tests/infra/test_runtime_credentials_eso.py tests/blueprint/contract_refactor_scripts_cases.py`
- `make infra-validate`
- `make infra-smoke`
- `make infra-audit-version`
- `make quality-hooks-run`

All passed locally.

Fixes #114
