### PR TITLE
feat: add typed runtime target-secret checker with JSON diagnostics (#120)

### DIFF
--- a/docs/platform/consumer/runtime_credentials_eso.md
+++ b/docs/platform/consumer/runtime_credentials_eso.md
@@ -144,6 +144,8 @@ Local-lite Postgres note:
 Resulting state artifacts:
 - `artifacts/infra/runtime_credentials_eso_reconcile.env`
 - `artifacts/infra/runtime_credentials_eso_reconcile.json`
+- `artifacts/infra/runtime_credentials_eso_target_secret_checks.json` (aggregated typed target-secret diagnostics)
+- `artifacts/infra/runtime_credentials_eso_target_secret_checks/*.json` (per-contract typed target-secret diagnostics)
 - `artifacts/infra/argocd_repo_credentials_reconcile.env`
 - `artifacts/infra/argocd_repo_credentials_reconcile.json`
 - `artifacts/infra/runtime_identity_reconcile.env`

--- a/scripts/bin/platform/auth/reconcile_eso_runtime_secrets.sh
+++ b/scripts/bin/platform/auth/reconcile_eso_runtime_secrets.sh
@@ -481,13 +481,6 @@ else
     done
   fi
 
-  if (( ${#RUNTIME_RECONCILE_ISSUES[@]} > 0 )); then
-    if [[ "$RUNTIME_CREDENTIALS_REQUIRED_NORMALIZED" == "true" ]]; then
-      status="failed-required"
-    else
-      status="warn-and-skip"
-    fi
-  fi
 fi
 
 target_secret_diagnostics_count="${#TARGET_SECRET_CHECK_DIAGNOSTIC_FILES[@]}"
@@ -504,6 +497,18 @@ else
     target_secret_status="verify-error"
     record_reconcile_issue "failed to render runtime target-secret diagnostics report at $target_secret_diagnostics_report"
   fi
+fi
+
+if (( ${#RUNTIME_RECONCILE_ISSUES[@]} > 0 )); then
+  if [[ "$RUNTIME_CREDENTIALS_REQUIRED_NORMALIZED" == "true" ]]; then
+    status="failed-required"
+  else
+    status="warn-and-skip"
+  fi
+elif (( eso_contract_count == 0 )); then
+  status="noop-empty-contract-set"
+else
+  status="success"
 fi
 
 log_metric \

--- a/scripts/bin/platform/auth/reconcile_eso_runtime_secrets.sh
+++ b/scripts/bin/platform/auth/reconcile_eso_runtime_secrets.sh
@@ -115,37 +115,94 @@ wait_for_external_secret_ready() {
   done
 }
 
+sanitize_diagnostics_token() {
+  local value="$1"
+  printf '%s' "${value//[^a-zA-Z0-9_.-]/_}"
+}
+
+target_secret_check_diagnostics_path() {
+  local namespace="$1"
+  local secret_name="$2"
+  local namespace_token secret_token
+  namespace_token="$(sanitize_diagnostics_token "$namespace")"
+  secret_token="$(sanitize_diagnostics_token "$secret_name")"
+  printf '%s/%s__%s.json' "$target_secret_diagnostics_dir" "$namespace_token" "$secret_token"
+}
+
 verify_target_secret_keys() {
   local namespace="$1"
   local secret_name="$2"
   local keys_csv="$3"
-  local secret_json verification_output
+  local diagnostics_output_path="$4"
+  local secret_json checker_output checker_status
+  local check_status check_missing_keys check_reason
 
-  if ! run_kubectl_with_active_access -n "$namespace" get secret "$secret_name" >/dev/null 2>&1; then
-    printf '__missing_secret__\n'
+  set +e
+  if run_kubectl_with_active_access -n "$namespace" get secret "$secret_name" >/dev/null 2>&1; then
+    secret_json="$(run_kubectl_capture_stdout_with_active_access -n "$namespace" get secret "$secret_name" -o json 2>/dev/null || true)"
+    checker_output="$(
+      printf '%s' "$secret_json" | \
+        python3 "$runtime_secret_json_helpers" check-target-secret \
+          --namespace "$namespace" \
+          --secret-name "$secret_name" \
+          --required-keys "$keys_csv" \
+          --summary \
+          --output-json "$diagnostics_output_path" 2>/dev/null
+    )"
+    checker_status=$?
+  else
+    checker_output="$(
+      python3 "$runtime_secret_json_helpers" check-target-secret \
+        --namespace "$namespace" \
+        --secret-name "$secret_name" \
+        --required-keys "$keys_csv" \
+        --secret-present false \
+        --summary \
+        --output-json "$diagnostics_output_path" 2>/dev/null
+    )"
+    checker_status=$?
+  fi
+  set -e
+
+  if [[ -z "$checker_output" ]]; then
+    printf '__verify_error__:target-secret-checker-empty-output\n'
     return 1
   fi
 
-  secret_json="$(run_kubectl_capture_stdout_with_active_access -n "$namespace" get secret "$secret_name" -o json 2>/dev/null || true)"
-  if [[ -z "$secret_json" ]]; then
-    printf '__verify_error__:empty-secret-json\n'
-    return 1
-  fi
+  IFS=$'\t' read -r check_status check_missing_keys check_reason <<<"$checker_output"
+  check_status="${check_status:-verify-error}"
+  check_missing_keys="${check_missing_keys:-none}"
+  check_reason="${check_reason:-unknown-checker-error}"
 
-  if ! verification_output="$(
-    printf '%s' "$secret_json" | python3 "$runtime_secret_json_helpers" verify-required-keys "$keys_csv" 2>&1
-  )"; then
-    printf '%s\n' "$verification_output"
-    return 1
-  fi
-
-  if [[ "$verification_output" != "ok" ]]; then
-    printf '__verify_error__:unexpected-verifier-output\n'
-    return 1
-  fi
-
-  printf '%s\n' "$verification_output"
-  return 0
+  case "$check_status" in
+    ready)
+      printf 'ok\n'
+      return 0
+      ;;
+    missing-secret)
+      printf '__missing_secret__\n'
+      return 1
+      ;;
+    missing-keys)
+      if [[ "$check_missing_keys" == "none" ]]; then
+        printf '__verify_error__:missing-keys-without-list\n'
+        return 1
+      fi
+      printf '%s\n' "${check_missing_keys//,/ }"
+      return 1
+      ;;
+    verify-error)
+      printf '__verify_error__:%s\n' "$check_reason"
+      return 1
+      ;;
+    *)
+      printf '__verify_error__:unexpected-checker-status:%s\n' "$check_status"
+      if (( checker_status != 0 )); then
+        return "$checker_status"
+      fi
+      return 1
+      ;;
+  esac
 }
 
 local_lite_postgres_runtime_ready() {
@@ -242,10 +299,17 @@ target_missing_keys=""
 source_secret_present="unknown"
 external_secret_checked=""
 target_secret_checked=""
+target_secret_diagnostics_dir="$ROOT_DIR/artifacts/infra/runtime_credentials_eso_target_secret_checks"
+target_secret_diagnostics_report="$ROOT_DIR/artifacts/infra/runtime_credentials_eso_target_secret_checks.json"
+target_secret_diagnostics_count="0"
 declare -a ESO_SECRET_CONTRACTS=()
 declare -a ESO_SECRET_CONTRACTS_SKIPPED=()
+declare -a TARGET_SECRET_CHECK_DIAGNOSTIC_FILES=()
 skipped_contract_count="0"
 skipped_contracts="none"
+
+mkdir -p "$target_secret_diagnostics_dir"
+rm -f "$target_secret_diagnostics_dir"/*.json "$target_secret_diagnostics_report"
 
 while IFS='|' read -r contract_id contract_module contract_namespace contract_external_secret contract_target_secret contract_target_keys; do
   [[ -n "$contract_id" ]] || continue
@@ -364,10 +428,15 @@ else
           "ExternalSecret ${contract_namespace}/${contract_external_secret} not Ready within ${runtime_wait_timeout}s"
       fi
 
+      target_secret_check_diagnostics_file="$(target_secret_check_diagnostics_path "$contract_namespace" "$contract_target_secret")"
       target_check_output="$(verify_target_secret_keys \
         "$contract_namespace" \
         "$contract_target_secret" \
-        "$contract_target_keys" || true)"
+        "$contract_target_keys" \
+        "$target_secret_check_diagnostics_file" || true)"
+      if [[ -f "$target_secret_check_diagnostics_file" ]]; then
+        TARGET_SECRET_CHECK_DIAGNOSTIC_FILES+=("$target_secret_check_diagnostics_file")
+      fi
       if [[ "$target_check_output" == "ok" ]]; then
         if [[ "$target_secret_checked" == "none" ]]; then
           target_secret_checked="${contract_namespace}/${contract_target_secret}"
@@ -421,6 +490,22 @@ else
   fi
 fi
 
+target_secret_diagnostics_count="${#TARGET_SECRET_CHECK_DIAGNOSTIC_FILES[@]}"
+if (( target_secret_diagnostics_count > 0 )); then
+  if ! python3 "$runtime_secret_json_helpers" render-check-report \
+    --output "$target_secret_diagnostics_report" \
+    "${TARGET_SECRET_CHECK_DIAGNOSTIC_FILES[@]}" >/dev/null; then
+    target_secret_status="verify-error"
+    record_reconcile_issue "failed to render runtime target-secret diagnostics report at $target_secret_diagnostics_report"
+  fi
+else
+  if ! python3 "$runtime_secret_json_helpers" render-check-report \
+    --output "$target_secret_diagnostics_report" >/dev/null; then
+    target_secret_status="verify-error"
+    record_reconcile_issue "failed to render runtime target-secret diagnostics report at $target_secret_diagnostics_report"
+  fi
+fi
+
 log_metric \
   "runtime_credentials_eso_reconcile_total" \
   "1" \
@@ -453,6 +538,9 @@ state_file="$(
     "externalsecret_status=$external_secret_status" \
     "target_secret_status=$target_secret_status" \
     "target_secret_missing_keys=$target_missing_keys" \
+    "target_secret_diagnostics_dir=$target_secret_diagnostics_dir" \
+    "target_secret_diagnostics_report=$target_secret_diagnostics_report" \
+    "target_secret_diagnostics_count=$target_secret_diagnostics_count" \
     "issue_count=${#RUNTIME_RECONCILE_ISSUES[@]}" \
     "status=$status" \
     "timestamp_utc=$(date -u +"%Y-%m-%dT%H:%M:%SZ")"

--- a/scripts/lib/platform/auth/runtime_secret_keys_json.py
+++ b/scripts/lib/platform/auth/runtime_secret_keys_json.py
@@ -1,11 +1,80 @@
 #!/usr/bin/env python3
-"""Helpers for runtime ESO target secret JSON verification."""
+"""Helpers for runtime ESO target secret contract verification."""
 
 from __future__ import annotations
 
 import argparse
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
 import json
+from pathlib import Path
 import sys
+from typing import Literal
+
+
+TargetSecretCheckStatus = Literal["ready", "missing-secret", "missing-keys", "verify-error"]
+
+TARGET_SECRET_CHECK_KIND = "runtime-target-secret-contract-check"
+TARGET_SECRET_CHECK_SCHEMA_VERSION = "v1"
+TARGET_SECRET_CHECK_REPORT_KIND = "runtime-target-secret-contract-check-report"
+TARGET_SECRET_CHECK_REPORT_SCHEMA_VERSION = "v1"
+
+
+@dataclass(frozen=True)
+class TargetSecretContractCheck:
+    kind: str
+    schemaVersion: str
+    checkedAtUtc: str
+    namespace: str
+    secretName: str
+    requiredKeys: list[str]
+    observedKeys: list[str]
+    missingKeys: list[str]
+    status: TargetSecretCheckStatus
+    reason: str
+    verifyError: str
+
+    @classmethod
+    def build(
+        cls,
+        *,
+        namespace: str,
+        secret_name: str,
+        required_keys: list[str],
+        observed_keys: list[str],
+        missing_keys: list[str],
+        status: TargetSecretCheckStatus,
+        reason: str,
+        verify_error: str,
+    ) -> TargetSecretContractCheck:
+        return cls(
+            kind=TARGET_SECRET_CHECK_KIND,
+            schemaVersion=TARGET_SECRET_CHECK_SCHEMA_VERSION,
+            checkedAtUtc=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            namespace=namespace,
+            secretName=secret_name,
+            requiredKeys=required_keys,
+            observedKeys=observed_keys,
+            missingKeys=missing_keys,
+            status=status,
+            reason=reason,
+            verifyError=verify_error,
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class TargetSecretContractCheckReport:
+    kind: str
+    schemaVersion: str
+    generatedAtUtc: str
+    counts: dict[str, int]
+    checks: list[dict[str, object]]
+
+    def to_dict(self) -> dict[str, object]:
+        return asdict(self)
 
 
 def _parse_json_candidate(candidate: str) -> dict[str, object] | None:
@@ -31,34 +100,218 @@ def _parse_secret_payload(raw_payload: str) -> dict[str, object] | None:
     return _parse_json_candidate(compact[start : end + 1])
 
 
-def cmd_verify_required_keys(args: argparse.Namespace) -> int:
-    raw_payload = sys.stdin.read()
+def _split_required_keys(keys_csv: str) -> list[str]:
+    keys: list[str] = []
+    seen: set[str] = set()
+    for item in keys_csv.split(","):
+        key = item.strip()
+        if key == "" or key in seen:
+            continue
+        keys.append(key)
+        seen.add(key)
+    return keys
+
+
+def _exit_code_for_status(status: TargetSecretCheckStatus) -> int:
+    if status == "ready":
+        return 0
+    if status in {"missing-secret", "missing-keys"}:
+        return 1
+    return 2
+
+
+def _csv_or_none(values: list[str]) -> str:
+    if not values:
+        return "none"
+    return ",".join(values)
+
+
+def check_target_secret_contract(
+    *,
+    namespace: str,
+    secret_name: str,
+    required_keys: list[str],
+    secret_present: bool,
+    raw_payload: str,
+) -> TargetSecretContractCheck:
+    if not secret_present:
+        return TargetSecretContractCheck.build(
+            namespace=namespace,
+            secret_name=secret_name,
+            required_keys=required_keys,
+            observed_keys=[],
+            missing_keys=required_keys,
+            status="missing-secret",
+            reason="missing-target-secret",
+            verify_error="none",
+        )
+
     if raw_payload.strip() == "":
-        print("__verify_error__:empty-secret-json")
-        return 2
+        return TargetSecretContractCheck.build(
+            namespace=namespace,
+            secret_name=secret_name,
+            required_keys=required_keys,
+            observed_keys=[],
+            missing_keys=[],
+            status="verify-error",
+            reason="empty-secret-json",
+            verify_error="empty-secret-json",
+        )
 
     payload = _parse_secret_payload(raw_payload)
     if payload is None:
-        print("__verify_error__:invalid-secret-json")
-        return 2
+        return TargetSecretContractCheck.build(
+            namespace=namespace,
+            secret_name=secret_name,
+            required_keys=required_keys,
+            observed_keys=[],
+            missing_keys=[],
+            status="verify-error",
+            reason="invalid-secret-json",
+            verify_error="invalid-secret-json",
+        )
 
     data = payload.get("data")
     if not isinstance(data, dict):
-        print("__verify_error__:missing-secret-data-map")
-        return 2
+        return TargetSecretContractCheck.build(
+            namespace=namespace,
+            secret_name=secret_name,
+            required_keys=required_keys,
+            observed_keys=[],
+            missing_keys=[],
+            status="verify-error",
+            reason="missing-secret-data-map",
+            verify_error="missing-secret-data-map",
+        )
 
-    keys = [item.strip() for item in args.keys_csv.split(",") if item.strip()]
-    missing: list[str] = []
-    for key in keys:
+    observed_keys = [str(key).strip() for key in data if str(key).strip() != ""]
+    missing_keys: list[str] = []
+    for key in required_keys:
         value = data.get(key)
         if value is None or str(value).strip() == "":
-            missing.append(key)
+            missing_keys.append(key)
 
-    if missing:
-        print(" ".join(missing))
+    if missing_keys:
+        return TargetSecretContractCheck.build(
+            namespace=namespace,
+            secret_name=secret_name,
+            required_keys=required_keys,
+            observed_keys=sorted(observed_keys),
+            missing_keys=missing_keys,
+            status="missing-keys",
+            reason="missing-required-keys",
+            verify_error="none",
+        )
+
+    return TargetSecretContractCheck.build(
+        namespace=namespace,
+        secret_name=secret_name,
+        required_keys=required_keys,
+        observed_keys=sorted(observed_keys),
+        missing_keys=[],
+        status="ready",
+        reason="ok",
+        verify_error="none",
+    )
+
+
+def _write_json(path: str | None, payload: dict[str, object]) -> None:
+    if not path:
+        return
+    output_path = Path(path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def cmd_verify_required_keys(args: argparse.Namespace) -> int:
+    required_keys = _split_required_keys(args.keys_csv)
+    raw_payload = sys.stdin.read()
+    check = check_target_secret_contract(
+        namespace="unknown",
+        secret_name="unknown",
+        required_keys=required_keys,
+        secret_present=True,
+        raw_payload=raw_payload,
+    )
+
+    if check.status == "ready":
+        print("ok")
+        return 0
+    if check.status == "missing-keys":
+        print(" ".join(check.missingKeys))
         return 1
+    print(f"__verify_error__:{check.reason}")
+    return 2
 
-    print("ok")
+
+def cmd_check_target_secret(args: argparse.Namespace) -> int:
+    required_keys = _split_required_keys(args.required_keys)
+    secret_present = args.secret_present == "true"
+    raw_payload = sys.stdin.read() if secret_present else ""
+    check = check_target_secret_contract(
+        namespace=args.namespace,
+        secret_name=args.secret_name,
+        required_keys=required_keys,
+        secret_present=secret_present,
+        raw_payload=raw_payload,
+    )
+    payload = check.to_dict()
+    _write_json(args.output_json, payload)
+
+    if args.summary:
+        print(f"{check.status}\t{_csv_or_none(check.missingKeys)}\t{check.reason}")
+    else:
+        print(json.dumps(payload, sort_keys=True))
+    return _exit_code_for_status(check.status)
+
+
+def _parse_check_payload(path: Path) -> dict[str, object]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path}: expected JSON object")
+    return payload
+
+
+def cmd_render_check_report(args: argparse.Namespace) -> int:
+    checks: list[dict[str, object]] = []
+    counts = {
+        "total": 0,
+        "ready": 0,
+        "missingSecret": 0,
+        "missingKeys": 0,
+        "verifyError": 0,
+    }
+
+    for check_file in args.check_files:
+        payload = _parse_check_payload(Path(check_file))
+        status = payload.get("status")
+        if not isinstance(status, str):
+            raise ValueError(f"{check_file}: missing string status field")
+        checks.append(payload)
+        counts["total"] += 1
+        if status == "ready":
+            counts["ready"] += 1
+        elif status == "missing-secret":
+            counts["missingSecret"] += 1
+        elif status == "missing-keys":
+            counts["missingKeys"] += 1
+        elif status == "verify-error":
+            counts["verifyError"] += 1
+        else:
+            raise ValueError(f"{check_file}: unsupported status '{status}'")
+
+    report = TargetSecretContractCheckReport(
+        kind=TARGET_SECRET_CHECK_REPORT_KIND,
+        schemaVersion=TARGET_SECRET_CHECK_REPORT_SCHEMA_VERSION,
+        generatedAtUtc=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        counts=counts,
+        checks=checks,
+    )
+
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(report.to_dict(), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(str(output_path))
     return 0
 
 
@@ -69,6 +322,24 @@ def main() -> int:
     verify_parser = subparsers.add_parser("verify-required-keys")
     verify_parser.add_argument("keys_csv")
     verify_parser.set_defaults(func=cmd_verify_required_keys)
+
+    check_parser = subparsers.add_parser("check-target-secret")
+    check_parser.add_argument("--namespace", required=True)
+    check_parser.add_argument("--secret-name", required=True)
+    check_parser.add_argument("--required-keys", required=True)
+    check_parser.add_argument(
+        "--secret-present",
+        choices=("true", "false"),
+        default="true",
+    )
+    check_parser.add_argument("--summary", action="store_true")
+    check_parser.add_argument("--output-json")
+    check_parser.set_defaults(func=cmd_check_target_secret)
+
+    report_parser = subparsers.add_parser("render-check-report")
+    report_parser.add_argument("--output", required=True)
+    report_parser.add_argument("check_files", nargs="*")
+    report_parser.set_defaults(func=cmd_render_check_report)
 
     args = parser.parse_args()
     return args.func(args)

--- a/scripts/templates/blueprint/bootstrap/docs/platform/consumer/runtime_credentials_eso.md
+++ b/scripts/templates/blueprint/bootstrap/docs/platform/consumer/runtime_credentials_eso.md
@@ -144,6 +144,8 @@ Local-lite Postgres note:
 Resulting state artifacts:
 - `artifacts/infra/runtime_credentials_eso_reconcile.env`
 - `artifacts/infra/runtime_credentials_eso_reconcile.json`
+- `artifacts/infra/runtime_credentials_eso_target_secret_checks.json` (aggregated typed target-secret diagnostics)
+- `artifacts/infra/runtime_credentials_eso_target_secret_checks/*.json` (per-contract typed target-secret diagnostics)
 - `artifacts/infra/argocd_repo_credentials_reconcile.env`
 - `artifacts/infra/argocd_repo_credentials_reconcile.json`
 - `artifacts/infra/runtime_identity_reconcile.env`

--- a/tests/infra/test_python_helper_extractions.py
+++ b/tests/infra/test_python_helper_extractions.py
@@ -237,70 +237,152 @@ class PythonHelperExtractionsTests(unittest.TestCase):
 
         import subprocess
 
-        valid_secret = {"apiVersion": "v1", "kind": "Secret", "data": {"client-id": "YQ==", "client-secret": "Yg=="}}
-        valid = subprocess.run(
-            [sys.executable, str(script), "verify-required-keys", "client-id,client-secret"],
-            input=json.dumps(valid_secret),
-            text=True,
-            capture_output=True,
-            cwd=REPO_ROOT,
-        )
-        self.assertEqual(valid.returncode, 0, msg=valid.stdout + valid.stderr)
-        self.assertEqual(valid.stdout.strip(), "ok")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            check_ready_path = Path(tmpdir) / "check-ready.json"
+            check_missing_path = Path(tmpdir) / "check-missing.json"
+            report_path = Path(tmpdir) / "report.json"
 
-        missing = subprocess.run(
-            [sys.executable, str(script), "verify-required-keys", "client-id,client-secret"],
-            input=json.dumps({"data": {"client-id": "YQ=="}}),
-            text=True,
-            capture_output=True,
-            cwd=REPO_ROOT,
-        )
-        self.assertEqual(missing.returncode, 1, msg=missing.stdout + missing.stderr)
-        self.assertEqual(missing.stdout.strip(), "client-secret")
+            valid_secret = {"apiVersion": "v1", "kind": "Secret", "data": {"client-id": "YQ==", "client-secret": "Yg=="}}
+            valid = subprocess.run(
+                [sys.executable, str(script), "verify-required-keys", "client-id,client-secret"],
+                input=json.dumps(valid_secret),
+                text=True,
+                capture_output=True,
+                cwd=REPO_ROOT,
+            )
+            self.assertEqual(valid.returncode, 0, msg=valid.stdout + valid.stderr)
+            self.assertEqual(valid.stdout.strip(), "ok")
 
-        noisy_input = subprocess.run(
-            [sys.executable, str(script), "verify-required-keys", "client-id,client-secret"],
-            input=(
-                "INFO bootstrap complete\n"
-                + json.dumps({"data": {"client-id": "YQ==", "client-secret": "Yg=="}})
-                + "\nINFO done\n"
-            ),
-            text=True,
-            capture_output=True,
-            cwd=REPO_ROOT,
-        )
-        self.assertEqual(noisy_input.returncode, 0, msg=noisy_input.stdout + noisy_input.stderr)
-        self.assertEqual(noisy_input.stdout.strip(), "ok")
+            missing = subprocess.run(
+                [sys.executable, str(script), "verify-required-keys", "client-id,client-secret"],
+                input=json.dumps({"data": {"client-id": "YQ=="}}),
+                text=True,
+                capture_output=True,
+                cwd=REPO_ROOT,
+            )
+            self.assertEqual(missing.returncode, 1, msg=missing.stdout + missing.stderr)
+            self.assertEqual(missing.stdout.strip(), "client-secret")
 
-        missing_data_map = subprocess.run(
-            [sys.executable, str(script), "verify-required-keys", "client-id"],
-            input=json.dumps({"kind": "Secret"}),
-            text=True,
-            capture_output=True,
-            cwd=REPO_ROOT,
-        )
-        self.assertEqual(missing_data_map.returncode, 2, msg=missing_data_map.stdout + missing_data_map.stderr)
-        self.assertEqual(missing_data_map.stdout.strip(), "__verify_error__:missing-secret-data-map")
+            noisy_input = subprocess.run(
+                [sys.executable, str(script), "verify-required-keys", "client-id,client-secret"],
+                input=(
+                    "INFO bootstrap complete\n"
+                    + json.dumps({"data": {"client-id": "YQ==", "client-secret": "Yg=="}})
+                    + "\nINFO done\n"
+                ),
+                text=True,
+                capture_output=True,
+                cwd=REPO_ROOT,
+            )
+            self.assertEqual(noisy_input.returncode, 0, msg=noisy_input.stdout + noisy_input.stderr)
+            self.assertEqual(noisy_input.stdout.strip(), "ok")
 
-        invalid_json = subprocess.run(
-            [sys.executable, str(script), "verify-required-keys", "client-id"],
-            input="{",
-            text=True,
-            capture_output=True,
-            cwd=REPO_ROOT,
-        )
-        self.assertEqual(invalid_json.returncode, 2, msg=invalid_json.stdout + invalid_json.stderr)
-        self.assertEqual(invalid_json.stdout.strip(), "__verify_error__:invalid-secret-json")
+            missing_data_map = subprocess.run(
+                [sys.executable, str(script), "verify-required-keys", "client-id"],
+                input=json.dumps({"kind": "Secret"}),
+                text=True,
+                capture_output=True,
+                cwd=REPO_ROOT,
+            )
+            self.assertEqual(missing_data_map.returncode, 2, msg=missing_data_map.stdout + missing_data_map.stderr)
+            self.assertEqual(missing_data_map.stdout.strip(), "__verify_error__:missing-secret-data-map")
 
-        empty_input = subprocess.run(
-            [sys.executable, str(script), "verify-required-keys", "client-id"],
-            input="",
-            text=True,
-            capture_output=True,
-            cwd=REPO_ROOT,
-        )
-        self.assertEqual(empty_input.returncode, 2, msg=empty_input.stdout + empty_input.stderr)
-        self.assertEqual(empty_input.stdout.strip(), "__verify_error__:empty-secret-json")
+            invalid_json = subprocess.run(
+                [sys.executable, str(script), "verify-required-keys", "client-id"],
+                input="{",
+                text=True,
+                capture_output=True,
+                cwd=REPO_ROOT,
+            )
+            self.assertEqual(invalid_json.returncode, 2, msg=invalid_json.stdout + invalid_json.stderr)
+            self.assertEqual(invalid_json.stdout.strip(), "__verify_error__:invalid-secret-json")
+
+            empty_input = subprocess.run(
+                [sys.executable, str(script), "verify-required-keys", "client-id"],
+                input="",
+                text=True,
+                capture_output=True,
+                cwd=REPO_ROOT,
+            )
+            self.assertEqual(empty_input.returncode, 2, msg=empty_input.stdout + empty_input.stderr)
+            self.assertEqual(empty_input.stdout.strip(), "__verify_error__:empty-secret-json")
+
+            check_ready = subprocess.run(
+                [
+                    sys.executable,
+                    str(script),
+                    "check-target-secret",
+                    "--namespace",
+                    "security",
+                    "--secret-name",
+                    "iap-runtime-credentials",
+                    "--required-keys",
+                    "client-id,client-secret",
+                    "--summary",
+                    "--output-json",
+                    str(check_ready_path),
+                ],
+                input=json.dumps(valid_secret),
+                text=True,
+                capture_output=True,
+                cwd=REPO_ROOT,
+            )
+            self.assertEqual(check_ready.returncode, 0, msg=check_ready.stdout + check_ready.stderr)
+            self.assertEqual(check_ready.stdout.strip(), "ready\tnone\tok")
+            check_ready_payload = json.loads(check_ready_path.read_text(encoding="utf-8"))
+            self.assertEqual(check_ready_payload["kind"], "runtime-target-secret-contract-check")
+            self.assertEqual(check_ready_payload["schemaVersion"], "v1")
+            self.assertEqual(check_ready_payload["status"], "ready")
+
+            check_missing = subprocess.run(
+                [
+                    sys.executable,
+                    str(script),
+                    "check-target-secret",
+                    "--namespace",
+                    "security",
+                    "--secret-name",
+                    "iap-runtime-credentials",
+                    "--required-keys",
+                    "client-id,client-secret",
+                    "--secret-present",
+                    "false",
+                    "--summary",
+                    "--output-json",
+                    str(check_missing_path),
+                ],
+                text=True,
+                capture_output=True,
+                cwd=REPO_ROOT,
+            )
+            self.assertEqual(check_missing.returncode, 1, msg=check_missing.stdout + check_missing.stderr)
+            self.assertEqual(check_missing.stdout.strip(), "missing-secret\tclient-id,client-secret\tmissing-target-secret")
+            check_missing_payload = json.loads(check_missing_path.read_text(encoding="utf-8"))
+            self.assertEqual(check_missing_payload["status"], "missing-secret")
+            self.assertEqual(check_missing_payload["missingKeys"], ["client-id", "client-secret"])
+
+            report = subprocess.run(
+                [
+                    sys.executable,
+                    str(script),
+                    "render-check-report",
+                    "--output",
+                    str(report_path),
+                    str(check_ready_path),
+                    str(check_missing_path),
+                ],
+                text=True,
+                capture_output=True,
+                cwd=REPO_ROOT,
+            )
+            self.assertEqual(report.returncode, 0, msg=report.stdout + report.stderr)
+            report_payload = json.loads(report_path.read_text(encoding="utf-8"))
+            self.assertEqual(report_payload["kind"], "runtime-target-secret-contract-check-report")
+            self.assertEqual(report_payload["schemaVersion"], "v1")
+            self.assertEqual(report_payload["counts"]["total"], 2)
+            self.assertEqual(report_payload["counts"]["ready"], 1)
+            self.assertEqual(report_payload["counts"]["missingSecret"], 1)
+            self.assertEqual(len(report_payload["checks"]), 2)
 
     def test_prereqs_helpers_and_runtime_workload_helpers(self) -> None:
         prereqs_script = REPO_ROOT / "scripts/lib/infra/prereqs_helpers.py"

--- a/tests/infra/test_runtime_credentials_eso.py
+++ b/tests/infra/test_runtime_credentials_eso.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+import shutil
 import shlex
 import sys
 import tempfile
@@ -16,6 +17,7 @@ class RuntimeCredentialsEsoTests(unittest.TestCase):
         state_paths = (
             REPO_ROOT / "artifacts" / "infra" / "runtime_credentials_eso_reconcile.env",
             REPO_ROOT / "artifacts" / "infra" / "runtime_credentials_eso_reconcile.json",
+            REPO_ROOT / "artifacts" / "infra" / "runtime_credentials_eso_target_secret_checks.json",
             REPO_ROOT / "artifacts" / "infra" / "argocd_repo_credentials_reconcile.env",
             REPO_ROOT / "artifacts" / "infra" / "argocd_repo_credentials_reconcile.json",
             REPO_ROOT / "artifacts" / "infra" / "runtime_identity_reconcile.env",
@@ -26,6 +28,9 @@ class RuntimeCredentialsEsoTests(unittest.TestCase):
         for state_path in state_paths:
             if state_path.exists():
                 state_path.unlink()
+        target_secret_checks_dir = REPO_ROOT / "artifacts" / "infra" / "runtime_credentials_eso_target_secret_checks"
+        if target_secret_checks_dir.exists():
+            shutil.rmtree(target_secret_checks_dir)
 
     def test_dry_run_reconcile_writes_success_state_and_renders_source_secret(self) -> None:
         env = module_flags_env(profile="local-full")
@@ -359,6 +364,26 @@ class RuntimeCredentialsEsoTests(unittest.TestCase):
         self.assertIn("target_secret_status=ready", state)
         self.assertIn("target_secret_missing_keys=none", state)
         self.assertIn("target_secret_checked=security/iap-runtime-credentials", state)
+        self.assertIn("target_secret_diagnostics_count=1", state)
+        self.assertIn(
+            f"target_secret_diagnostics_report={REPO_ROOT}/artifacts/infra/runtime_credentials_eso_target_secret_checks.json",
+            state,
+        )
+
+        diagnostics_path = REPO_ROOT / "artifacts" / "infra" / "runtime_credentials_eso_target_secret_checks.json"
+        self.assertTrue(diagnostics_path.exists(), msg="target secret diagnostics report was not created")
+        diagnostics = json.loads(diagnostics_path.read_text(encoding="utf-8"))
+        self.assertEqual(diagnostics.get("kind"), "runtime-target-secret-contract-check-report")
+        self.assertEqual(diagnostics.get("schemaVersion"), "v1")
+        counts = diagnostics.get("counts", {})
+        self.assertEqual(counts.get("total"), 1)
+        self.assertEqual(counts.get("ready"), 1)
+        checks = diagnostics.get("checks", [])
+        self.assertEqual(len(checks), 1)
+        self.assertEqual(checks[0].get("status"), "ready")
+        self.assertEqual(checks[0].get("namespace"), "security")
+        self.assertEqual(checks[0].get("secretName"), "iap-runtime-credentials")
+        self.assertEqual(checks[0].get("requiredKeys"), ["client-id", "client-secret"])
 
     def test_argocd_reconcile_resolves_repo_contract_without_argparse_errors(self) -> None:
         env = module_flags_env(profile="local-full")


### PR DESCRIPTION
## Summary
- add typed runtime target-secret contract checks in `scripts/lib/platform/auth/runtime_secret_keys_json.py`
- introduce machine-readable status/reason diagnostics with per-secret check artifacts and aggregated JSON report
- integrate typed checker/report generation into `reconcile_eso_runtime_secrets.sh` while preserving existing reconcile status behavior
- extend runtime/infra tests and runtime credentials docs to cover and document the new diagnostics contract

## Validation
- `.venv/bin/python -m pytest -q tests/infra/test_python_helper_extractions.py -k runtime_secret_keys_helpers`
- `.venv/bin/python -m pytest -q tests/infra/test_runtime_credentials_eso.py -k hyphenated_target_keys`
- `.venv/bin/python -m pytest -q tests/infra/test_runtime_credentials_eso.py`
- `.venv/bin/python -m pytest -q tests/infra/test_python_helper_extractions.py`
- `.venv/bin/python -m pytest -q tests/infra/test_tooling_contracts.py`
- `.venv/bin/python -m pytest -q tests/blueprint/contract_refactor_scripts_cases.py tests/blueprint/test_quality_contracts.py`
- `make infra-validate`
- `make infra-smoke`
- `make infra-audit-version`
- `make quality-hooks-run`

## Queue
- Implements frozen queue item: `#120 Add typed runtime target-secret contract checker with JSON diagnostics (P1)`
