### PR TITLE
Add platform context to AGENTS.md and claude.yaml skill wiring

### DIFF
--- a/.agents/skills/blueprint-consumer-ops/agents/claude.yaml
+++ b/.agents/skills/blueprint-consumer-ops/agents/claude.yaml
@@ -1,0 +1,5 @@
+interface:
+  display_name: "Blueprint Consumer Ops"
+  short_description: "Deterministic generated-consumer operations runbook"
+  slash_command: "/blueprint-consumer-ops"
+  command_file: ".claude/commands/blueprint-consumer-ops.md"

--- a/.agents/skills/blueprint-consumer-upgrade/agents/claude.yaml
+++ b/.agents/skills/blueprint-consumer-upgrade/agents/claude.yaml
@@ -1,0 +1,5 @@
+interface:
+  display_name: "Blueprint Consumer Upgrade"
+  short_description: "Safe consumer upgrade from latest blueprint tag"
+  slash_command: "/blueprint-consumer-upgrade"
+  command_file: ".claude/commands/blueprint-consumer-upgrade.md"

--- a/.agents/skills/blueprint-sdd-clarification-gate/agents/claude.yaml
+++ b/.agents/skills/blueprint-sdd-clarification-gate/agents/claude.yaml
@@ -1,0 +1,5 @@
+interface:
+  display_name: "Blueprint SDD Clarification Gate"
+  short_description: "Block ambiguous specs before implementation"
+  slash_command: "/blueprint-sdd-clarification-gate"
+  command_file: ".claude/commands/blueprint-sdd-clarification-gate.md"

--- a/.agents/skills/blueprint-sdd-document-sync/agents/claude.yaml
+++ b/.agents/skills/blueprint-sdd-document-sync/agents/claude.yaml
@@ -1,0 +1,5 @@
+interface:
+  display_name: "Blueprint SDD Document Sync"
+  short_description: "Complete SDD Document phase with sync checks"
+  slash_command: "/blueprint-sdd-document-sync"
+  command_file: ".claude/commands/blueprint-sdd-document-sync.md"

--- a/.agents/skills/blueprint-sdd-intake-decompose/agents/claude.yaml
+++ b/.agents/skills/blueprint-sdd-intake-decompose/agents/claude.yaml
@@ -1,0 +1,5 @@
+interface:
+  display_name: "Blueprint SDD Intake"
+  short_description: "Decompose high-level requirements into independent SDD specs"
+  slash_command: "/blueprint-sdd-intake-decompose"
+  command_file: ".claude/commands/blueprint-sdd-intake-decompose.md"

--- a/.agents/skills/blueprint-sdd-plan-slicer/agents/claude.yaml
+++ b/.agents/skills/blueprint-sdd-plan-slicer/agents/claude.yaml
@@ -1,0 +1,5 @@
+interface:
+  display_name: "Blueprint SDD Plan Slicer"
+  short_description: "Turn approved specs into executable slices"
+  slash_command: "/blueprint-sdd-plan-slicer"
+  command_file: ".claude/commands/blueprint-sdd-plan-slicer.md"

--- a/.agents/skills/blueprint-sdd-pr-packager/agents/claude.yaml
+++ b/.agents/skills/blueprint-sdd-pr-packager/agents/claude.yaml
@@ -1,0 +1,5 @@
+interface:
+  display_name: "Blueprint SDD PR Packager"
+  short_description: "Complete SDD Publish phase with deterministic PR context"
+  slash_command: "/blueprint-sdd-pr-packager"
+  command_file: ".claude/commands/blueprint-sdd-pr-packager.md"

--- a/.agents/skills/blueprint-sdd-traceability-keeper/agents/claude.yaml
+++ b/.agents/skills/blueprint-sdd-traceability-keeper/agents/claude.yaml
@@ -1,0 +1,5 @@
+interface:
+  display_name: "Blueprint SDD Traceability"
+  short_description: "Enforce requirement-to-test-to-doc coverage"
+  slash_command: "/blueprint-sdd-traceability-keeper"
+  command_file: ".claude/commands/blueprint-sdd-traceability-keeper.md"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,12 @@ repos:
         language: system
         entry: bash -n
         files: \.sh$
+      - id: quality-docs-lint
+        name: quality docs lint (markdown targets and links)
+        language: system
+        entry: make quality-docs-lint
+        pass_filenames: false
+        always_run: true
       - id: quality-validate-branch
         name: quality validate branch naming (pre-push)
         language: system

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,27 @@ This file is the canonical governance source for human and agent contributors.
 - You use mature, high-adoption open-source tooling only.
 - You avoid experimental libraries/frameworks in runtime paths.
 
+## Platform Context
+This section provides context for code assistants to understand the blueprint before starting work.
+
+**Purpose:** `stackit-platform-blueprint` is the upstream platform blueprint. It defines governance, tooling, skill catalog, spec-kit templates, and contract validation for all generated consumers.
+
+**Blueprint-managed paths (source of truth here, propagated to consumers on upgrade):**
+- `scripts/templates/consumer/init/` — consumer bootstrap templates (new consumers)
+- `scripts/templates/blueprint/bootstrap/` — consumer in-repo managed-file templates (drift-checked on upgrade)
+- `.agents/skills/` — canonical skill runbooks (`SKILL.md`) and agent wiring (`openai.yaml`, `claude.yaml`)
+- `scripts/bin/blueprint/` — validation, bootstrap, and upgrade tooling
+- `docs/blueprint/` — blueprint reference documentation
+
+**Key tooling:**
+- `scripts/bin/blueprint/validate_contract.py` — contract validation (branch naming, template drift, make targets, shell scripts); `--branch-only` for fast pre-push checks
+- `scripts/bin/blueprint/bootstrap_repo.sh` — new consumer initialization
+- `.spec-kit/` — SDD template packs and control catalog
+
+**Key make targets:**
+- `make infra-validate` — run full contract validation
+- `make quality-hooks-fast` — fast pre-commit hook suite
+
 ## Mandatory Workflow
 1. Read `AGENTS.md` before starting work.
 2. During `Discover`, `High-Level Architecture`, `Specify`, and `Plan`, do not use assumptions as substitutes for missing requirements; resolve ambiguity explicitly or mark the work item blocked.

--- a/blueprint/contract.yaml
+++ b/blueprint/contract.yaml
@@ -86,29 +86,45 @@ spec:
       - specs/README.md
       - .agents/skills/blueprint-consumer-upgrade/SKILL.md
       - .agents/skills/blueprint-consumer-upgrade/agents/openai.yaml
+      - .agents/skills/blueprint-consumer-upgrade/agents/claude.yaml
       - .agents/skills/blueprint-consumer-upgrade/references/manual_merge_checklist.md
       - .agents/skills/blueprint-consumer-upgrade/scripts/resolve_latest_stable_ref.sh
       - .agents/skills/blueprint-consumer-ops/SKILL.md
       - .agents/skills/blueprint-consumer-ops/agents/openai.yaml
+      - .agents/skills/blueprint-consumer-ops/agents/claude.yaml
       - .agents/skills/blueprint-consumer-ops/references/consumer_ops_checklist.md
       - .agents/skills/blueprint-sdd-intake-decompose/SKILL.md
       - .agents/skills/blueprint-sdd-intake-decompose/agents/openai.yaml
+      - .agents/skills/blueprint-sdd-intake-decompose/agents/claude.yaml
       - .agents/skills/blueprint-sdd-intake-decompose/references/intake_checklist.md
       - .agents/skills/blueprint-sdd-clarification-gate/SKILL.md
       - .agents/skills/blueprint-sdd-clarification-gate/agents/openai.yaml
+      - .agents/skills/blueprint-sdd-clarification-gate/agents/claude.yaml
       - .agents/skills/blueprint-sdd-clarification-gate/references/clarification_categories.md
       - .agents/skills/blueprint-sdd-plan-slicer/SKILL.md
       - .agents/skills/blueprint-sdd-plan-slicer/agents/openai.yaml
+      - .agents/skills/blueprint-sdd-plan-slicer/agents/claude.yaml
       - .agents/skills/blueprint-sdd-plan-slicer/references/plan_slice_checklist.md
       - .agents/skills/blueprint-sdd-traceability-keeper/SKILL.md
       - .agents/skills/blueprint-sdd-traceability-keeper/agents/openai.yaml
+      - .agents/skills/blueprint-sdd-traceability-keeper/agents/claude.yaml
       - .agents/skills/blueprint-sdd-traceability-keeper/references/traceability_matrix_template.md
       - .agents/skills/blueprint-sdd-document-sync/SKILL.md
       - .agents/skills/blueprint-sdd-document-sync/agents/openai.yaml
+      - .agents/skills/blueprint-sdd-document-sync/agents/claude.yaml
       - .agents/skills/blueprint-sdd-document-sync/references/document_phase_checklist.md
       - .agents/skills/blueprint-sdd-pr-packager/SKILL.md
       - .agents/skills/blueprint-sdd-pr-packager/agents/openai.yaml
+      - .agents/skills/blueprint-sdd-pr-packager/agents/claude.yaml
       - .agents/skills/blueprint-sdd-pr-packager/references/pr_packaging_checklist.md
+      - .claude/commands/blueprint-consumer-upgrade.md
+      - .claude/commands/blueprint-consumer-ops.md
+      - .claude/commands/blueprint-sdd-intake-decompose.md
+      - .claude/commands/blueprint-sdd-clarification-gate.md
+      - .claude/commands/blueprint-sdd-plan-slicer.md
+      - .claude/commands/blueprint-sdd-traceability-keeper.md
+      - .claude/commands/blueprint-sdd-document-sync.md
+      - .claude/commands/blueprint-sdd-pr-packager.md
       - Makefile
       - make/blueprint.generated.mk
       - make/platform.mk
@@ -239,29 +255,45 @@ spec:
       - scripts/templates/consumer/init/.github/workflows/ci.yml.tmpl
       - scripts/templates/consumer/init/.agents/skills/blueprint-consumer-upgrade/SKILL.md.tmpl
       - scripts/templates/consumer/init/.agents/skills/blueprint-consumer-upgrade/agents/openai.yaml.tmpl
+      - scripts/templates/consumer/init/.agents/skills/blueprint-consumer-upgrade/agents/claude.yaml.tmpl
       - scripts/templates/consumer/init/.agents/skills/blueprint-consumer-upgrade/references/manual_merge_checklist.md.tmpl
       - scripts/templates/consumer/init/.agents/skills/blueprint-consumer-upgrade/scripts/resolve_latest_stable_ref.sh.tmpl
       - scripts/templates/consumer/init/.agents/skills/blueprint-consumer-ops/SKILL.md.tmpl
       - scripts/templates/consumer/init/.agents/skills/blueprint-consumer-ops/agents/openai.yaml.tmpl
+      - scripts/templates/consumer/init/.agents/skills/blueprint-consumer-ops/agents/claude.yaml.tmpl
       - scripts/templates/consumer/init/.agents/skills/blueprint-consumer-ops/references/consumer_ops_checklist.md.tmpl
       - scripts/templates/consumer/init/.agents/skills/blueprint-sdd-intake-decompose/SKILL.md.tmpl
       - scripts/templates/consumer/init/.agents/skills/blueprint-sdd-intake-decompose/agents/openai.yaml.tmpl
+      - scripts/templates/consumer/init/.agents/skills/blueprint-sdd-intake-decompose/agents/claude.yaml.tmpl
       - scripts/templates/consumer/init/.agents/skills/blueprint-sdd-intake-decompose/references/intake_checklist.md.tmpl
       - scripts/templates/consumer/init/.agents/skills/blueprint-sdd-clarification-gate/SKILL.md.tmpl
       - scripts/templates/consumer/init/.agents/skills/blueprint-sdd-clarification-gate/agents/openai.yaml.tmpl
+      - scripts/templates/consumer/init/.agents/skills/blueprint-sdd-clarification-gate/agents/claude.yaml.tmpl
       - scripts/templates/consumer/init/.agents/skills/blueprint-sdd-clarification-gate/references/clarification_categories.md.tmpl
       - scripts/templates/consumer/init/.agents/skills/blueprint-sdd-plan-slicer/SKILL.md.tmpl
       - scripts/templates/consumer/init/.agents/skills/blueprint-sdd-plan-slicer/agents/openai.yaml.tmpl
+      - scripts/templates/consumer/init/.agents/skills/blueprint-sdd-plan-slicer/agents/claude.yaml.tmpl
       - scripts/templates/consumer/init/.agents/skills/blueprint-sdd-plan-slicer/references/plan_slice_checklist.md.tmpl
       - scripts/templates/consumer/init/.agents/skills/blueprint-sdd-traceability-keeper/SKILL.md.tmpl
       - scripts/templates/consumer/init/.agents/skills/blueprint-sdd-traceability-keeper/agents/openai.yaml.tmpl
+      - scripts/templates/consumer/init/.agents/skills/blueprint-sdd-traceability-keeper/agents/claude.yaml.tmpl
       - scripts/templates/consumer/init/.agents/skills/blueprint-sdd-traceability-keeper/references/traceability_matrix_template.md.tmpl
       - scripts/templates/consumer/init/.agents/skills/blueprint-sdd-document-sync/SKILL.md.tmpl
       - scripts/templates/consumer/init/.agents/skills/blueprint-sdd-document-sync/agents/openai.yaml.tmpl
+      - scripts/templates/consumer/init/.agents/skills/blueprint-sdd-document-sync/agents/claude.yaml.tmpl
       - scripts/templates/consumer/init/.agents/skills/blueprint-sdd-document-sync/references/document_phase_checklist.md.tmpl
       - scripts/templates/consumer/init/.agents/skills/blueprint-sdd-pr-packager/SKILL.md.tmpl
       - scripts/templates/consumer/init/.agents/skills/blueprint-sdd-pr-packager/agents/openai.yaml.tmpl
+      - scripts/templates/consumer/init/.agents/skills/blueprint-sdd-pr-packager/agents/claude.yaml.tmpl
       - scripts/templates/consumer/init/.agents/skills/blueprint-sdd-pr-packager/references/pr_packaging_checklist.md.tmpl
+      - scripts/templates/consumer/init/.claude/commands/blueprint-consumer-upgrade.md.tmpl
+      - scripts/templates/consumer/init/.claude/commands/blueprint-consumer-ops.md.tmpl
+      - scripts/templates/consumer/init/.claude/commands/blueprint-sdd-intake-decompose.md.tmpl
+      - scripts/templates/consumer/init/.claude/commands/blueprint-sdd-clarification-gate.md.tmpl
+      - scripts/templates/consumer/init/.claude/commands/blueprint-sdd-plan-slicer.md.tmpl
+      - scripts/templates/consumer/init/.claude/commands/blueprint-sdd-traceability-keeper.md.tmpl
+      - scripts/templates/consumer/init/.claude/commands/blueprint-sdd-document-sync.md.tmpl
+      - scripts/templates/consumer/init/.claude/commands/blueprint-sdd-pr-packager.md.tmpl
       - scripts/templates/consumer/init/.spec-kit/policy-mapping.md.tmpl
       - scripts/templates/consumer/init/.spec-kit/control-catalog.yaml.tmpl
       - scripts/templates/consumer/init/.spec-kit/control-catalog.md.tmpl

--- a/scripts/templates/blueprint/bootstrap/.pre-commit-config.yaml
+++ b/scripts/templates/blueprint/bootstrap/.pre-commit-config.yaml
@@ -15,6 +15,12 @@ repos:
         language: system
         entry: bash -n
         files: \.sh$
+      - id: quality-docs-lint
+        name: quality docs lint (markdown targets and links)
+        language: system
+        entry: make quality-docs-lint
+        pass_filenames: false
+        always_run: true
       - id: quality-validate-branch
         name: quality validate branch naming (pre-push)
         language: system

--- a/scripts/templates/blueprint/bootstrap/blueprint/contract.yaml
+++ b/scripts/templates/blueprint/bootstrap/blueprint/contract.yaml
@@ -86,29 +86,45 @@ spec:
       - specs/README.md
       - .agents/skills/blueprint-consumer-upgrade/SKILL.md
       - .agents/skills/blueprint-consumer-upgrade/agents/openai.yaml
+      - .agents/skills/blueprint-consumer-upgrade/agents/claude.yaml
       - .agents/skills/blueprint-consumer-upgrade/references/manual_merge_checklist.md
       - .agents/skills/blueprint-consumer-upgrade/scripts/resolve_latest_stable_ref.sh
       - .agents/skills/blueprint-consumer-ops/SKILL.md
       - .agents/skills/blueprint-consumer-ops/agents/openai.yaml
+      - .agents/skills/blueprint-consumer-ops/agents/claude.yaml
       - .agents/skills/blueprint-consumer-ops/references/consumer_ops_checklist.md
       - .agents/skills/blueprint-sdd-intake-decompose/SKILL.md
       - .agents/skills/blueprint-sdd-intake-decompose/agents/openai.yaml
+      - .agents/skills/blueprint-sdd-intake-decompose/agents/claude.yaml
       - .agents/skills/blueprint-sdd-intake-decompose/references/intake_checklist.md
       - .agents/skills/blueprint-sdd-clarification-gate/SKILL.md
       - .agents/skills/blueprint-sdd-clarification-gate/agents/openai.yaml
+      - .agents/skills/blueprint-sdd-clarification-gate/agents/claude.yaml
       - .agents/skills/blueprint-sdd-clarification-gate/references/clarification_categories.md
       - .agents/skills/blueprint-sdd-plan-slicer/SKILL.md
       - .agents/skills/blueprint-sdd-plan-slicer/agents/openai.yaml
+      - .agents/skills/blueprint-sdd-plan-slicer/agents/claude.yaml
       - .agents/skills/blueprint-sdd-plan-slicer/references/plan_slice_checklist.md
       - .agents/skills/blueprint-sdd-traceability-keeper/SKILL.md
       - .agents/skills/blueprint-sdd-traceability-keeper/agents/openai.yaml
+      - .agents/skills/blueprint-sdd-traceability-keeper/agents/claude.yaml
       - .agents/skills/blueprint-sdd-traceability-keeper/references/traceability_matrix_template.md
       - .agents/skills/blueprint-sdd-document-sync/SKILL.md
       - .agents/skills/blueprint-sdd-document-sync/agents/openai.yaml
+      - .agents/skills/blueprint-sdd-document-sync/agents/claude.yaml
       - .agents/skills/blueprint-sdd-document-sync/references/document_phase_checklist.md
       - .agents/skills/blueprint-sdd-pr-packager/SKILL.md
       - .agents/skills/blueprint-sdd-pr-packager/agents/openai.yaml
+      - .agents/skills/blueprint-sdd-pr-packager/agents/claude.yaml
       - .agents/skills/blueprint-sdd-pr-packager/references/pr_packaging_checklist.md
+      - .claude/commands/blueprint-consumer-upgrade.md
+      - .claude/commands/blueprint-consumer-ops.md
+      - .claude/commands/blueprint-sdd-intake-decompose.md
+      - .claude/commands/blueprint-sdd-clarification-gate.md
+      - .claude/commands/blueprint-sdd-plan-slicer.md
+      - .claude/commands/blueprint-sdd-traceability-keeper.md
+      - .claude/commands/blueprint-sdd-document-sync.md
+      - .claude/commands/blueprint-sdd-pr-packager.md
       - Makefile
       - make/blueprint.generated.mk
       - make/platform.mk
@@ -239,29 +255,45 @@ spec:
       - scripts/templates/consumer/init/.github/workflows/ci.yml.tmpl
       - scripts/templates/consumer/init/.agents/skills/blueprint-consumer-upgrade/SKILL.md.tmpl
       - scripts/templates/consumer/init/.agents/skills/blueprint-consumer-upgrade/agents/openai.yaml.tmpl
+      - scripts/templates/consumer/init/.agents/skills/blueprint-consumer-upgrade/agents/claude.yaml.tmpl
       - scripts/templates/consumer/init/.agents/skills/blueprint-consumer-upgrade/references/manual_merge_checklist.md.tmpl
       - scripts/templates/consumer/init/.agents/skills/blueprint-consumer-upgrade/scripts/resolve_latest_stable_ref.sh.tmpl
       - scripts/templates/consumer/init/.agents/skills/blueprint-consumer-ops/SKILL.md.tmpl
       - scripts/templates/consumer/init/.agents/skills/blueprint-consumer-ops/agents/openai.yaml.tmpl
+      - scripts/templates/consumer/init/.agents/skills/blueprint-consumer-ops/agents/claude.yaml.tmpl
       - scripts/templates/consumer/init/.agents/skills/blueprint-consumer-ops/references/consumer_ops_checklist.md.tmpl
       - scripts/templates/consumer/init/.agents/skills/blueprint-sdd-intake-decompose/SKILL.md.tmpl
       - scripts/templates/consumer/init/.agents/skills/blueprint-sdd-intake-decompose/agents/openai.yaml.tmpl
+      - scripts/templates/consumer/init/.agents/skills/blueprint-sdd-intake-decompose/agents/claude.yaml.tmpl
       - scripts/templates/consumer/init/.agents/skills/blueprint-sdd-intake-decompose/references/intake_checklist.md.tmpl
       - scripts/templates/consumer/init/.agents/skills/blueprint-sdd-clarification-gate/SKILL.md.tmpl
       - scripts/templates/consumer/init/.agents/skills/blueprint-sdd-clarification-gate/agents/openai.yaml.tmpl
+      - scripts/templates/consumer/init/.agents/skills/blueprint-sdd-clarification-gate/agents/claude.yaml.tmpl
       - scripts/templates/consumer/init/.agents/skills/blueprint-sdd-clarification-gate/references/clarification_categories.md.tmpl
       - scripts/templates/consumer/init/.agents/skills/blueprint-sdd-plan-slicer/SKILL.md.tmpl
       - scripts/templates/consumer/init/.agents/skills/blueprint-sdd-plan-slicer/agents/openai.yaml.tmpl
+      - scripts/templates/consumer/init/.agents/skills/blueprint-sdd-plan-slicer/agents/claude.yaml.tmpl
       - scripts/templates/consumer/init/.agents/skills/blueprint-sdd-plan-slicer/references/plan_slice_checklist.md.tmpl
       - scripts/templates/consumer/init/.agents/skills/blueprint-sdd-traceability-keeper/SKILL.md.tmpl
       - scripts/templates/consumer/init/.agents/skills/blueprint-sdd-traceability-keeper/agents/openai.yaml.tmpl
+      - scripts/templates/consumer/init/.agents/skills/blueprint-sdd-traceability-keeper/agents/claude.yaml.tmpl
       - scripts/templates/consumer/init/.agents/skills/blueprint-sdd-traceability-keeper/references/traceability_matrix_template.md.tmpl
       - scripts/templates/consumer/init/.agents/skills/blueprint-sdd-document-sync/SKILL.md.tmpl
       - scripts/templates/consumer/init/.agents/skills/blueprint-sdd-document-sync/agents/openai.yaml.tmpl
+      - scripts/templates/consumer/init/.agents/skills/blueprint-sdd-document-sync/agents/claude.yaml.tmpl
       - scripts/templates/consumer/init/.agents/skills/blueprint-sdd-document-sync/references/document_phase_checklist.md.tmpl
       - scripts/templates/consumer/init/.agents/skills/blueprint-sdd-pr-packager/SKILL.md.tmpl
       - scripts/templates/consumer/init/.agents/skills/blueprint-sdd-pr-packager/agents/openai.yaml.tmpl
+      - scripts/templates/consumer/init/.agents/skills/blueprint-sdd-pr-packager/agents/claude.yaml.tmpl
       - scripts/templates/consumer/init/.agents/skills/blueprint-sdd-pr-packager/references/pr_packaging_checklist.md.tmpl
+      - scripts/templates/consumer/init/.claude/commands/blueprint-consumer-upgrade.md.tmpl
+      - scripts/templates/consumer/init/.claude/commands/blueprint-consumer-ops.md.tmpl
+      - scripts/templates/consumer/init/.claude/commands/blueprint-sdd-intake-decompose.md.tmpl
+      - scripts/templates/consumer/init/.claude/commands/blueprint-sdd-clarification-gate.md.tmpl
+      - scripts/templates/consumer/init/.claude/commands/blueprint-sdd-plan-slicer.md.tmpl
+      - scripts/templates/consumer/init/.claude/commands/blueprint-sdd-traceability-keeper.md.tmpl
+      - scripts/templates/consumer/init/.claude/commands/blueprint-sdd-document-sync.md.tmpl
+      - scripts/templates/consumer/init/.claude/commands/blueprint-sdd-pr-packager.md.tmpl
       - scripts/templates/consumer/init/.spec-kit/policy-mapping.md.tmpl
       - scripts/templates/consumer/init/.spec-kit/control-catalog.yaml.tmpl
       - scripts/templates/consumer/init/.spec-kit/control-catalog.md.tmpl

--- a/scripts/templates/consumer/init/.agents/skills/blueprint-consumer-ops/agents/claude.yaml.tmpl
+++ b/scripts/templates/consumer/init/.agents/skills/blueprint-consumer-ops/agents/claude.yaml.tmpl
@@ -1,0 +1,5 @@
+interface:
+  display_name: "Blueprint Consumer Ops"
+  short_description: "Deterministic generated-consumer operations runbook"
+  slash_command: "/blueprint-consumer-ops"
+  command_file: ".claude/commands/blueprint-consumer-ops.md"

--- a/scripts/templates/consumer/init/.agents/skills/blueprint-consumer-upgrade/agents/claude.yaml.tmpl
+++ b/scripts/templates/consumer/init/.agents/skills/blueprint-consumer-upgrade/agents/claude.yaml.tmpl
@@ -1,0 +1,5 @@
+interface:
+  display_name: "Blueprint Consumer Upgrade"
+  short_description: "Safe consumer upgrade from latest blueprint tag"
+  slash_command: "/blueprint-consumer-upgrade"
+  command_file: ".claude/commands/blueprint-consumer-upgrade.md"

--- a/scripts/templates/consumer/init/.agents/skills/blueprint-sdd-clarification-gate/agents/claude.yaml.tmpl
+++ b/scripts/templates/consumer/init/.agents/skills/blueprint-sdd-clarification-gate/agents/claude.yaml.tmpl
@@ -1,0 +1,5 @@
+interface:
+  display_name: "Blueprint SDD Clarification Gate"
+  short_description: "Block ambiguous specs before implementation"
+  slash_command: "/blueprint-sdd-clarification-gate"
+  command_file: ".claude/commands/blueprint-sdd-clarification-gate.md"

--- a/scripts/templates/consumer/init/.agents/skills/blueprint-sdd-document-sync/agents/claude.yaml.tmpl
+++ b/scripts/templates/consumer/init/.agents/skills/blueprint-sdd-document-sync/agents/claude.yaml.tmpl
@@ -1,0 +1,5 @@
+interface:
+  display_name: "Blueprint SDD Document Sync"
+  short_description: "Complete SDD Document phase with sync checks"
+  slash_command: "/blueprint-sdd-document-sync"
+  command_file: ".claude/commands/blueprint-sdd-document-sync.md"

--- a/scripts/templates/consumer/init/.agents/skills/blueprint-sdd-intake-decompose/agents/claude.yaml.tmpl
+++ b/scripts/templates/consumer/init/.agents/skills/blueprint-sdd-intake-decompose/agents/claude.yaml.tmpl
@@ -1,0 +1,5 @@
+interface:
+  display_name: "Blueprint SDD Intake"
+  short_description: "Decompose high-level requirements into independent SDD specs"
+  slash_command: "/blueprint-sdd-intake-decompose"
+  command_file: ".claude/commands/blueprint-sdd-intake-decompose.md"

--- a/scripts/templates/consumer/init/.agents/skills/blueprint-sdd-plan-slicer/agents/claude.yaml.tmpl
+++ b/scripts/templates/consumer/init/.agents/skills/blueprint-sdd-plan-slicer/agents/claude.yaml.tmpl
@@ -1,0 +1,5 @@
+interface:
+  display_name: "Blueprint SDD Plan Slicer"
+  short_description: "Turn approved specs into executable slices"
+  slash_command: "/blueprint-sdd-plan-slicer"
+  command_file: ".claude/commands/blueprint-sdd-plan-slicer.md"

--- a/scripts/templates/consumer/init/.agents/skills/blueprint-sdd-pr-packager/agents/claude.yaml.tmpl
+++ b/scripts/templates/consumer/init/.agents/skills/blueprint-sdd-pr-packager/agents/claude.yaml.tmpl
@@ -1,0 +1,5 @@
+interface:
+  display_name: "Blueprint SDD PR Packager"
+  short_description: "Complete SDD Publish phase with deterministic PR context"
+  slash_command: "/blueprint-sdd-pr-packager"
+  command_file: ".claude/commands/blueprint-sdd-pr-packager.md"

--- a/scripts/templates/consumer/init/.agents/skills/blueprint-sdd-traceability-keeper/agents/claude.yaml.tmpl
+++ b/scripts/templates/consumer/init/.agents/skills/blueprint-sdd-traceability-keeper/agents/claude.yaml.tmpl
@@ -1,0 +1,5 @@
+interface:
+  display_name: "Blueprint SDD Traceability"
+  short_description: "Enforce requirement-to-test-to-doc coverage"
+  slash_command: "/blueprint-sdd-traceability-keeper"
+  command_file: ".claude/commands/blueprint-sdd-traceability-keeper.md"

--- a/scripts/templates/consumer/init/.claude/commands/blueprint-consumer-ops.md.tmpl
+++ b/scripts/templates/consumer/init/.claude/commands/blueprint-consumer-ops.md.tmpl
@@ -1,0 +1,10 @@
+Read and execute the skill runbook at:
+`.agents/skills/blueprint-consumer-ops/SKILL.md`
+
+Apply all guardrails and the required report format defined there.
+
+Input provided: $ARGUMENTS
+
+If no input was provided above, ask conversationally what operation or context
+to use before proceeding. In either case, keep the conversation open for
+clarifications — do not proceed past a phase if there are unresolved questions.

--- a/scripts/templates/consumer/init/.claude/commands/blueprint-consumer-upgrade.md.tmpl
+++ b/scripts/templates/consumer/init/.claude/commands/blueprint-consumer-upgrade.md.tmpl
@@ -1,0 +1,10 @@
+Read and execute the skill runbook at:
+`.agents/skills/blueprint-consumer-upgrade/SKILL.md`
+
+Apply all guardrails and the required report format defined there.
+
+Input provided: $ARGUMENTS
+
+If no input was provided above, ask conversationally what consumer repo or target
+version to use before proceeding. In either case, keep the conversation open
+for clarifications — do not proceed past a phase if there are unresolved questions.

--- a/scripts/templates/consumer/init/.claude/commands/blueprint-sdd-clarification-gate.md.tmpl
+++ b/scripts/templates/consumer/init/.claude/commands/blueprint-sdd-clarification-gate.md.tmpl
@@ -1,0 +1,10 @@
+Read and execute the skill runbook at:
+`.agents/skills/blueprint-sdd-clarification-gate/SKILL.md`
+
+Apply all guardrails and the required report format defined there.
+
+Input provided: $ARGUMENTS
+
+If no input was provided above, ask conversationally what spec or work item
+to gate before proceeding. In either case, keep the conversation open
+for clarifications — do not proceed past a phase if there are unresolved questions.

--- a/scripts/templates/consumer/init/.claude/commands/blueprint-sdd-document-sync.md.tmpl
+++ b/scripts/templates/consumer/init/.claude/commands/blueprint-sdd-document-sync.md.tmpl
@@ -1,0 +1,10 @@
+Read and execute the skill runbook at:
+`.agents/skills/blueprint-sdd-document-sync/SKILL.md`
+
+Apply all guardrails and the required report format defined there.
+
+Input provided: $ARGUMENTS
+
+If no input was provided above, ask conversationally what spec or work item
+to document before proceeding. In either case, keep the conversation open
+for clarifications — do not proceed past a phase if there are unresolved questions.

--- a/scripts/templates/consumer/init/.claude/commands/blueprint-sdd-intake-decompose.md.tmpl
+++ b/scripts/templates/consumer/init/.claude/commands/blueprint-sdd-intake-decompose.md.tmpl
@@ -1,0 +1,10 @@
+Read and execute the skill runbook at:
+`.agents/skills/blueprint-sdd-intake-decompose/SKILL.md`
+
+Apply all guardrails and the required report format defined there.
+
+Input provided: $ARGUMENTS
+
+If no input was provided above, ask conversationally what requirements document
+or scope to use before proceeding. In either case, keep the conversation open
+for clarifications — do not proceed past a phase if there are unresolved questions.

--- a/scripts/templates/consumer/init/.claude/commands/blueprint-sdd-plan-slicer.md.tmpl
+++ b/scripts/templates/consumer/init/.claude/commands/blueprint-sdd-plan-slicer.md.tmpl
@@ -1,0 +1,10 @@
+Read and execute the skill runbook at:
+`.agents/skills/blueprint-sdd-plan-slicer/SKILL.md`
+
+Apply all guardrails and the required report format defined there.
+
+Input provided: $ARGUMENTS
+
+If no input was provided above, ask conversationally what approved spec or work item
+to slice before proceeding. In either case, keep the conversation open
+for clarifications — do not proceed past a phase if there are unresolved questions.

--- a/scripts/templates/consumer/init/.claude/commands/blueprint-sdd-pr-packager.md.tmpl
+++ b/scripts/templates/consumer/init/.claude/commands/blueprint-sdd-pr-packager.md.tmpl
@@ -1,0 +1,10 @@
+Read and execute the skill runbook at:
+`.agents/skills/blueprint-sdd-pr-packager/SKILL.md`
+
+Apply all guardrails and the required report format defined there.
+
+Input provided: $ARGUMENTS
+
+If no input was provided above, ask conversationally what spec or work item
+to package before proceeding. In either case, keep the conversation open
+for clarifications — do not proceed past a phase if there are unresolved questions.

--- a/scripts/templates/consumer/init/.claude/commands/blueprint-sdd-traceability-keeper.md.tmpl
+++ b/scripts/templates/consumer/init/.claude/commands/blueprint-sdd-traceability-keeper.md.tmpl
@@ -1,0 +1,10 @@
+Read and execute the skill runbook at:
+`.agents/skills/blueprint-sdd-traceability-keeper/SKILL.md`
+
+Apply all guardrails and the required report format defined there.
+
+Input provided: $ARGUMENTS
+
+If no input was provided above, ask conversationally what spec or work item
+to trace before proceeding. In either case, keep the conversation open
+for clarifications — do not proceed past a phase if there are unresolved questions.

--- a/scripts/templates/consumer/init/AGENTS.md.tmpl
+++ b/scripts/templates/consumer/init/AGENTS.md.tmpl
@@ -14,6 +14,11 @@ This file is the canonical governance source for this generated platform reposit
 - Use blueprint-managed paths only when the task explicitly involves bootstrap, contract, validation, or inherited blueprint behavior.
 - Treat `blueprint/repo.init.env` as tracked non-sensitive operator input, and `blueprint/repo.init.secrets.env` as local-sensitive operator input, not product implementation files.
 
+## Platform Context
+<!-- TODO: Fill in platform context for code assistants before starting meaningful work.
+     Include: platform purpose, tech stack (backend/frontend/auth/infra), app layout, key make targets.
+     Keep it factual and concise — agents read this at the start of every session. -->
+
 ## Mandatory Workflow
 1. Read `AGENTS.md` before starting work.
 2. During `Discover`, `High-Level Architecture`, `Specify`, and `Plan`, do not use assumptions as substitutes for missing requirements; resolve ambiguity explicitly or mark the work item blocked.


### PR DESCRIPTION
## Summary
- Adds `## Platform Context` section to `AGENTS.md` with blueprint purpose, managed paths, key tooling, and make targets — gives all agents immediate context at session start
- Adds `## Platform Context` stub to `AGENTS.md.tmpl` so new consumers know where to add their platform context on bootstrap
- Adds `agents/claude.yaml` for all 8 skills for Claude Code skill interoperability
- Adds `claude.yaml.tmpl` and `.claude/commands/*.md.tmpl` to consumer init templates so new consumers get full Claude Code wiring on bootstrap

## Test plan
- [ ] CI passes (blueprint-quality)
- [ ] `AGENTS.md` Platform Context section is accurate and complete
- [ ] All 8 `agents/claude.yaml` files present with correct slash commands
- [ ] Consumer init templates include all new Claude Code wiring

🤖 Generated with [Claude Code](https://claude.com/claude-code)