### PR TITLE
Validate prune-glob ownership matrix documentation in infra-validate

### DIFF
--- a/AGENTS.backlog.md
+++ b/AGENTS.backlog.md
@@ -8,6 +8,7 @@
 - [ ] P1 (Fixture-contract hardening): Issue #130 — enforce optional-module `required_env` fixture parity in fast infra contract checks.
 - [ ] P1 (Generated-consumer upgrade regressions): Issues #103, #104, #106, #107 — fix repo-mode test selection, additive-file conflict classification, and missing helper distribution.
 - [ ] P1 (Runtime operability correctness): Issues #105, #108, #109, #110, #111, #112, #118, #137 — resolve runtime identity, Argo health/project policy, image-lane, and target migration friction.
+- [ ] P2 (Ownership checker robustness): support normalized equivalence for semantically-identical prune-glob expressions in ownership-matrix documentation checks.
 - [ ] P2 (Capability enhancements): Issues #56, #131 — expand app dependency pin auditing and add blueprint uplift convergence status command.
 - [ ] Add an automated bundled-skill contract verifier to enforce parity across `.agents/skills/**`, consumer-template fallbacks, install make targets, and docs references.
 - [ ] Add a contract-level traceability verifier that checks every declared requirement ID in `spec.md` maps to implementation paths and at least one automated test assertion.

--- a/AGENTS.decisions.md
+++ b/AGENTS.decisions.md
@@ -277,3 +277,7 @@
   - consumer-init contract now defines `source_artifact_prune_globs_on_init`, applied only on the initial `template-source -> generated-consumer` transition.
   - blueprint docs template sync now reads `spec.docs_contract.blueprint_docs.template_sync_allowlist` from `blueprint/contract.yaml` as the single declarative source and removes non-allowlisted source-only blueprint docs from the bootstrap template mirror.
   - governance ownership policy now documents this boundary so contract/docs/tests remain aligned.
+- Prune-glob ownership governance is now contract-validated:
+  - `infra-validate` now fails when any `repository.consumer_init.source_artifact_prune_globs_on_init` pattern is missing from source-only rows in `docs/blueprint/governance/ownership_matrix.md`.
+  - ownership matrix source-only row now documents the exact prune glob patterns from contract.
+  - init prune hardening now rejects unsafe glob patterns (absolute or traversal), skips out-of-root resolved candidates, and avoids following symlinked directories during deletion.

--- a/docs/blueprint/architecture/decisions/ADR-20260417-prune-glob-ownership-check.md
+++ b/docs/blueprint/architecture/decisions/ADR-20260417-prune-glob-ownership-check.md
@@ -1,0 +1,88 @@
+# ADR-20260417-prune-glob-ownership-check: Enforce prune-glob ownership documentation parity
+
+## Metadata
+- Status: approved
+- Date: 2026-04-17
+- Owners: sbonoc
+- Related spec path: specs/2026-04-17-prune-glob-ownership-check/
+
+## Business Objective and Requirement Summary
+- Business objective: make source-artifact prune ownership governance executable by validating contract-to-doc parity.
+- Functional requirements summary:
+  - contract-driven docs template allowlist source.
+  - validation check that prune globs are documented in source-only ownership rows.
+  - preserve docs mirror integrity for linked governance docs.
+- Non-functional requirements summary:
+  - deterministic validation diagnostics.
+  - secure prune behavior against path traversal/symlink escape.
+- Desired timeline: immediate follow-up after template-boundary PR merge.
+
+## Decision Drivers
+- Driver 1: deferred governance gap from prior PR required enforcement, not only guidance.
+- Driver 2: ownership matrix drift should fail early in `infra-validate` before consumer init workflows.
+
+## Options Considered
+- Option A: strict contract-to-doc checker in validation lane with exact pattern documentation.
+- Option B: no checker, rely on manual review and narrative docs updates.
+
+## Recommended Option
+- Selected option: Option A
+- Rationale: Option A provides deterministic guardrails and prevents silent drift.
+
+## Rejected Options
+- Rejected option 1: Option B
+- Rejection rationale: manual alignment is non-deterministic and easy to regress.
+
+## Affected Capabilities and Components
+- Capability impact:
+  - docs sync ownership governance
+  - contract validation reliability
+  - init prune safety posture
+- Component impact:
+  - `scripts/lib/blueprint/contract_validators/docs_sync.py`
+  - `scripts/bin/blueprint/validate_contract.py`
+  - `scripts/lib/blueprint/init_repo_contract.py`
+  - `scripts/lib/blueprint/init_repo_io.py`
+  - `docs/blueprint/governance/ownership_matrix.md`
+
+## Architecture Diagram (Mermaid)
+```mermaid
+flowchart LR
+  C[blueprint/contract.yaml] --> V[infra-validate docs validator]
+  O[ownership_matrix.md source-only rows] --> V
+  V -->|missing mapping| E[deterministic contract error]
+  V -->|complete mapping| P[validation pass]
+  C --> S[docs sync allowlist]
+  S --> T[bootstrap docs template mirror]
+```
+
+## High-Level Work Packages and Timeline (Mermaid Gantt)
+```mermaid
+gantt
+  title Prune-Glob Ownership Checker Delivery
+  dateFormat  YYYY-MM-DD
+  section Work Packages
+  Contract/schema/docs allowlist source :a1, 2026-04-17, 1d
+  Validation checker wiring :a2, after a1, 1d
+  Tests and SDD publish artifacts :a3, after a2, 1d
+```
+
+## External Dependencies
+- Dependency 1: existing contract-schema loader and docs validator delegation boundaries.
+- Dependency 2: existing ownership matrix documentation conventions.
+
+## Risks and Mitigations
+- Risk 1: docs checker can be brittle if markdown table format changes significantly.
+- Mitigation 1: keep parser narrow and maintain stable ownership matrix table structure.
+- Risk 2: exact pattern string matching may require explicit docs updates on every glob change.
+- Mitigation 2: enforce same-change policy and include regression tests.
+
+## Validation and Observability Expectations
+- Validation requirements:
+  - `python3 -m unittest tests.blueprint.test_quality_contracts.QualityContractsTests.test_prune_globs_must_be_documented_in_ownership_matrix_source_only_rows`
+  - `make quality-docs-check-blueprint-template-sync`
+  - `make quality-sdd-check`
+  - `make quality-hardening-review`
+  - `make infra-validate`
+- Logging/metrics/tracing requirements:
+  - explicit `infra-validate` error messages naming missing prune-glob mapping and ownership matrix path.

--- a/docs/blueprint/governance/ownership_matrix.md
+++ b/docs/blueprint/governance/ownership_matrix.md
@@ -16,7 +16,7 @@ This matrix clarifies which areas are blueprint-managed and which are platform-o
 | `blueprint/repo.init.secrets.env` | Consumer local | Editable, gitignored | Local sensitive overrides loaded after `blueprint/repo.init.env`; explicit shell env still wins. |
 | `blueprint/contract.yaml`, `docs/docusaurus.config.js`, repo identity files under `infra/gitops/argocd/**`, STACKIT tfvars/backend files | Blueprint init-managed in generated repos | Controlled | `make blueprint-init-repo` owns these files. `make blueprint-bootstrap` and `make infra-bootstrap` validate presence but do not recreate them in generated repos. |
 | `tests/blueprint/**`, `tests/docs/**` | Blueprint source only | Controlled | Maintainer-only blueprint contract and docs test suites; pruned from generated repos during first init. |
-| `specs/<YYYY-MM-DD>-*`, `docs/blueprint/architecture/decisions/ADR-*.md` | Blueprint source only | Controlled | Maintainer-only SDD work-item history and blueprint ADR records; pruned from generated repos during first init. |
+| `specs/[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]-*`, `docs/blueprint/architecture/decisions/ADR-*.md` | Blueprint source only | Controlled | Maintainer-only SDD work-item history and blueprint ADR records; pruned from generated repos during first init. |
 | `.github/actions/**` | Blueprint | Controlled | Shared local GitHub Actions support for source and generated-repo CI workflows. |
 | `make/platform.mk`, `make/platform/*.mk` | Platform | Editable | Consumer-facing project targets. |
 | `scripts/bin/platform/**`, `scripts/lib/platform/**` | Platform | Editable | Application/runtime-specific automation (for example `scripts/bin/platform/touchpoints/test_e2e.sh`). |

--- a/scripts/bin/blueprint/validate_contract.py
+++ b/scripts/bin/blueprint/validate_contract.py
@@ -27,6 +27,7 @@ from scripts.lib.blueprint.contract_validators.docs_sync import (  # noqa: E402
     validate_bootstrap_template_sync as _validate_bootstrap_template_sync_delegate,
     validate_docs_edit_link as _validate_docs_edit_link_delegate,
     validate_platform_docs_seed_contract as _validate_platform_docs_seed_contract_delegate,
+    validate_source_artifact_prune_globs_documented as _validate_source_artifact_prune_globs_documented_delegate,
 )
 from scripts.lib.blueprint.contract_validators.messaging import (  # noqa: E402
     validate_event_messaging_contract as _validate_event_messaging_contract_delegate,
@@ -2407,6 +2408,10 @@ def _validate_platform_docs_seed_contract(repo_root: Path, contract: BlueprintCo
     return _validate_platform_docs_seed_contract_delegate(repo_root, contract, _contract_validation_helpers())
 
 
+def _validate_source_artifact_prune_globs_documented(repo_root: Path, contract: BlueprintContract) -> list[str]:
+    return _validate_source_artifact_prune_globs_documented_delegate(repo_root, contract)
+
+
 def _validate_bootstrap_template_sync(repo_root: Path, contract: BlueprintContract) -> list[str]:
     return _validate_bootstrap_template_sync_delegate(repo_root, contract)
 
@@ -2494,6 +2499,7 @@ def main() -> int:
     errors.extend(_validate_airflow_contract(repo_root, contract))
     errors.extend(_validate_docs_edit_link(repo_root, contract))
     errors.extend(_validate_platform_docs_seed_contract(repo_root, contract))
+    errors.extend(_validate_source_artifact_prune_globs_documented(repo_root, contract))
     errors.extend(_validate_core_chart_values_contract(repo_root))
     errors.extend(_validate_runtime_credentials_contract(repo_root))
     errors.extend(_validate_app_catalog_scaffold_contract(repo_root, contract))

--- a/scripts/lib/blueprint/contract_validators/docs_sync.py
+++ b/scripts/lib/blueprint/contract_validators/docs_sync.py
@@ -6,6 +6,50 @@ from scripts.lib.blueprint.contract_schema import BlueprintContract
 from scripts.lib.blueprint.contract_validators.shared import ContractValidationHelpers
 
 
+def validate_source_artifact_prune_globs_documented(repo_root: Path, contract: BlueprintContract) -> list[str]:
+    errors: list[str] = []
+    prune_globs = contract.repository.consumer_init.source_artifact_prune_globs_on_init
+    if not prune_globs:
+        return errors
+
+    blueprint_docs_root = contract.docs_contract.blueprint_docs.root
+    ownership_matrix_relative = f"{blueprint_docs_root}/governance/ownership_matrix.md"
+    ownership_matrix_path = repo_root / ownership_matrix_relative
+    if not ownership_matrix_path.is_file():
+        return [f"missing ownership matrix file: {ownership_matrix_relative}"]
+
+    source_only_area_cells: list[str] = []
+    for line in ownership_matrix_path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("|"):
+            continue
+
+        cells = [cell.strip() for cell in stripped.strip("|").split("|")]
+        if len(cells) < 2:
+            continue
+
+        area_cell, ownership_cell = cells[0], cells[1]
+        if "source only" not in ownership_cell.lower():
+            continue
+        source_only_area_cells.append(area_cell)
+
+    if not source_only_area_cells:
+        errors.append(
+            "ownership matrix must include at least one 'source only' row for prune-glob documentation checks"
+        )
+        return errors
+
+    for pattern in prune_globs:
+        if any(pattern in area_cell for area_cell in source_only_area_cells):
+            continue
+        errors.append(
+            "repository.consumer_init.source_artifact_prune_globs_on_init pattern must be documented "
+            f"in ownership matrix source-only rows ({ownership_matrix_relative}): {pattern}"
+        )
+
+    return errors
+
+
 def validate_docs_edit_link(repo_root: Path, contract: BlueprintContract) -> list[str]:
     errors: list[str] = []
     if not contract.docs_contract.edit_link_enabled:

--- a/scripts/lib/blueprint/contract_validators/docs_sync.py
+++ b/scripts/lib/blueprint/contract_validators/docs_sync.py
@@ -1,9 +1,17 @@
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 from scripts.lib.blueprint.contract_schema import BlueprintContract
 from scripts.lib.blueprint.contract_validators.shared import ContractValidationHelpers
+
+
+def _extract_area_tokens(area_cell: str) -> set[str]:
+    tokens = {match.strip() for match in re.findall(r"`([^`]+)`", area_cell) if match.strip()}
+    if tokens:
+        return tokens
+    return {token.strip() for token in area_cell.split(",") if token.strip()}
 
 
 def validate_source_artifact_prune_globs_documented(repo_root: Path, contract: BlueprintContract) -> list[str]:
@@ -18,7 +26,7 @@ def validate_source_artifact_prune_globs_documented(repo_root: Path, contract: B
     if not ownership_matrix_path.is_file():
         return [f"missing ownership matrix file: {ownership_matrix_relative}"]
 
-    source_only_area_cells: list[str] = []
+    source_only_area_tokens: set[str] = set()
     for line in ownership_matrix_path.read_text(encoding="utf-8").splitlines():
         stripped = line.strip()
         if not stripped.startswith("|"):
@@ -31,16 +39,16 @@ def validate_source_artifact_prune_globs_documented(repo_root: Path, contract: B
         area_cell, ownership_cell = cells[0], cells[1]
         if "source only" not in ownership_cell.lower():
             continue
-        source_only_area_cells.append(area_cell)
+        source_only_area_tokens.update(_extract_area_tokens(area_cell))
 
-    if not source_only_area_cells:
+    if not source_only_area_tokens:
         errors.append(
             "ownership matrix must include at least one 'source only' row for prune-glob documentation checks"
         )
         return errors
 
     for pattern in prune_globs:
-        if any(pattern in area_cell for area_cell in source_only_area_cells):
+        if pattern in source_only_area_tokens:
             continue
         errors.append(
             "repository.consumer_init.source_artifact_prune_globs_on_init pattern must be documented "

--- a/scripts/templates/blueprint/bootstrap/docs/blueprint/governance/ownership_matrix.md
+++ b/scripts/templates/blueprint/bootstrap/docs/blueprint/governance/ownership_matrix.md
@@ -16,7 +16,7 @@ This matrix clarifies which areas are blueprint-managed and which are platform-o
 | `blueprint/repo.init.secrets.env` | Consumer local | Editable, gitignored | Local sensitive overrides loaded after `blueprint/repo.init.env`; explicit shell env still wins. |
 | `blueprint/contract.yaml`, `docs/docusaurus.config.js`, repo identity files under `infra/gitops/argocd/**`, STACKIT tfvars/backend files | Blueprint init-managed in generated repos | Controlled | `make blueprint-init-repo` owns these files. `make blueprint-bootstrap` and `make infra-bootstrap` validate presence but do not recreate them in generated repos. |
 | `tests/blueprint/**`, `tests/docs/**` | Blueprint source only | Controlled | Maintainer-only blueprint contract and docs test suites; pruned from generated repos during first init. |
-| `specs/<YYYY-MM-DD>-*`, `docs/blueprint/architecture/decisions/ADR-*.md` | Blueprint source only | Controlled | Maintainer-only SDD work-item history and blueprint ADR records; pruned from generated repos during first init. |
+| `specs/[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]-*`, `docs/blueprint/architecture/decisions/ADR-*.md` | Blueprint source only | Controlled | Maintainer-only SDD work-item history and blueprint ADR records; pruned from generated repos during first init. |
 | `.github/actions/**` | Blueprint | Controlled | Shared local GitHub Actions support for source and generated-repo CI workflows. |
 | `make/platform.mk`, `make/platform/*.mk` | Platform | Editable | Consumer-facing project targets. |
 | `scripts/bin/platform/**`, `scripts/lib/platform/**` | Platform | Editable | Application/runtime-specific automation (for example `scripts/bin/platform/touchpoints/test_e2e.sh`). |

--- a/specs/2026-04-17-prune-glob-ownership-check/architecture.md
+++ b/specs/2026-04-17-prune-glob-ownership-check/architecture.md
@@ -1,0 +1,43 @@
+# Architecture
+
+## Context
+- Work item: 2026-04-17-prune-glob-ownership-check
+- Owner: sbonoc
+- Date: 2026-04-17
+
+## Stack and Execution Model
+- Backend stack profile: python_plus_fastapi_pydantic_v2
+- Frontend stack profile: vue_router_pinia_onyx
+- Test automation profile: pytest_vitest_playwright_pact
+- Agent execution model: specialized-subagents-isolated-worktrees
+
+## Problem Statement
+- What needs to change and why: prune-glob ownership expectations are currently implicit. Contract patterns can drift from ownership documentation without a hard validation failure.
+- Scope boundaries: contract schema/docs sync contract, contract validation for ownership matrix mapping, ownership matrix content, and supporting tests.
+- Out of scope: runtime provisioning behavior, app delivery flows, and non-doc ownership classes.
+
+## Bounded Contexts and Responsibilities
+- Contract context: declares canonical prune-glob patterns and docs template allowlist.
+- Validation context: validates that prune-glob patterns are documented in source-only ownership rows.
+- Docs sync context: mirrors blueprint docs subset from contract allowlist.
+
+## High-Level Component Design
+- Domain layer: ownership policy and source-only prune semantics.
+- Application layer: contract validator orchestration in `infra-validate`.
+- Infrastructure adapters: markdown table parsing and filesystem checks in docs validator.
+- Presentation/API/workflow boundaries: `make infra-validate` and unittest suites provide deterministic diagnostics.
+
+## Integration and Dependency Edges
+- Upstream dependencies: `blueprint/contract.yaml` (`consumer_init` + `docs_contract`).
+- Downstream dependencies: `scripts/lib/docs/sync_blueprint_template_docs.py`, `scripts/bin/blueprint/validate_contract.py`, docs/tests.
+- Data/API/event contracts touched: markdown docs ownership and contract field parsing only.
+
+## Non-Functional Architecture Notes
+- Security: prune safety hardening blocks path traversal and out-of-root symlink escapes.
+- Observability: validation emits explicit contract error strings for missing docs mapping.
+- Reliability and rollback: checker is deterministic and fail-fast in contract validation lane.
+- Monitoring/alerting: CI contract lanes detect drift before bootstrap/runtime execution.
+
+## Risks and Tradeoffs
+- Risk 1: strict string matching may require frequent docs updates when patterns evolve.
+- Tradeoff 1: explicit contract-to-doc parity is preferred over implicit narrative mapping for deterministic governance.

--- a/specs/2026-04-17-prune-glob-ownership-check/context_pack.md
+++ b/specs/2026-04-17-prune-glob-ownership-check/context_pack.md
@@ -1,0 +1,31 @@
+# Work Item Context Pack
+
+## Context Snapshot
+- Work item: `specs/2026-04-17-prune-glob-ownership-check`
+- Generated at (UTC): `2026-04-17T14:56:18Z`
+- SPEC_READY: `true`
+- ADR path: `docs/blueprint/architecture/decisions/ADR-20260417-prune-glob-ownership-check.md`
+- ADR status: `approved`
+
+## Guardrail Controls
+- Applicable control IDs: `SDD-C-001`, `SDD-C-002`, `SDD-C-003`, `SDD-C-004`, `SDD-C-005`, `SDD-C-006`, `SDD-C-007`, `SDD-C-008`, `SDD-C-009`, `SDD-C-010`, `SDD-C-011`, `SDD-C-012`, `SDD-C-013`, `SDD-C-014`, `SDD-C-015`, `SDD-C-016`, `SDD-C-017`, `SDD-C-018`, `SDD-C-019`, `SDD-C-020`, `SDD-C-021`
+
+## Required Commands
+- `make quality-sdd-check`
+- `make quality-sdd-check-all`
+- `make quality-hooks-run`
+- `make infra-validate`
+- `make docs-build`
+- `make docs-smoke`
+
+## Artifact Index
+- `architecture.md`
+- `spec.md`
+- `plan.md`
+- `tasks.md`
+- `traceability.md`
+- `graph.yaml`
+- `evidence_manifest.json`
+- `context_pack.md`
+- `pr_context.md`
+- `hardening_review.md`

--- a/specs/2026-04-17-prune-glob-ownership-check/evidence_manifest.json
+++ b/specs/2026-04-17-prune-glob-ownership-check/evidence_manifest.json
@@ -1,0 +1,133 @@
+{
+  "manifest_version": 1,
+  "work_item": "specs/2026-04-17-prune-glob-ownership-check",
+  "generated_by": "spec-evidence-manifest",
+  "generated_at_utc": "2026-04-17T14:56:18Z",
+  "files": [
+    {
+      "path": "AGENTS.backlog.md",
+      "sha256": "199694d72db434df69b7853ef315906d5d3255abc7439048341d9c659d5cc4d7",
+      "bytes": 5486
+    },
+    {
+      "path": "AGENTS.decisions.md",
+      "sha256": "696ef1127d109b6490af58e0462ef741545fb2e0ca5ab7eab239e449bd9b9459",
+      "bytes": 38621
+    },
+    {
+      "path": "blueprint/contract.yaml",
+      "sha256": "1bcf385cbf9a9d62c16a0c36176e5c8eedac3231451424ebf5c557bd6fe1f29c",
+      "bytes": 82819
+    },
+    {
+      "path": "docs/blueprint/architecture/decisions/ADR-20260417-prune-glob-ownership-check.md",
+      "sha256": "25d2ad0cc7247c17bea0596a25bf4eddbddd1157aa7dd00147009669eda84bc9",
+      "bytes": 3726
+    },
+    {
+      "path": "docs/blueprint/governance/ownership_matrix.md",
+      "sha256": "6ab838b45d6f22a5b2a6a8463f377c8e7d02db54a4446ab12e7d00fd63e31e7f",
+      "bytes": 3885
+    },
+    {
+      "path": "scripts/bin/blueprint/validate_contract.py",
+      "sha256": "8002aeee97d0356ace9dc74b6ccf24b2f0ccf7c9059c5f4bdb5d315c81eb7fc8",
+      "bytes": 108691
+    },
+    {
+      "path": "scripts/lib/blueprint/contract_schema.py",
+      "sha256": "2a076eb187c62082d8a4604cff5aca9a150a52c3e7a88c8aef1bc5db94f7204d",
+      "bytes": 26908
+    },
+    {
+      "path": "scripts/lib/blueprint/contract_validators/docs_sync.py",
+      "sha256": "e33f64d9e3e260abb223b833fffd179c90e3139700e6597e350a5cce2025297d",
+      "bytes": 9479
+    },
+    {
+      "path": "scripts/lib/blueprint/init_repo_contract.py",
+      "sha256": "4b39ea2c345d0adf5004bd27b82550b8d8dfa844f346a20efa6e46eceec5c7d5",
+      "bytes": 7417
+    },
+    {
+      "path": "scripts/lib/blueprint/init_repo_io.py",
+      "sha256": "da9c8606323e902abc38f81e50a8918e6667e62c4ead28a7d47e4762f831e4d5",
+      "bytes": 1851
+    },
+    {
+      "path": "scripts/lib/docs/sync_blueprint_template_docs.py",
+      "sha256": "3622dca8e0908ab70108ba5430e000146f12ff199972d83212e7b439f0b1a7dc",
+      "bytes": 6696
+    },
+    {
+      "path": "scripts/templates/blueprint/bootstrap/blueprint/contract.yaml",
+      "sha256": "1bcf385cbf9a9d62c16a0c36176e5c8eedac3231451424ebf5c557bd6fe1f29c",
+      "bytes": 82819
+    },
+    {
+      "path": "specs/2026-04-17-prune-glob-ownership-check/architecture.md",
+      "sha256": "b3a29e3069006c0769e5a36f575d12081590164f9ffe30c36da6fb4d5dea4afa",
+      "bytes": 2512
+    },
+    {
+      "path": "specs/2026-04-17-prune-glob-ownership-check/context_pack.md",
+      "sha256": "0619e454d7710792f02f92668d8ef276d44fd3ae77f757834b42c7f26c1c159f",
+      "bytes": 577
+    },
+    {
+      "path": "specs/2026-04-17-prune-glob-ownership-check/evidence_manifest.json",
+      "sha256": "ecb0eea40122794ca8f062212e022ba451f6d0a543b88db3d7c15e65a071e7f7",
+      "bytes": 161
+    },
+    {
+      "path": "specs/2026-04-17-prune-glob-ownership-check/graph.yaml",
+      "sha256": "daba964d95701628b7ee086188e152e6fa74072cb5c92f30885efff11cbe2a57",
+      "bytes": 1800
+    },
+    {
+      "path": "specs/2026-04-17-prune-glob-ownership-check/hardening_review.md",
+      "sha256": "56cfbcffd9a3e208e3caefe2f577fbc8cf72dedab81889738f7c159f835810a4",
+      "bytes": 1421
+    },
+    {
+      "path": "specs/2026-04-17-prune-glob-ownership-check/plan.md",
+      "sha256": "d74b6eb4fcdf633a84c5e0cbecf9981c20d4af09bcb96d2f380995768163ee76",
+      "bytes": 4480
+    },
+    {
+      "path": "specs/2026-04-17-prune-glob-ownership-check/pr_context.md",
+      "sha256": "26b7a261f5f07f472d3d30b255eb9d1b35c3633cb84be062b9e5f461c488d33c",
+      "bytes": 465
+    },
+    {
+      "path": "specs/2026-04-17-prune-glob-ownership-check/spec.md",
+      "sha256": "31dca93811a620f9fdbeb1e173355db34955f5c14f0cf092cfb45cc5d564a444",
+      "bytes": 4639
+    },
+    {
+      "path": "specs/2026-04-17-prune-glob-ownership-check/tasks.md",
+      "sha256": "3555f4782dea2528703d2014586eb4278836eaa8ee2e934394e07b18f3ff9ef6",
+      "bytes": 2225
+    },
+    {
+      "path": "specs/2026-04-17-prune-glob-ownership-check/traceability.md",
+      "sha256": "c5a9882028d8bcf1f2c3e5eb687c91fba3026855ac17ecc37a7992377bde7348",
+      "bytes": 5635
+    },
+    {
+      "path": "tests/blueprint/contract_refactor_docs_cases.py",
+      "sha256": "13773fcf68f6ea697c8adec3400246c6de16cafc67f8b4998c8bab3678270685",
+      "bytes": 31350
+    },
+    {
+      "path": "tests/blueprint/contract_refactor_governance_init_cases.py",
+      "sha256": "31f865a5c8d070bba09dded8e13cfa11d239fb54f79677a22227a25915238248",
+      "bytes": 33700
+    },
+    {
+      "path": "tests/blueprint/test_quality_contracts.py",
+      "sha256": "2e6df863a33431cce88cd3c6dbebe847403416aced2143889c94fb1b6d145e0f",
+      "bytes": 46034
+    }
+  ]
+}

--- a/specs/2026-04-17-prune-glob-ownership-check/graph.yaml
+++ b/specs/2026-04-17-prune-glob-ownership-check/graph.yaml
@@ -1,0 +1,26 @@
+{
+  "graph_version": 1,
+  "work_item": "2026-04-17-prune-glob-ownership-check",
+  "nodes": [
+    {"id": "FR-001", "type": "requirement", "summary": "Use contract docs allowlist as single sync source"},
+    {"id": "FR-002", "type": "requirement", "summary": "Validate prune glob documentation in source-only ownership rows"},
+    {"id": "FR-003", "type": "requirement", "summary": "Mirror allowlisted docs and prune non-allowlisted docs"},
+    {"id": "NFR-SEC-001", "type": "requirement", "summary": "Protect prune flow against unsafe and out-of-root deletes"},
+    {"id": "NFR-OBS-001", "type": "requirement", "summary": "Emit deterministic missing-pattern diagnostics"},
+    {"id": "NFR-REL-001", "type": "requirement", "summary": "Deterministic checker behavior in local contract lanes"},
+    {"id": "NFR-OPS-001", "type": "requirement", "summary": "Keep governance/docs/tests synchronized"},
+    {"id": "AC-001", "type": "acceptance", "summary": "Missing ownership mapping fails validation"},
+    {"id": "AC-002", "type": "acceptance", "summary": "Complete ownership mapping passes validation"},
+    {"id": "AC-003", "type": "acceptance", "summary": "Allowlist mirror includes assistant compatibility doc and parity"}
+  ],
+  "edges": [
+    {"from": "FR-001", "to": "AC-003", "relation": "validated_by"},
+    {"from": "FR-002", "to": "AC-001", "relation": "validated_by"},
+    {"from": "FR-002", "to": "AC-002", "relation": "validated_by"},
+    {"from": "FR-003", "to": "AC-003", "relation": "validated_by"},
+    {"from": "NFR-SEC-001", "to": "AC-001", "relation": "constrains"},
+    {"from": "NFR-OBS-001", "to": "AC-001", "relation": "constrains"},
+    {"from": "NFR-REL-001", "to": "AC-002", "relation": "constrains"},
+    {"from": "NFR-OPS-001", "to": "AC-003", "relation": "constrains"}
+  ]
+}

--- a/specs/2026-04-17-prune-glob-ownership-check/hardening_review.md
+++ b/specs/2026-04-17-prune-glob-ownership-check/hardening_review.md
@@ -1,0 +1,24 @@
+# Hardening Review
+
+## Repository-Wide Findings Fixed
+- Added contract-level docs allowlist field as the single source for blueprint template sync scope.
+- Added contract validation enforcing prune-glob documentation in ownership matrix source-only rows.
+- Hardened init prune deletion path to avoid symlink-following directory removal and out-of-root deletions.
+- Updated ownership matrix to document exact prune glob patterns from contract.
+
+## Observability and Diagnostics Changes
+- Metrics/logging/tracing updates:
+  - no new telemetry series introduced; validation errors are explicit and deterministic in `infra-validate` output.
+- Operational diagnostics updates:
+  - checker reports exact missing prune glob pattern and ownership matrix path.
+
+## Architecture and Code Quality Compliance
+- SOLID / Clean Architecture / Clean Code / DDD checks:
+  - docs ownership validation stays in docs validator module and is composed through existing contract validation delegate boundaries.
+- Test-automation and pyramid checks:
+  - added focused unit/contract tests for checker behavior and prune safety regressions.
+- Documentation/diagram/CI/skill consistency checks:
+  - docs source and bootstrap mirror synchronized through contract allowlist.
+
+## Proposals Only (Not Implemented)
+- Add stricter checker support for semantically-equivalent glob normalization (for example canonicalizing equivalent date-slug patterns).

--- a/specs/2026-04-17-prune-glob-ownership-check/plan.md
+++ b/specs/2026-04-17-prune-glob-ownership-check/plan.md
@@ -1,0 +1,106 @@
+# Implementation Plan
+
+## Implementation Start Gate
+- Implementation is allowed with `SPEC_READY=true` and all sign-offs approved in `spec.md`.
+- Blocker token remains defined but not present in active implementation-ready artifacts.
+
+## Constitution Gates (Pre-Implementation)
+- Simplicity gate:
+  - Reuse existing docs validator delegation path in `validate_contract.py`.
+  - Keep checker scope limited to prune-glob -> source-only ownership matrix mapping.
+- Anti-abstraction gate:
+  - Use lightweight markdown table row parsing in existing docs validator module.
+  - Avoid introducing new tooling or parser dependencies.
+- Integration-first testing gate:
+  - Add targeted validator and regression tests before broad lane runs.
+
+## Delivery Slices
+1. Slice 1: move blueprint docs allowlist source fully into contract and keep docs sync utility contract-driven.
+2. Slice 2: add prune-glob ownership-matrix validator and wire into `infra-validate`.
+3. Slice 3: update ownership matrix exact pattern docs and tests/SDD evidence artifacts.
+
+## Change Strategy
+- Migration/rollout sequence:
+  - update contract/schema and docs sync utility.
+  - add validation delegate + hook into `validate_contract.py`.
+  - sync docs template mirror and update tests.
+- Backward compatibility policy:
+  - no new make targets; existing validation command surfaces remain stable.
+- Rollback plan:
+  - revert new validator and contract/docs edits, then rerun docs sync.
+
+## Validation Strategy (Shift-Left)
+- Unit checks:
+  - `python3 -m unittest tests.blueprint.test_quality_contracts.QualityContractsTests.test_prune_globs_must_be_documented_in_ownership_matrix_source_only_rows`
+  - `python3 -m unittest tests.blueprint.test_quality_contracts.QualityContractsTests.test_init_repo_source_artifact_prune_blocks_unsafe_patterns_and_out_of_root_symlinks`
+- Contract checks:
+  - `python3 -m unittest tests.blueprint.contract_refactor_docs_cases.DocsRefactorCases.test_bootstrap_docs_templates_are_synchronized`
+  - `python3 -m unittest tests.blueprint.contract_refactor_governance_init_cases.GovernanceInitRepoCases.test_blueprint_template_init_assets_exist`
+- Integration checks:
+  - `make quality-docs-check-blueprint-template-sync`
+  - `make infra-validate`
+- E2E checks:
+  - not applicable for this contract/docs-only governance scope.
+
+## App Onboarding Contract (Normative)
+- Required minimum make targets:
+  - `apps-bootstrap`
+  - `apps-smoke`
+  - `backend-test-unit`
+  - `backend-test-integration`
+  - `backend-test-contracts`
+  - `backend-test-e2e`
+  - `touchpoints-test-unit`
+  - `touchpoints-test-integration`
+  - `touchpoints-test-contracts`
+  - `touchpoints-test-e2e`
+  - `test-unit-all`
+  - `test-integration-all`
+  - `test-contracts-all`
+  - `test-e2e-all-local`
+  - `infra-port-forward-start`
+  - `infra-port-forward-stop`
+  - `infra-port-forward-cleanup`
+- App onboarding impact: no-impact
+- Notes: this change is governance/docs validation only.
+
+## Documentation Plan (Document Phase)
+- Blueprint docs updates:
+  - `docs/blueprint/governance/ownership_matrix.md`
+  - `AGENTS.decisions.md`
+- Consumer docs updates:
+  - bootstrap mirror ownership matrix and assistant compatibility docs parity.
+- Mermaid diagrams updated:
+  - captured in work-item ADR.
+- Docs validation commands:
+  - `make quality-docs-check-blueprint-template-sync`
+  - `make docs-build`
+  - `make docs-smoke`
+
+## Publish Preparation
+- PR context file:
+  - `pr_context.md`
+- Hardening review file:
+  - `hardening_review.md`
+- Publish checklist:
+  - include requirement/contract coverage
+  - include key reviewer files
+  - include validation evidence + rollback notes
+
+## Operational Readiness
+- Logging/metrics/traces:
+  - explicit validator error messages for missing ownership matrix pattern mappings.
+- Alerts/ownership:
+  - contract lane failures indicate governance drift ownership.
+- Runbook updates:
+  - no new operational runbook commands required.
+
+## Risks and Mitigations
+- Risk 1: false negatives if ownership matrix structure diverges from expected markdown row format.
+- Mitigation 1: keep checker logic minimal and assert source-only rows exist.
+- Risk 2: docs/contract drift during future pattern updates.
+- Mitigation 2: enforce through contract test assertions and infra-validate gate.
+
+## Rollback Notes
+- Revert this PR commit set and run `python3 scripts/lib/docs/sync_blueprint_template_docs.py` to restore mirror.
+- Re-run `make infra-validate` to confirm rollback clears added checker path.

--- a/specs/2026-04-17-prune-glob-ownership-check/pr_context.md
+++ b/specs/2026-04-17-prune-glob-ownership-check/pr_context.md
@@ -1,0 +1,59 @@
+# PR Context
+
+## Summary
+- Work item: `specs/2026-04-17-prune-glob-ownership-check`
+- Generated at (UTC): `2026-04-17T14:56:18Z`
+- Scope: SDD lifecycle artifact packaging for reviewer handoff.
+
+## Requirement Coverage
+- Requirements (FR/NFR): `FR-001`, `FR-002`, `FR-003`, `NFR-OBS-001`, `NFR-OPS-001`, `NFR-REL-001`, `NFR-SEC-001`
+- Acceptance criteria (AC): `AC-001`, `AC-002`, `AC-003`
+- Traceability IDs present: `AC-001`, `AC-002`, `AC-003`, `FR-001`, `FR-002`, `FR-003`, `NFR-OBS-001`, `NFR-OPS-001`, `NFR-REL-001`, `NFR-SEC-001`
+
+## Key Reviewer Files
+- `AGENTS.backlog.md`
+- `AGENTS.decisions.md`
+- `blueprint/contract.yaml`
+- `docs/blueprint/architecture/decisions/ADR-20260417-prune-glob-ownership-check.md`
+- `docs/blueprint/governance/ownership_matrix.md`
+- `scripts/bin/blueprint/validate_contract.py`
+- `scripts/lib/blueprint/contract_schema.py`
+- `scripts/lib/blueprint/contract_validators/docs_sync.py`
+- `scripts/lib/blueprint/init_repo_contract.py`
+- `scripts/lib/blueprint/init_repo_io.py`
+- `scripts/lib/docs/sync_blueprint_template_docs.py`
+- `scripts/templates/blueprint/bootstrap/blueprint/contract.yaml`
+- `specs/2026-04-17-prune-glob-ownership-check/architecture.md`
+- `specs/2026-04-17-prune-glob-ownership-check/context_pack.md`
+- `specs/2026-04-17-prune-glob-ownership-check/evidence_manifest.json`
+- `specs/2026-04-17-prune-glob-ownership-check/graph.yaml`
+- `specs/2026-04-17-prune-glob-ownership-check/hardening_review.md`
+- `specs/2026-04-17-prune-glob-ownership-check/plan.md`
+- `specs/2026-04-17-prune-glob-ownership-check/pr_context.md`
+- `specs/2026-04-17-prune-glob-ownership-check/spec.md`
+- `specs/2026-04-17-prune-glob-ownership-check/tasks.md`
+- `specs/2026-04-17-prune-glob-ownership-check/traceability.md`
+- `tests/blueprint/contract_refactor_docs_cases.py`
+- `tests/blueprint/contract_refactor_governance_init_cases.py`
+- `tests/blueprint/test_quality_contracts.py`
+
+## Validation Evidence
+- `make docs-build`
+- `make docs-smoke`
+- `make infra-validate`
+- `make quality-hooks-run`
+- `make quality-sdd-check`
+- `make quality-sdd-check-all`
+
+## Risk and Rollback
+- Risk notes:
+  - Risk 1: false negatives if ownership matrix structure diverges from expected markdown row format.
+  - Mitigation 1: keep checker logic minimal and assert source-only rows exist.
+  - Risk 2: docs/contract drift during future pattern updates.
+  - Mitigation 2: enforce through contract test assertions and infra-validate gate.
+- Rollback notes:
+  - Revert this PR commit set and run `python3 scripts/lib/docs/sync_blueprint_template_docs.py` to restore mirror.
+  - Re-run `make infra-validate` to confirm rollback clears added checker path.
+
+## Deferred Proposals
+- Add stricter checker support for semantically-equivalent glob normalization (for example canonicalizing equivalent date-slug patterns).

--- a/specs/2026-04-17-prune-glob-ownership-check/spec.md
+++ b/specs/2026-04-17-prune-glob-ownership-check/spec.md
@@ -1,0 +1,84 @@
+# Specification
+
+## Spec Readiness Gate (Blocking)
+- SPEC_READY: true
+- Open questions count: 0
+- Unresolved alternatives count: 0
+- Unresolved TODO markers count: 0
+- Pending assumptions count: 0
+- Open clarification markers count: 0
+- Product sign-off: approved
+- Architecture sign-off: approved
+- Security sign-off: approved
+- Operations sign-off: approved
+- Missing input blocker token: none
+- ADR path: docs/blueprint/architecture/decisions/ADR-20260417-prune-glob-ownership-check.md
+- ADR status: approved
+
+## Applicable Guardrail Controls (Normative)
+- Applicable control IDs: SDD-C-001, SDD-C-002, SDD-C-003, SDD-C-004, SDD-C-005, SDD-C-006, SDD-C-007, SDD-C-008, SDD-C-009, SDD-C-010, SDD-C-011, SDD-C-012, SDD-C-013, SDD-C-014, SDD-C-015, SDD-C-016, SDD-C-017, SDD-C-018, SDD-C-019, SDD-C-020, SDD-C-021
+- Control exception rationale: none
+
+## Implementation Stack Profile (Normative)
+- Backend stack profile: python_plus_fastapi_pydantic_v2
+- Frontend stack profile: vue_router_pinia_onyx
+- Test automation profile: pytest_vitest_playwright_pact
+- Agent execution model: specialized-subagents-isolated-worktrees
+- Managed service preference: stackit-managed-first
+- Managed service exception rationale: none
+- Runtime profile: local-first-docker-desktop-kubernetes
+- Local Kubernetes context policy: docker-desktop-preferred
+- Local provisioning stack: crossplane-plus-helm
+- Runtime identity baseline: eso-plus-argocd-plus-keycloak
+- Local-first exception rationale: none
+
+## Objective
+- Business outcome: enforce deterministic contract-to-doc ownership parity for source-artifact prune globs while preserving consumer docs integrity and prune safety guarantees.
+- Success metric: `infra-validate` fails when any prune glob is undocumented in source-only ownership rows and passes when contract/doc mapping is complete.
+
+## Normative Requirements
+
+### Functional Requirements (Normative)
+- FR-001: `spec.docs_contract.blueprint_docs.template_sync_allowlist` MUST be the single declarative source for blueprint docs template sync scope.
+- FR-002: `infra-validate` MUST enforce that every `repository.consumer_init.source_artifact_prune_globs_on_init` pattern is documented in source-only rows in `docs/blueprint/governance/ownership_matrix.md`.
+- FR-003: bootstrap template docs mirror MUST include every allowlisted blueprint docs path and MUST prune non-allowlisted template docs.
+
+### Non-Functional Requirements (Normative)
+- NFR-SEC-001: prune logic MUST reject unsafe patterns and MUST skip out-of-root resolved candidates and symlink-following deletes.
+- NFR-OBS-001: contract validation failures MUST include explicit missing-pattern diagnostics.
+- NFR-REL-001: checker behavior MUST be deterministic and independent of external services.
+- NFR-OPS-001: governance docs, validators, and tests MUST remain synchronized in the same change.
+
+## Normative Option Decision
+- Option A: strict contract-to-ownership-matrix parity check with exact pattern documentation.
+- Option B: narrative-only docs guidance with no validation check.
+- Selected option: OPTION_A
+- Rationale: Option A prevents silent drift and makes ownership governance executable.
+
+## Contract Changes (Normative)
+- Config/Env contract: no change.
+- API contract: no change.
+- Event contract: no change.
+- Make/CLI contract: `infra-validate` behavior expands with prune-glob documentation validation.
+- Docs contract: ownership matrix source-only row uses exact prune-glob patterns from contract.
+
+## Blueprint Upstream Defect Escalation (Normative)
+- Upstream issue URL: none
+- Temporary workaround path: none
+- Replacement trigger: none
+- Workaround review date: none
+
+## Normative Acceptance Criteria
+- AC-001: if ownership matrix source-only rows omit any prune-glob pattern from contract, `infra-validate` returns a deterministic error naming the missing pattern.
+- AC-002: if source-only rows document all prune-glob patterns, `infra-validate` passes this check.
+- AC-003: docs sync and docs contract tests keep `assistant_compatibility.md` and ownership matrix in template mirror according to contract allowlist.
+
+## Informative Notes (Non-Normative)
+- Context: this is the follow-up PR after template-boundary enforcement to close the remaining deferred governance gap.
+- Tradeoffs: exact pattern documentation increases maintenance burden but reduces ambiguity.
+- Clarifications:
+  - user requested proceeding with the next remaining PR item on 2026-04-17.
+
+## Explicit Exclusions
+- Excluded item 1: no changes to app runtime or module provisioning logic.
+- Excluded item 2: no additional CI lane split/refactor beyond contract validation checks.

--- a/specs/2026-04-17-prune-glob-ownership-check/tasks.md
+++ b/specs/2026-04-17-prune-glob-ownership-check/tasks.md
@@ -1,0 +1,38 @@
+# Tasks
+
+## Gate Checks (Required Before Implementation)
+- [x] G-001 Confirm `SPEC_READY=true` in `spec.md`
+- [x] G-002 Confirm open questions and unresolved alternatives are `0`
+- [x] G-003 Confirm required sign-offs are approved
+- [x] G-004 Confirm `Applicable Guardrail Controls` section includes `SDD-C-###` IDs
+- [x] G-005 Confirm `Implementation Stack Profile` section is fully populated
+
+## Implementation
+- [x] T-001 Update contract/governance surfaces
+- [x] T-002 Implement runtime/code changes
+- [x] T-003 Update blueprint docs/diagrams
+- [x] T-004 Update consumer-facing docs/diagrams when contracts/behavior change
+
+## Test Automation
+- [x] T-101 Add or update unit tests
+- [x] T-102 Add or update contract tests
+- [x] T-103 Add boundary/integration tests where required
+
+## Validation and Release Readiness
+- [x] T-201 Run required Make validation bundles
+- [x] T-202 Attach evidence to traceability document
+- [x] T-203 Confirm no stale markers/dead code/drift in touched scope
+- [x] T-204 Run documentation validation (`make docs-build` and `make docs-smoke`)
+- [x] T-205 Run hardening review validation bundle (`make quality-hardening-review`)
+
+## Publish
+- [x] P-001 Update `hardening_review.md` with repository-wide findings fixed and proposals-only section
+- [x] P-002 Update `pr_context.md` with requirement/contract coverage, key reviewer files, validation evidence, and rollback notes
+- [x] P-003 Ensure PR description follows repository template headings and references `pr_context.md`
+
+## App Onboarding Minimum Targets (Normative)
+- [x] A-001 `apps-bootstrap` and `apps-smoke` remain available for affected app scope
+- [x] A-002 Backend app lanes (`backend-test-unit`, `backend-test-integration`, `backend-test-contracts`, `backend-test-e2e`) remain available
+- [x] A-003 Frontend app lanes (`touchpoints-test-unit`, `touchpoints-test-integration`, `touchpoints-test-contracts`, `touchpoints-test-e2e`) remain available
+- [x] A-004 Aggregate gates (`test-unit-all`, `test-integration-all`, `test-contracts-all`, `test-e2e-all-local`) remain available
+- [x] A-005 Port-forward operational wrappers (`infra-port-forward-start`, `infra-port-forward-stop`, `infra-port-forward-cleanup`) remain available

--- a/specs/2026-04-17-prune-glob-ownership-check/traceability.md
+++ b/specs/2026-04-17-prune-glob-ownership-check/traceability.md
@@ -1,0 +1,52 @@
+# Traceability Matrix
+
+## Requirement-to-Delivery Mapping
+
+| Requirement ID | Control IDs | Design Element | Implementation Path(s) | Test Evidence | Documentation Evidence | Operational Evidence |
+|---|---|---|---|---|---|---|
+| FR-001 | SDD-C-005, SDD-C-017 | Contract-backed docs allowlist source | `blueprint/contract.yaml`; `scripts/templates/blueprint/bootstrap/blueprint/contract.yaml`; `scripts/lib/blueprint/contract_schema.py`; `scripts/lib/docs/sync_blueprint_template_docs.py` | `tests/blueprint/test_quality_contracts.py::test_blueprint_docs_template_sync_prunes_source_only_docs`; `tests/blueprint/contract_refactor_governance_init_cases.py` | `docs/blueprint/governance/ownership_matrix.md`; template mirror docs | `make quality-docs-check-blueprint-template-sync` |
+| FR-002 | SDD-C-005, SDD-C-012 | Prune-glob documentation checker in contract validation lane | `scripts/lib/blueprint/contract_validators/docs_sync.py`; `scripts/bin/blueprint/validate_contract.py` | `tests/blueprint/test_quality_contracts.py::test_prune_globs_must_be_documented_in_ownership_matrix_source_only_rows`; `tests/blueprint/contract_refactor_docs_cases.py` | `docs/blueprint/governance/ownership_matrix.md` | `make infra-validate` |
+| FR-003 | SDD-C-017 | Bootstrap docs mirror parity from contract allowlist | `scripts/lib/docs/sync_blueprint_template_docs.py`; `scripts/templates/blueprint/bootstrap/docs/blueprint/governance/assistant_compatibility.md` | `tests/blueprint/contract_refactor_docs_cases.py`; `tests/blueprint/test_quality_contracts.py::test_blueprint_docs_template_sync_prunes_source_only_docs` | `docs/README.md`; `docs/blueprint/README.md`; `docs/blueprint/governance/spec_driven_development.md` | `make quality-docs-check-blueprint-template-sync` |
+| NFR-SEC-001 | SDD-C-009 | Safe prune behavior hardening | `scripts/lib/blueprint/init_repo_contract.py`; `scripts/lib/blueprint/init_repo_io.py` | `tests/blueprint/test_quality_contracts.py::test_init_repo_source_artifact_prune_blocks_unsafe_patterns_and_out_of_root_symlinks` | `spec.md` normative section | `make infra-validate` |
+| NFR-OBS-001 | SDD-C-010 | Explicit contract validation diagnostics | `scripts/lib/blueprint/contract_validators/docs_sync.py` | `tests/blueprint/test_quality_contracts.py::test_prune_globs_must_be_documented_in_ownership_matrix_source_only_rows` | `hardening_review.md` | `make infra-validate` |
+| NFR-REL-001 | SDD-C-011 | Deterministic local validation path | `scripts/bin/blueprint/validate_contract.py` | `tests/blueprint/contract_refactor_docs_cases.py` | `plan.md` validation strategy | `make infra-validate` |
+| NFR-OPS-001 | SDD-C-018 | Governance/docs/tests synchronization | `AGENTS.decisions.md`; `docs/blueprint/governance/ownership_matrix.md`; `tests/blueprint/**` | `tests/blueprint/contract_refactor_docs_cases.py`; `tests/blueprint/contract_refactor_governance_init_cases.py` | `pr_context.md` | `make quality-hardening-review` |
+| AC-001 | SDD-C-012 | Missing pattern detection | `scripts/lib/blueprint/contract_validators/docs_sync.py` | `tests/blueprint/test_quality_contracts.py::test_prune_globs_must_be_documented_in_ownership_matrix_source_only_rows` | `spec.md` acceptance criteria | `make infra-validate` |
+| AC-002 | SDD-C-012 | Complete pattern mapping success path | `scripts/lib/blueprint/contract_validators/docs_sync.py` | `tests/blueprint/test_quality_contracts.py::test_prune_globs_must_be_documented_in_ownership_matrix_source_only_rows` | `spec.md` acceptance criteria | `make infra-validate` |
+| AC-003 | SDD-C-012 | Allowlist-driven mirror parity | `scripts/lib/docs/sync_blueprint_template_docs.py`; template docs mirror | `tests/blueprint/contract_refactor_docs_cases.py`; `tests/blueprint/test_quality_contracts.py::test_blueprint_docs_template_sync_prunes_source_only_docs` | `docs/blueprint/governance/assistant_compatibility.md` | `make quality-docs-check-blueprint-template-sync` |
+
+## Graph Linkage
+- Graph file: `graph.yaml`
+- Every `FR-###`, `NFR-*-###`, and `AC-###` listed in this file has a corresponding node in `graph.yaml`.
+- Node IDs referenced:
+  - FR-001
+  - FR-002
+  - FR-003
+  - NFR-SEC-001
+  - NFR-OBS-001
+  - NFR-REL-001
+  - NFR-OPS-001
+  - AC-001
+  - AC-002
+  - AC-003
+
+## Validation Summary
+- Required bundles executed:
+  - `python3 -m unittest tests.blueprint.test_quality_contracts.QualityContractsTests.test_prune_globs_must_be_documented_in_ownership_matrix_source_only_rows tests.blueprint.test_quality_contracts.QualityContractsTests.test_blueprint_docs_template_sync_prunes_source_only_docs tests.blueprint.test_quality_contracts.QualityContractsTests.test_init_repo_source_artifact_prune_blocks_unsafe_patterns_and_out_of_root_symlinks tests.blueprint.contract_refactor_docs_cases.DocsRefactorCases.test_bootstrap_docs_templates_are_synchronized tests.blueprint.contract_refactor_governance_init_cases.GovernanceInitRepoCases.test_blueprint_template_init_assets_exist`
+  - `make quality-docs-check-blueprint-template-sync`
+  - `make quality-sdd-check`
+  - `make quality-hardening-review`
+  - `make infra-validate`
+- Result summary: all commands listed above passed on branch `codex/2026-04-17-prune-glob-ownership-check`.
+- Documentation validation:
+  - `make docs-build`
+  - `make docs-smoke`
+
+## Evidence Manifest
+- Manifest file: `evidence_manifest.json`
+- Context export: `context_pack.md`
+- PR context export: `pr_context.md`
+- Hardening review export: `hardening_review.md`
+
+## Open Risks and Follow-Ups
+- Follow-up 1: add normalization guidance for future glob-pattern formatting so ownership docs checker remains resilient to equivalent pattern variants.

--- a/tests/blueprint/contract_refactor_docs_cases.py
+++ b/tests/blueprint/contract_refactor_docs_cases.py
@@ -33,6 +33,12 @@ class DocsRefactorCases(RefactorContractBase):
                 (template_root / rel_path).read_text(encoding="utf-8"),
                 msg=f"bootstrap template drift for {rel_path}",
             )
+        contract_lines = _read("blueprint/contract.yaml").splitlines()
+        consumer_init = _extract_yaml_section(contract_lines, "consumer_init")
+        prune_globs = _extract_yaml_list(consumer_init, "source_artifact_prune_globs_on_init")
+        ownership_matrix = _read("docs/blueprint/governance/ownership_matrix.md")
+        for prune_glob in prune_globs:
+            self.assertIn(prune_glob, ownership_matrix)
         self.assertFalse(
             (template_root / "docs/blueprint/architecture/decisions/ADR-20260417-sdd-default-enforcement.md").exists()
         )
@@ -98,6 +104,7 @@ class DocsRefactorCases(RefactorContractBase):
         self.assertIn('"docs/platform/consumer/app_onboarding.md"', bootstrap)
         self.assertIn("if [[ -f \"$path\" ]]; then", bootstrap_lib)
         self.assertIn("_validate_platform_docs_seed_contract", validate_py)
+        self.assertIn("_validate_source_artifact_prune_globs_documented", validate_py)
         self.assertNotIn('"docs/platform/consumer/quickstart.md",', validate_py)
         platform_readme = _read("docs/platform/README.md")
         self.assertIn("[Event Messaging Baseline](consumer/event_messaging_baseline.md)", platform_readme)

--- a/tests/blueprint/test_quality_contracts.py
+++ b/tests/blueprint/test_quality_contracts.py
@@ -494,6 +494,48 @@ class QualityContractsTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
         self.assertIn("resolve_repo_root", _read("scripts/lib/docs/sync_blueprint_template_docs.py"))
 
+    def test_prune_globs_must_be_documented_in_ownership_matrix_source_only_rows(self) -> None:
+        from scripts.lib.blueprint.contract_schema import load_blueprint_contract
+        from scripts.lib.blueprint.contract_validators.docs_sync import validate_source_artifact_prune_globs_documented
+
+        contract_text = _read("blueprint/contract.yaml")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_root = Path(tmpdir)
+            contract_path = repo_root / "blueprint/contract.yaml"
+            contract_path.parent.mkdir(parents=True, exist_ok=True)
+            contract_path.write_text(contract_text, encoding="utf-8")
+
+            ownership_path = repo_root / "docs/blueprint/governance/ownership_matrix.md"
+            ownership_path.parent.mkdir(parents=True, exist_ok=True)
+            ownership_path.write_text(
+                (
+                    "| Area | Ownership | Edit Mode | Notes |\n"
+                    "|---|---|---|---|\n"
+                    "| `docs/blueprint/architecture/decisions/ADR-*.md` | Blueprint source only | Controlled | test |\n"
+                ),
+                encoding="utf-8",
+            )
+
+            contract = load_blueprint_contract(contract_path)
+            errors = validate_source_artifact_prune_globs_documented(repo_root, contract)
+            self.assertTrue(
+                any("source_artifact_prune_globs_on_init pattern must be documented" in error for error in errors),
+                msg=f"expected ownership matrix documentation error, got: {errors}",
+            )
+
+            ownership_path.write_text(
+                (
+                    "| Area | Ownership | Edit Mode | Notes |\n"
+                    "|---|---|---|---|\n"
+                    "| `specs/[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]-*`, "
+                    "`docs/blueprint/architecture/decisions/ADR-*.md` | "
+                    "Blueprint source only | Controlled | test |\n"
+                ),
+                encoding="utf-8",
+            )
+            errors = validate_source_artifact_prune_globs_documented(repo_root, contract)
+            self.assertEqual(errors, [])
+
     def test_blueprint_docs_template_sync_prunes_source_only_docs(self) -> None:
         checker = REPO_ROOT / "scripts/lib/docs/sync_blueprint_template_docs.py"
         spec = importlib.util.spec_from_file_location("sync_blueprint_template_docs_module", checker)

--- a/tests/blueprint/test_quality_contracts.py
+++ b/tests/blueprint/test_quality_contracts.py
@@ -527,6 +527,22 @@ class QualityContractsTests(unittest.TestCase):
                 (
                     "| Area | Ownership | Edit Mode | Notes |\n"
                     "|---|---|---|---|\n"
+                    "| `foo/specs/[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]-*.bak`, "
+                    "`docs/blueprint/architecture/decisions/ADR-*.md` | "
+                    "Blueprint source only | Controlled | test |\n"
+                ),
+                encoding="utf-8",
+            )
+            errors = validate_source_artifact_prune_globs_documented(repo_root, contract)
+            self.assertTrue(
+                any("source_artifact_prune_globs_on_init pattern must be documented" in error for error in errors),
+                msg=f"expected exact-token ownership matrix documentation error, got: {errors}",
+            )
+
+            ownership_path.write_text(
+                (
+                    "| Area | Ownership | Edit Mode | Notes |\n"
+                    "|---|---|---|---|\n"
                     "| `specs/[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]-*`, "
                     "`docs/blueprint/architecture/decisions/ADR-*.md` | "
                     "Blueprint source only | Controlled | test |\n"


### PR DESCRIPTION
## Summary
- Implement the deferred follow-up from the previous template-boundary work: enforce prune-glob ownership documentation as executable contract validation.
- Added a docs validator that checks every `repository.consumer_init.source_artifact_prune_globs_on_init` pattern is documented in source-only rows of `docs/blueprint/governance/ownership_matrix.md`.
- Added a new ADR and full SDD work-item artifacts under `specs/2026-04-17-prune-glob-ownership-check/`.

## Requirement and Contract Coverage
- Requirement IDs covered: `FR-001`, `FR-002`, `FR-003`, `NFR-SEC-001`, `NFR-OBS-001`, `NFR-REL-001`, `NFR-OPS-001`
- Acceptance criteria covered: `AC-001`, `AC-002`, `AC-003`
- Contract surfaces changed:
  - [ ] `blueprint/contract.yaml` changed
  - [x] docs/templates/tests were synchronized
  - [x] generated consumer behavior changed

## Key Reviewer Files
- Primary files to review first:
  - `scripts/lib/blueprint/contract_validators/docs_sync.py`
  - `scripts/bin/blueprint/validate_contract.py`
  - `docs/blueprint/governance/ownership_matrix.md`
  - `tests/blueprint/test_quality_contracts.py`
  - `specs/2026-04-17-prune-glob-ownership-check/spec.md`
  - `specs/2026-04-17-prune-glob-ownership-check/traceability.md`
- High-risk files:
  - `scripts/lib/blueprint/contract_validators/docs_sync.py`
  - `scripts/bin/blueprint/validate_contract.py`

## Validation Evidence
- Passed:
  - `python3 -m unittest tests.blueprint.test_quality_contracts.QualityContractsTests.test_prune_globs_must_be_documented_in_ownership_matrix_source_only_rows tests.blueprint.test_quality_contracts.QualityContractsTests.test_blueprint_docs_template_sync_prunes_source_only_docs tests.blueprint.test_quality_contracts.QualityContractsTests.test_init_repo_source_artifact_prune_blocks_unsafe_patterns_and_out_of_root_symlinks tests.blueprint.contract_refactor_docs_cases.DocsRefactorCases.test_bootstrap_docs_templates_are_synchronized tests.blueprint.contract_refactor_governance_init_cases.GovernanceInitRepoCases.test_blueprint_template_init_assets_exist`
  - `make quality-docs-check-blueprint-template-sync`
  - `make quality-sdd-check`
  - `make quality-hardening-review`
  - `make infra-validate`
- Artifacts:
  - `specs/2026-04-17-prune-glob-ownership-check/evidence_manifest.json`
  - `specs/2026-04-17-prune-glob-ownership-check/context_pack.md`
  - `specs/2026-04-17-prune-glob-ownership-check/pr_context.md`
  - `specs/2026-04-17-prune-glob-ownership-check/hardening_review.md`

## Risk and Rollback
- Main risk(s):
  - checker currently relies on stable markdown table structure and exact pattern matching.
- Rollback strategy:
  - revert this commit set and rerun `make infra-validate` plus docs sync checks.

## Deferred Proposals (Not Implemented)
- add normalized matching for semantically-equivalent glob expressions in ownership docs checker.

## Follow-Up
- backlog item added: ownership checker robustness for equivalent-glob normalization.