### PR TITLE
Add Claude Code interoperability (CLAUDE.md + slash commands)

### DIFF
--- a/.claude/commands/blueprint-consumer-ops.md
+++ b/.claude/commands/blueprint-consumer-ops.md
@@ -1,0 +1,10 @@
+Read and execute the skill runbook at:
+`.agents/skills/blueprint-consumer-ops/SKILL.md`
+
+Apply all guardrails and the required report format defined there.
+
+Input provided: $ARGUMENTS
+
+If no input was provided above, ask conversationally what operation or context
+to use before proceeding. In either case, keep the conversation open for
+clarifications — do not proceed past a phase if there are unresolved questions.

--- a/.claude/commands/blueprint-consumer-upgrade.md
+++ b/.claude/commands/blueprint-consumer-upgrade.md
@@ -1,0 +1,10 @@
+Read and execute the skill runbook at:
+`.agents/skills/blueprint-consumer-upgrade/SKILL.md`
+
+Apply all guardrails and the required report format defined there.
+
+Input provided: $ARGUMENTS
+
+If no input was provided above, ask conversationally what upgrade scope or
+context to use before proceeding. In either case, keep the conversation open
+for clarifications — do not proceed past a phase if there are unresolved questions.

--- a/.claude/commands/blueprint-sdd-clarification-gate.md
+++ b/.claude/commands/blueprint-sdd-clarification-gate.md
@@ -1,0 +1,10 @@
+Read and execute the skill runbook at:
+`.agents/skills/blueprint-sdd-clarification-gate/SKILL.md`
+
+Apply all guardrails and the required report format defined there.
+
+Input provided: $ARGUMENTS
+
+If no input was provided above, ask conversationally which work item or spec
+to evaluate before proceeding. In either case, keep the conversation open for
+clarifications — do not proceed past a phase if there are unresolved questions.

--- a/.claude/commands/blueprint-sdd-document-sync.md
+++ b/.claude/commands/blueprint-sdd-document-sync.md
@@ -1,0 +1,10 @@
+Read and execute the skill runbook at:
+`.agents/skills/blueprint-sdd-document-sync/SKILL.md`
+
+Apply all guardrails and the required report format defined there.
+
+Input provided: $ARGUMENTS
+
+If no input was provided above, ask conversationally which work item or document
+set to sync before proceeding. In either case, keep the conversation open for
+clarifications — do not proceed past a phase if there are unresolved questions.

--- a/.claude/commands/blueprint-sdd-intake-decompose.md
+++ b/.claude/commands/blueprint-sdd-intake-decompose.md
@@ -1,0 +1,10 @@
+Read and execute the skill runbook at:
+`.agents/skills/blueprint-sdd-intake-decompose/SKILL.md`
+
+Apply all guardrails and the required report format defined there.
+
+Input provided: $ARGUMENTS
+
+If no input was provided above, ask conversationally what requirements document
+or scope to use before proceeding. In either case, keep the conversation open
+for clarifications — do not proceed past a phase if there are unresolved questions.

--- a/.claude/commands/blueprint-sdd-plan-slicer.md
+++ b/.claude/commands/blueprint-sdd-plan-slicer.md
@@ -1,0 +1,10 @@
+Read and execute the skill runbook at:
+`.agents/skills/blueprint-sdd-plan-slicer/SKILL.md`
+
+Apply all guardrails and the required report format defined there.
+
+Input provided: $ARGUMENTS
+
+If no input was provided above, ask conversationally which work item or spec
+to slice before proceeding. In either case, keep the conversation open for
+clarifications — do not proceed past a phase if there are unresolved questions.

--- a/.claude/commands/blueprint-sdd-pr-packager.md
+++ b/.claude/commands/blueprint-sdd-pr-packager.md
@@ -1,0 +1,10 @@
+Read and execute the skill runbook at:
+`.agents/skills/blueprint-sdd-pr-packager/SKILL.md`
+
+Apply all guardrails and the required report format defined there.
+
+Input provided: $ARGUMENTS
+
+If no input was provided above, ask conversationally which work item or branch
+to package before proceeding. In either case, keep the conversation open for
+clarifications — do not proceed past a phase if there are unresolved questions.

--- a/.claude/commands/blueprint-sdd-traceability-keeper.md
+++ b/.claude/commands/blueprint-sdd-traceability-keeper.md
@@ -1,0 +1,10 @@
+Read and execute the skill runbook at:
+`.agents/skills/blueprint-sdd-traceability-keeper/SKILL.md`
+
+Apply all guardrails and the required report format defined there.
+
+Input provided: $ARGUMENTS
+
+If no input was provided above, ask conversationally which work item or spec
+to trace before proceeding. In either case, keep the conversation open for
+clarifications — do not proceed past a phase if there are unresolved questions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,14 @@ This file is the canonical governance source for human and agent contributors.
 - If required inputs are missing, the work item must be marked with `BLOCKED_MISSING_INPUTS` and remain `SPEC_READY=false`.
 - Code assistants must not silently fill missing business or non-functional requirements in spec artifacts.
 
+## Sign-off Policy
+- Sign-offs (`Product`, `Architecture`, `Security`, `Operations`) are granted explicitly
+  by the user or designated reviewers via conversation or pull request review.
+- Code assistants MUST NOT self-approve or assume any sign-off is granted.
+- Keep `SPEC_READY=false` until each required sign-off is explicitly stated.
+- In single-author mode the user holds all sign-off roles. In multi-author mode,
+  each sign-off should be traceable to the reviewer's git identity.
+
 ## SDD Artifact Contract
 - Canonical work-item location: `specs/<YYYY-MM-DD>-<work-item-slug>/`.
 - Required work-item documents:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,21 @@
+# Claude Code — Governance Delegation
+
+Read `AGENTS.md` before starting any work. All lifecycle rules, SDD guardrails,
+quality gates, ownership boundaries, and the sign-off policy are defined there
+and apply to this assistant without exception.
+
+## Skills
+
+Skill runbooks are in `.agents/skills/<name>/SKILL.md`. Apply them proactively
+when the context matches. They are also available as slash commands:
+
+| Slash command | Runbook |
+|---|---|
+| `/blueprint-consumer-ops` | `.agents/skills/blueprint-consumer-ops/SKILL.md` |
+| `/blueprint-consumer-upgrade` | `.agents/skills/blueprint-consumer-upgrade/SKILL.md` |
+| `/blueprint-sdd-clarification-gate` | `.agents/skills/blueprint-sdd-clarification-gate/SKILL.md` |
+| `/blueprint-sdd-document-sync` | `.agents/skills/blueprint-sdd-document-sync/SKILL.md` |
+| `/blueprint-sdd-intake-decompose` | `.agents/skills/blueprint-sdd-intake-decompose/SKILL.md` |
+| `/blueprint-sdd-plan-slicer` | `.agents/skills/blueprint-sdd-plan-slicer/SKILL.md` |
+| `/blueprint-sdd-pr-packager` | `.agents/skills/blueprint-sdd-pr-packager/SKILL.md` |
+| `/blueprint-sdd-traceability-keeper` | `.agents/skills/blueprint-sdd-traceability-keeper/SKILL.md` |


### PR DESCRIPTION
## Summary
- Adds `CLAUDE.md` as a minimal delegation file pointing Claude Code to `AGENTS.md` as the single governance source.
- Adds `.claude/commands/` with one slash command per skill, enabling `/blueprint-*` invocation in Claude Code with both argument and conversational modes.
- Adds `Sign-off Policy` section to `AGENTS.md` so all assistants share the same explicit sign-off governance (no self-approval, git-identity traceability for multi-author mode).
- Mirrors sbonoc/dhe-marketplace#27 — same change applied to the blueprint source repo for multi-agent interoperability parity.
- No spec work item — this is a tooling/meta change.

## Requirement and Contract Coverage
- Requirement IDs covered: N/A (meta/tooling)
- Acceptance criteria covered: Claude Code can invoke all 8 skills via `/blueprint-*` slash commands; Codex workflow unchanged.
- Contract surfaces changed:
  - [ ] platform-owned code changed
  - [x] docs or runbooks were updated
  - [ ] blueprint-managed surfaces changed intentionally

## Key Reviewer Files
- Primary files to review first: `CLAUDE.md`, `AGENTS.md` (Sign-off Policy section)
- High-risk files: none — additive only, no existing behaviour changed

## Validation Evidence
- Pre-commit hooks passed on commit and push.
- All 8 `.claude/commands/` files verified to reference correct `SKILL.md` paths.

## Risk and Rollback
- Main risk(s): none — purely additive files, no code or contract changed.
- Rollback strategy: delete `CLAUDE.md` and `.claude/` and revert the `AGENTS.md` hunk.

## Deferred Proposals (Not Implemented)
- Adding per-skill `agents/claude.yaml` wiring if Claude Code gains a native skill-dispatch mechanism equivalent to Codex.

## Follow-Up
- None for this repo at this time.