### PR TITLE
fix: prevent false missing ESO runtime secret keys (#119)

### DIFF
--- a/scripts/bin/platform/auth/reconcile_eso_runtime_secrets.sh
+++ b/scripts/bin/platform/auth/reconcile_eso_runtime_secrets.sh
@@ -42,6 +42,7 @@ fi
 
 require_command python3
 runtime_identity_contract_cli="$ROOT_DIR/scripts/lib/infra/runtime_identity_contract.py"
+runtime_secret_json_helpers="$ROOT_DIR/scripts/lib/platform/auth/runtime_secret_keys_json.py"
 
 while IFS=$'\t' read -r env_name env_default; do
   [[ -n "$env_name" ]] || continue
@@ -118,30 +119,32 @@ verify_target_secret_keys() {
   local namespace="$1"
   local secret_name="$2"
   local keys_csv="$3"
+  local secret_json verification_output
 
-  if ! kubectl -n "$namespace" get secret "$secret_name" >/dev/null 2>&1; then
+  if ! run_kubectl_with_active_access -n "$namespace" get secret "$secret_name" >/dev/null 2>&1; then
     printf '__missing_secret__\n'
     return 1
   fi
 
-  local raw_key key value
-  local -a missing_keys=()
-  IFS=',' read -r -a requested_keys <<<"$keys_csv"
-  for raw_key in "${requested_keys[@]}"; do
-    key="$(trim_whitespace "$raw_key")"
-    [[ -n "$key" ]] || continue
-    value="$(kubectl -n "$namespace" get secret "$secret_name" -o "jsonpath={.data[\"$key\"]}" 2>/dev/null || true)"
-    if [[ -z "$value" ]]; then
-      missing_keys+=("$key")
-    fi
-  done
-
-  if (( ${#missing_keys[@]} > 0 )); then
-    printf '%s\n' "${missing_keys[*]}"
+  secret_json="$(run_kubectl_capture_stdout_with_active_access -n "$namespace" get secret "$secret_name" -o json 2>/dev/null || true)"
+  if [[ -z "$secret_json" ]]; then
+    printf '__verify_error__:empty-secret-json\n'
     return 1
   fi
 
-  printf 'ok\n'
+  if ! verification_output="$(
+    printf '%s' "$secret_json" | python3 "$runtime_secret_json_helpers" verify-required-keys "$keys_csv" 2>&1
+  )"; then
+    printf '%s\n' "$verification_output"
+    return 1
+  fi
+
+  if [[ "$verification_output" != "ok" ]]; then
+    printf '__verify_error__:unexpected-verifier-output\n'
+    return 1
+  fi
+
+  printf '%s\n' "$verification_output"
   return 0
 }
 
@@ -383,6 +386,18 @@ else
         fi
         record_reconcile_issue \
           "target secret ${contract_namespace}/${contract_target_secret} is missing"
+        continue
+      fi
+
+      if [[ "$target_check_output" == "__verify_error__:"* ]]; then
+        target_secret_status="verify-error"
+        if [[ "$target_missing_keys" == "none" ]]; then
+          target_missing_keys="${contract_namespace}/${contract_target_secret}:verify-error"
+        else
+          target_missing_keys+=",${contract_namespace}/${contract_target_secret}:verify-error"
+        fi
+        record_reconcile_issue \
+          "target secret ${contract_namespace}/${contract_target_secret} verification error: ${target_check_output#__verify_error__:}"
         continue
       fi
 

--- a/scripts/lib/platform/auth/runtime_secret_keys_json.py
+++ b/scripts/lib/platform/auth/runtime_secret_keys_json.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Helpers for runtime ESO target secret JSON verification."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+
+def _parse_json_candidate(candidate: str) -> dict[str, object] | None:
+    try:
+        payload = json.loads(candidate)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    return payload
+
+
+def _parse_secret_payload(raw_payload: str) -> dict[str, object] | None:
+    payload = _parse_json_candidate(raw_payload)
+    if payload is not None:
+        return payload
+
+    compact = raw_payload.strip()
+    start = compact.find("{")
+    end = compact.rfind("}")
+    if start == -1 or end <= start:
+        return None
+    return _parse_json_candidate(compact[start : end + 1])
+
+
+def cmd_verify_required_keys(args: argparse.Namespace) -> int:
+    raw_payload = sys.stdin.read()
+    if raw_payload.strip() == "":
+        print("__verify_error__:empty-secret-json")
+        return 2
+
+    payload = _parse_secret_payload(raw_payload)
+    if payload is None:
+        print("__verify_error__:invalid-secret-json")
+        return 2
+
+    data = payload.get("data")
+    if not isinstance(data, dict):
+        print("__verify_error__:missing-secret-data-map")
+        return 2
+
+    keys = [item.strip() for item in args.keys_csv.split(",") if item.strip()]
+    missing: list[str] = []
+    for key in keys:
+        value = data.get(key)
+        if value is None or str(value).strip() == "":
+            missing.append(key)
+
+    if missing:
+        print(" ".join(missing))
+        return 1
+
+    print("ok")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    verify_parser = subparsers.add_parser("verify-required-keys")
+    verify_parser.add_argument("keys_csv")
+    verify_parser.set_defaults(func=cmd_verify_required_keys)
+
+    args = parser.parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/infra/test_python_helper_extractions.py
+++ b/tests/infra/test_python_helper_extractions.py
@@ -232,6 +232,76 @@ class PythonHelperExtractionsTests(unittest.TestCase):
             self.assertEqual(invalid_base64.returncode, 1)
             self.assertIn("contains invalid base64 content", invalid_base64.stderr)
 
+    def test_runtime_secret_keys_helpers(self) -> None:
+        script = REPO_ROOT / "scripts/lib/platform/auth/runtime_secret_keys_json.py"
+
+        import subprocess
+
+        valid_secret = {"apiVersion": "v1", "kind": "Secret", "data": {"client-id": "YQ==", "client-secret": "Yg=="}}
+        valid = subprocess.run(
+            [sys.executable, str(script), "verify-required-keys", "client-id,client-secret"],
+            input=json.dumps(valid_secret),
+            text=True,
+            capture_output=True,
+            cwd=REPO_ROOT,
+        )
+        self.assertEqual(valid.returncode, 0, msg=valid.stdout + valid.stderr)
+        self.assertEqual(valid.stdout.strip(), "ok")
+
+        missing = subprocess.run(
+            [sys.executable, str(script), "verify-required-keys", "client-id,client-secret"],
+            input=json.dumps({"data": {"client-id": "YQ=="}}),
+            text=True,
+            capture_output=True,
+            cwd=REPO_ROOT,
+        )
+        self.assertEqual(missing.returncode, 1, msg=missing.stdout + missing.stderr)
+        self.assertEqual(missing.stdout.strip(), "client-secret")
+
+        noisy_input = subprocess.run(
+            [sys.executable, str(script), "verify-required-keys", "client-id,client-secret"],
+            input=(
+                "INFO bootstrap complete\n"
+                + json.dumps({"data": {"client-id": "YQ==", "client-secret": "Yg=="}})
+                + "\nINFO done\n"
+            ),
+            text=True,
+            capture_output=True,
+            cwd=REPO_ROOT,
+        )
+        self.assertEqual(noisy_input.returncode, 0, msg=noisy_input.stdout + noisy_input.stderr)
+        self.assertEqual(noisy_input.stdout.strip(), "ok")
+
+        missing_data_map = subprocess.run(
+            [sys.executable, str(script), "verify-required-keys", "client-id"],
+            input=json.dumps({"kind": "Secret"}),
+            text=True,
+            capture_output=True,
+            cwd=REPO_ROOT,
+        )
+        self.assertEqual(missing_data_map.returncode, 2, msg=missing_data_map.stdout + missing_data_map.stderr)
+        self.assertEqual(missing_data_map.stdout.strip(), "__verify_error__:missing-secret-data-map")
+
+        invalid_json = subprocess.run(
+            [sys.executable, str(script), "verify-required-keys", "client-id"],
+            input="{",
+            text=True,
+            capture_output=True,
+            cwd=REPO_ROOT,
+        )
+        self.assertEqual(invalid_json.returncode, 2, msg=invalid_json.stdout + invalid_json.stderr)
+        self.assertEqual(invalid_json.stdout.strip(), "__verify_error__:invalid-secret-json")
+
+        empty_input = subprocess.run(
+            [sys.executable, str(script), "verify-required-keys", "client-id"],
+            input="",
+            text=True,
+            capture_output=True,
+            cwd=REPO_ROOT,
+        )
+        self.assertEqual(empty_input.returncode, 2, msg=empty_input.stdout + empty_input.stderr)
+        self.assertEqual(empty_input.stdout.strip(), "__verify_error__:empty-secret-json")
+
     def test_prereqs_helpers_and_runtime_workload_helpers(self) -> None:
         prereqs_script = REPO_ROOT / "scripts/lib/infra/prereqs_helpers.py"
         workload_script = REPO_ROOT / "scripts/lib/platform/apps/runtime_workload_helpers.py"

--- a/tests/infra/test_runtime_credentials_eso.py
+++ b/tests/infra/test_runtime_credentials_eso.py
@@ -205,6 +205,161 @@ class RuntimeCredentialsEsoTests(unittest.TestCase):
         self.assertIn("skipped_contract_count=0", state)
         self.assertIn("skipped_contracts=none", state)
 
+    def test_required_mode_does_not_false_flag_hyphenated_target_keys_as_missing(self) -> None:
+        env = module_flags_env(profile="local-full")
+        env.update(
+            {
+                "DRY_RUN": "false",
+                "RUNTIME_CREDENTIALS_REQUIRED": "true",
+                "RUNTIME_CREDENTIALS_SOURCE_SECRET_LITERALS": "username=dev-user,password=dev-password",
+            }
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            shim_dir = Path(tmpdir)
+
+            python_shim = shim_dir / "python3"
+            python_shim.write_text(
+                "\n".join(
+                    [
+                        "#!/usr/bin/env bash",
+                        "set -euo pipefail",
+                        f'target_contract_cli="{REPO_ROOT}/scripts/lib/infra/runtime_identity_contract.py"',
+                        'if [[ "${1:-}" == "$target_contract_cli" ]]; then',
+                        '  case "${2:-}" in',
+                        "    runtime-env-defaults)",
+                        "      cat <<'EOF'",
+                        "KEYCLOAK_OPTIONAL_MODULE_RECONCILIATION_ENABLED\ttrue",
+                        "RUNTIME_CREDENTIALS_SOURCE_NAMESPACE\tsecurity",
+                        "RUNTIME_CREDENTIALS_TARGET_NAMESPACE\tapps",
+                        "RUNTIME_CREDENTIALS_ESO_WAIT_TIMEOUT\t15",
+                        "RUNTIME_CREDENTIALS_REQUIRED\tfalse",
+                        "EOF",
+                        "      exit 0",
+                        "      ;;",
+                        "    eso-contracts)",
+                        "      cat <<'EOF'",
+                        "iap-runtime-credentials\t\tsecurity\tiap-runtime-credentials\tiap-runtime-credentials\tclient-id,client-secret",
+                        "EOF",
+                        "      exit 0",
+                        "      ;;",
+                        "  esac",
+                        "fi",
+                        f"exec {shlex.quote(sys.executable)} \"$@\"",
+                        "",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            python_shim.chmod(0o755)
+
+            kubectl_shim = shim_dir / "kubectl"
+            kubectl_shim.write_text(
+                "\n".join(
+                    [
+                        "#!/usr/bin/env bash",
+                        "set -euo pipefail",
+                        'if [[ "${1:-}" == "--context=docker-desktop" && "${2:-}" == "config" && "${3:-}" == "view" && "${4:-}" == "--raw" && "${5:-}" == "--minify" && "${6:-}" == "--flatten" ]]; then',
+                        "  cat <<'EOF'",
+                        "apiVersion: v1",
+                        "kind: Config",
+                        "clusters:",
+                        "- cluster:",
+                        "    server: https://docker-desktop.example:6443",
+                        "  name: docker-desktop",
+                        "contexts:",
+                        "- context:",
+                        "    cluster: docker-desktop",
+                        "    user: docker-desktop",
+                        "  name: docker-desktop",
+                        "current-context: docker-desktop",
+                        "users:",
+                        "- name: docker-desktop",
+                        "  user:",
+                        "    token: placeholder",
+                        "EOF",
+                        "  exit 0",
+                        "fi",
+                        'if [[ "${1:-}" == "config" && "${2:-}" == "get-contexts" && "${3:-}" == "-o" && "${4:-}" == "name" ]]; then',
+                        "  printf 'docker-desktop\\n'",
+                        "  exit 0",
+                        "fi",
+                        'if [[ "${1:-}" == "config" && "${2:-}" == "current-context" ]]; then',
+                        "  printf 'docker-desktop\\n'",
+                        "  exit 0",
+                        "fi",
+                        'while [[ "$#" -gt 0 ]]; do',
+                        '  case "$1" in',
+                        "    --kubeconfig|--context)",
+                        "      shift 2",
+                        "      continue",
+                        "      ;;",
+                        "    --kubeconfig=*|--context=*)",
+                        "      shift",
+                        "      continue",
+                        "      ;;",
+                        "  esac",
+                        "  break",
+                        "done",
+                        'if [[ "${1:-}" == "apply" && "${2:-}" == "-k" ]]; then',
+                        "  exit 0",
+                        "fi",
+                        'if [[ "${1:-}" == "apply" && "${2:-}" == "-f" ]]; then',
+                        "  exit 0",
+                        "fi",
+                        'if [[ "${1:-}" == "get" && "${2:-}" == "crd/clustersecretstores.external-secrets.io" ]]; then',
+                        "  printf 'Established=True\\n'",
+                        "  exit 0",
+                        "fi",
+                        'if [[ "${1:-}" == "get" && "${2:-}" == "crd/externalsecrets.external-secrets.io" ]]; then',
+                        "  printf 'Established=True\\n'",
+                        "  exit 0",
+                        "fi",
+                        'if [[ "${1:-}" == "-n" && "${2:-}" == "security" && "${3:-}" == "get" && "${4:-}" == "externalsecret" && "${5:-}" == "iap-runtime-credentials" && "${6:-}" == "-o" ]]; then',
+                        "  printf 'Ready=True\\n'",
+                        "  exit 0",
+                        "fi",
+                        'if [[ "${1:-}" == "-n" && "${2:-}" == "security" && "${3:-}" == "get" && "${4:-}" == "externalsecret" && "${5:-}" == "iap-runtime-credentials" ]]; then',
+                        "  exit 0",
+                        "fi",
+                        'if [[ "${1:-}" == "-n" && "${2:-}" == "security" && "${3:-}" == "get" && "${4:-}" == "secret" && "${5:-}" == "iap-runtime-credentials" && "${6:-}" == "-o" && "${7:-}" == "json" ]]; then',
+                        "  cat <<'EOF'",
+                        '{"apiVersion":"v1","kind":"Secret","metadata":{"name":"iap-runtime-credentials","namespace":"security"},"data":{"client-id":"Y2xpZW50LWlk","client-secret":"Y2xpZW50LXNlY3JldA=="}}',
+                        "EOF",
+                        "  exit 0",
+                        "fi",
+                        'if [[ "${1:-}" == "-n" && "${2:-}" == "security" && "${3:-}" == "get" && "${4:-}" == "secret" && "${5:-}" == "iap-runtime-credentials" && "${6:-}" == "-o" ]]; then',
+                        "  printf 'simulated jsonpath parser mismatch\\n' >&2",
+                        "  exit 1",
+                        "fi",
+                        'if [[ "${1:-}" == "-n" && "${2:-}" == "security" && "${3:-}" == "get" && "${4:-}" == "secret" && "${5:-}" == "iap-runtime-credentials" ]]; then',
+                        "  exit 0",
+                        "fi",
+                        'printf "unexpected kubectl call: %s\\n" "$*" >&2',
+                        "exit 1",
+                        "",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            kubectl_shim.chmod(0o755)
+
+            env["PATH"] = f"{shim_dir}:{os.environ.get('PATH', '')}"
+            result = run_make("auth-reconcile-eso-runtime-secrets", env)
+
+        self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+        combined_output = result.stdout + result.stderr
+        self.assertNotIn("missing key(s)", combined_output)
+        self.assertNotIn("verification error", combined_output)
+
+        state_path = REPO_ROOT / "artifacts" / "infra" / "runtime_credentials_eso_reconcile.env"
+        self.assertTrue(state_path.exists(), msg="runtime credentials state artifact was not created")
+        state = state_path.read_text(encoding="utf-8")
+        self.assertIn("status=success", state)
+        self.assertIn("target_secret_status=ready", state)
+        self.assertIn("target_secret_missing_keys=none", state)
+        self.assertIn("target_secret_checked=security/iap-runtime-credentials", state)
+
     def test_argocd_reconcile_resolves_repo_contract_without_argparse_errors(self) -> None:
         env = module_flags_env(profile="local-full")
         env.update(


### PR DESCRIPTION
## Summary
- fix false missing-key reports in runtime ESO target secret verification by switching from per-key jsonpath reads to full secret JSON verification
- extract target secret key verification logic into `scripts/lib/platform/auth/runtime_secret_keys_json.py` for reusable, testable behavior
- keep explicit `__verify_error__:*` contract handling so verification failures are not mislabeled as missing keys
- add regression coverage for hyphenated key names and focused helper extraction tests

## Validation
- `.venv/bin/python -m pytest -q tests/infra/test_runtime_credentials_eso.py`
- `.venv/bin/python -m pytest -q tests/infra/test_tooling_contracts.py`
- `.venv/bin/python -m pytest -q tests/blueprint/contract_refactor_scripts_cases.py tests/blueprint/test_quality_contracts.py`
- `.venv/bin/python -m pytest -q tests/infra/test_python_helper_extractions.py -k 'runtime_secret_keys_helpers or argocd_repo_credentials_helpers'`
- `.venv/bin/python -m pytest -q tests/infra/test_runtime_credentials_eso.py tests/infra/test_python_helper_extractions.py -k 'runtime_secret_keys_helpers or hyphenated_target_keys'`
- `make infra-validate`
- `make infra-smoke`
- `make infra-audit-version`
- `make quality-hooks-run`

## Queue
- Implements frozen queue item: `#119 Fix runtime ESO key verification false missing keys (P1)`
