### PR TITLE
Add Claude Code interoperability (CLAUDE.md + slash commands)

### DIFF
--- a/.claude/commands/blueprint-consumer-ops.md
+++ b/.claude/commands/blueprint-consumer-ops.md
@@ -1,0 +1,10 @@
+Read and execute the skill runbook at:
+`.agents/skills/blueprint-consumer-ops/SKILL.md`
+
+Apply all guardrails and the required report format defined there.
+
+Input provided: $ARGUMENTS
+
+If no input was provided above, ask conversationally what operation or context
+to use before proceeding. In either case, keep the conversation open for
+clarifications — do not proceed past a phase if there are unresolved questions.

--- a/.claude/commands/blueprint-consumer-upgrade.md
+++ b/.claude/commands/blueprint-consumer-upgrade.md
@@ -1,0 +1,10 @@
+Read and execute the skill runbook at:
+`.agents/skills/blueprint-consumer-upgrade/SKILL.md`
+
+Apply all guardrails and the required report format defined there.
+
+Input provided: $ARGUMENTS
+
+If no input was provided above, ask conversationally what upgrade scope or
+context to use before proceeding. In either case, keep the conversation open
+for clarifications — do not proceed past a phase if there are unresolved questions.

--- a/.claude/commands/blueprint-sdd-clarification-gate.md
+++ b/.claude/commands/blueprint-sdd-clarification-gate.md
@@ -1,0 +1,10 @@
+Read and execute the skill runbook at:
+`.agents/skills/blueprint-sdd-clarification-gate/SKILL.md`
+
+Apply all guardrails and the required report format defined there.
+
+Input provided: $ARGUMENTS
+
+If no input was provided above, ask conversationally which work item or spec
+to evaluate before proceeding. In either case, keep the conversation open for
+clarifications — do not proceed past a phase if there are unresolved questions.

--- a/.claude/commands/blueprint-sdd-document-sync.md
+++ b/.claude/commands/blueprint-sdd-document-sync.md
@@ -1,0 +1,10 @@
+Read and execute the skill runbook at:
+`.agents/skills/blueprint-sdd-document-sync/SKILL.md`
+
+Apply all guardrails and the required report format defined there.
+
+Input provided: $ARGUMENTS
+
+If no input was provided above, ask conversationally which work item or document
+set to sync before proceeding. In either case, keep the conversation open for
+clarifications — do not proceed past a phase if there are unresolved questions.

--- a/.claude/commands/blueprint-sdd-intake-decompose.md
+++ b/.claude/commands/blueprint-sdd-intake-decompose.md
@@ -1,0 +1,10 @@
+Read and execute the skill runbook at:
+`.agents/skills/blueprint-sdd-intake-decompose/SKILL.md`
+
+Apply all guardrails and the required report format defined there.
+
+Input provided: $ARGUMENTS
+
+If no input was provided above, ask conversationally what requirements document
+or scope to use before proceeding. In either case, keep the conversation open
+for clarifications — do not proceed past a phase if there are unresolved questions.

--- a/.claude/commands/blueprint-sdd-plan-slicer.md
+++ b/.claude/commands/blueprint-sdd-plan-slicer.md
@@ -1,0 +1,10 @@
+Read and execute the skill runbook at:
+`.agents/skills/blueprint-sdd-plan-slicer/SKILL.md`
+
+Apply all guardrails and the required report format defined there.
+
+Input provided: $ARGUMENTS
+
+If no input was provided above, ask conversationally which work item or spec
+to slice before proceeding. In either case, keep the conversation open for
+clarifications — do not proceed past a phase if there are unresolved questions.

--- a/.claude/commands/blueprint-sdd-pr-packager.md
+++ b/.claude/commands/blueprint-sdd-pr-packager.md
@@ -1,0 +1,10 @@
+Read and execute the skill runbook at:
+`.agents/skills/blueprint-sdd-pr-packager/SKILL.md`
+
+Apply all guardrails and the required report format defined there.
+
+Input provided: $ARGUMENTS
+
+If no input was provided above, ask conversationally which work item or branch
+to package before proceeding. In either case, keep the conversation open for
+clarifications — do not proceed past a phase if there are unresolved questions.

--- a/.claude/commands/blueprint-sdd-traceability-keeper.md
+++ b/.claude/commands/blueprint-sdd-traceability-keeper.md
@@ -1,0 +1,10 @@
+Read and execute the skill runbook at:
+`.agents/skills/blueprint-sdd-traceability-keeper/SKILL.md`
+
+Apply all guardrails and the required report format defined there.
+
+Input provided: $ARGUMENTS
+
+If no input was provided above, ask conversationally which work item or spec
+to trace before proceeding. In either case, keep the conversation open for
+clarifications — do not proceed past a phase if there are unresolved questions.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
       - id: quality-validate-branch
         name: quality validate branch naming (pre-push)
         language: system
-        entry: python scripts/bin/blueprint/validate_contract.py --branch-only
+        entry: python3 scripts/bin/blueprint/validate_contract.py --branch-only
         pass_filenames: false
         stages: [pre-push]
         always_run: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,13 @@ repos:
         language: system
         entry: bash -n
         files: \.sh$
+      - id: quality-validate-branch
+        name: quality validate branch naming (pre-push)
+        language: system
+        entry: python scripts/bin/blueprint/validate_contract.py --branch-only
+        pass_filenames: false
+        stages: [pre-push]
+        always_run: true
       - id: infra-audit-version-cached
         name: infra audit version cached (pre-push)
         language: system

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,14 @@ This file is the canonical governance source for human and agent contributors.
 - If required inputs are missing, the work item must be marked with `BLOCKED_MISSING_INPUTS` and remain `SPEC_READY=false`.
 - Code assistants must not silently fill missing business or non-functional requirements in spec artifacts.
 
+## Sign-off Policy
+- Sign-offs (`Product`, `Architecture`, `Security`, `Operations`) are granted explicitly
+  by the user or designated reviewers via conversation or pull request review.
+- Code assistants MUST NOT self-approve or assume any sign-off is granted.
+- Keep `SPEC_READY=false` until each required sign-off is explicitly stated.
+- In single-author mode the user holds all sign-off roles. In multi-author mode,
+  each sign-off should be traceable to the reviewer's git identity.
+
 ## SDD Artifact Contract
 - Canonical work-item location: `specs/<YYYY-MM-DD>-<work-item-slug>/`.
 - Required work-item documents:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,21 @@
+# Claude Code — Governance Delegation
+
+Read `AGENTS.md` before starting any work. All lifecycle rules, SDD guardrails,
+quality gates, ownership boundaries, and the sign-off policy are defined there
+and apply to this assistant without exception.
+
+## Skills
+
+Skill runbooks are in `.agents/skills/<name>/SKILL.md`. Apply them proactively
+when the context matches. They are also available as slash commands:
+
+| Slash command | Runbook |
+|---|---|
+| `/blueprint-consumer-ops` | `.agents/skills/blueprint-consumer-ops/SKILL.md` |
+| `/blueprint-consumer-upgrade` | `.agents/skills/blueprint-consumer-upgrade/SKILL.md` |
+| `/blueprint-sdd-clarification-gate` | `.agents/skills/blueprint-sdd-clarification-gate/SKILL.md` |
+| `/blueprint-sdd-document-sync` | `.agents/skills/blueprint-sdd-document-sync/SKILL.md` |
+| `/blueprint-sdd-intake-decompose` | `.agents/skills/blueprint-sdd-intake-decompose/SKILL.md` |
+| `/blueprint-sdd-plan-slicer` | `.agents/skills/blueprint-sdd-plan-slicer/SKILL.md` |
+| `/blueprint-sdd-pr-packager` | `.agents/skills/blueprint-sdd-pr-packager/SKILL.md` |
+| `/blueprint-sdd-traceability-keeper` | `.agents/skills/blueprint-sdd-traceability-keeper/SKILL.md` |

--- a/scripts/bin/blueprint/validate_contract.py
+++ b/scripts/bin/blueprint/validate_contract.py
@@ -2419,6 +2419,15 @@ def parse_args() -> argparse.Namespace:
         default=str(repo_root / "blueprint/contract.yaml"),
         help="Path to blueprint contract YAML.",
     )
+    parser.add_argument(
+        "--branch-only",
+        action="store_true",
+        help=(
+            "Run only branch naming validation against the contract. "
+            "Fast and read-only — intended for pre-push hooks to catch "
+            "branch naming violations before they reach CI."
+        ),
+    )
     return parser.parse_args()
 
 
@@ -2427,8 +2436,28 @@ def main() -> int:
     repo_root = _resolve_repo_root()
     contract_path = Path(args.contract_path).resolve()
 
+    # Load contract first; both fast and full paths need it.
     try:
         contract = load_blueprint_contract(contract_path)
+    except ValueError as exc:
+        print(f"[infra-validate] contract error: {exc}", file=sys.stderr)
+        return 1
+
+    if args.branch_only:
+        # Fast, read-only path: validates only branch naming against the contract.
+        # Does not render makefiles, run shellcheck, or touch the working tree.
+        # Catches the most common pre-push violation (wrong branch prefix) in <1 s.
+        errors = _validate_branch_naming_contract(contract)
+        if errors:
+            for error in errors:
+                print(f"[infra-validate] error: {error}", file=sys.stderr)
+            print(f"[infra-validate] failed with {len(errors)} issue(s)", file=sys.stderr)
+            return 1
+        print("[infra-validate] branch naming validation passed")
+        return 0
+
+    # Full validation path: runs all contract checks.
+    try:
         required_files = _required_files_for_repo_mode(contract)
         required_paths = contract.structure.required_paths
         required_diagrams = contract.docs_contract.required_diagrams

--- a/scripts/templates/blueprint/bootstrap/.pre-commit-config.yaml
+++ b/scripts/templates/blueprint/bootstrap/.pre-commit-config.yaml
@@ -15,6 +15,13 @@ repos:
         language: system
         entry: bash -n
         files: \.sh$
+      - id: quality-validate-branch
+        name: quality validate branch naming (pre-push)
+        language: system
+        entry: python3 scripts/bin/blueprint/validate_contract.py --branch-only
+        pass_filenames: false
+        stages: [pre-push]
+        always_run: true
       - id: infra-audit-version-cached
         name: infra audit version cached (pre-push)
         language: system


### PR DESCRIPTION
## Summary
- Adds `CLAUDE.md` as a minimal delegation file pointing Claude Code to `AGENTS.md` as the single governance source.
- Adds `.claude/commands/` with one slash command per skill, enabling `/blueprint-*` invocation in Claude Code with both argument and conversational modes.
- Adds `Sign-off Policy` section to `AGENTS.md` so all assistants share the same explicit sign-off governance (no self-approval, git-identity traceability for multi-author mode).
- Adds `--branch-only` flag to `validate_contract.py` and a `quality-validate-branch` pre-push hook so branch naming violations are caught locally before reaching CI.

## Requirement and Contract Coverage
- Requirement IDs covered: N/A (meta/tooling)
- Acceptance criteria covered: Claude Code can invoke all 8 skills via `/blueprint-*` slash commands; Codex workflow unchanged; branch naming violations caught at pre-push.
- Contract surfaces changed:
  - [ ] platform-owned code changed
  - [x] docs or runbooks were updated
  - [ ] blueprint-managed surfaces changed intentionally

## Key Reviewer Files
- Primary files to review first: `CLAUDE.md`, `AGENTS.md` (Sign-off Policy section), `scripts/bin/blueprint/validate_contract.py`, `.pre-commit-config.yaml`
- High-risk files: `scripts/bin/blueprint/validate_contract.py` — `--branch-only` flag and `main()` refactor

## Validation Evidence
- Pre-commit hooks passed on commit and push (including new `quality-validate-branch` hook).
- All 8 `.claude/commands/` files verified to reference correct `SKILL.md` paths.
- `--branch-only` flag manually verified to exit 0 on `feature/` prefix.

## Risk and Rollback
- Main risk(s): none — `validate_contract.py` change is purely additive (new flag, no change to existing behaviour). Full validation path is identical to before.
- Rollback strategy: delete `CLAUDE.md` and `.claude/`, revert `AGENTS.md` hunk, revert `validate_contract.py` and `.pre-commit-config.yaml` hunks.

## Deferred Proposals (Not Implemented)
- Adding per-skill `agents/claude.yaml` wiring if Claude Code gains a native skill-dispatch mechanism equivalent to Codex.

## Follow-Up
- Consumer repo `sbonoc/dhe-marketplace` will pick up the `validate_contract.py` fix on next blueprint upgrade (already backported).