### PR TITLE
Issue #102: preflight checklist for missing required consumer Make targets

### DIFF
--- a/AGENTS.backlog.md
+++ b/AGENTS.backlog.md
@@ -2,7 +2,7 @@
 
 ## Current Priorities
 - [x] P0 (SDD UX): Issue #138 — local smoke + positive-path filter/transform guardrails are now enforced in SDD templates/governance, including red->green translation for reproducible pre-PR findings.
-- [ ] P0 (Upgrade preflight ergonomics): Issue #102 — detect missing consumer-owned required Make targets in preflight with explicit remediation guidance.
+- [x] P0 (Upgrade preflight ergonomics): Issue #102 — detect missing consumer-owned required Make targets in preflight with explicit remediation guidance.
 - [ ] P0 (Upgrade validation determinism): Issue #129 — add repo-mode-aware required-file reconciliation checks and deterministic remediation hints.
 - [ ] P1 (Upgrade convergence safety): Issue #128 — add ownership-aware reconcile report artifact and `blueprint-upgrade-consumer-postcheck` gate.
 - [ ] P1 (Fixture-contract hardening): Issue #130 — enforce optional-module `required_env` fixture parity in fast infra contract checks.

--- a/AGENTS.decisions.md
+++ b/AGENTS.decisions.md
@@ -141,6 +141,7 @@
   - `apps-ci-bootstrap-consumer` is now a generated-consumer fail-fast placeholder in `make/platform.mk`; blueprint no longer assumes consumer app paths for dependency install.
   - generated-consumer maintainers must replace that target with deterministic repository-specific dependency bootstrap commands; template-source mode skips the placeholder to keep source CI deterministic.
   - upgrade planning/preflight now emits required-manual-action diagnostics when platform-owned Make targets required by blueprint CI surfaces (for example `apps-ci-bootstrap`) are missing in generated-consumer repositories.
+  - upgrade planning/preflight now also emits required-manual-action diagnostics for contract-required consumer-owned Make targets even when no known invoker path is present, using deterministic fallback dependency context (`blueprint/contract.yaml: spec.make_contract.required_targets -> <target>`) and location guidance (`make/platform.mk` or `make/platform/*.mk`).
 - Helm chart pin coverage is guarded against repo-prefix drift:
   - tests assert every non-OCI chart pin in `infra/audit_version.sh` has a matching repo-prefix mapping in `scripts/lib/infra/tooling.sh`.
 - Async message-contract testing is an opt-in Pact contract lane:

--- a/docs/blueprint/architecture/decisions/ADR-20260417-upgrade-preflight-required-make-target-checklist.md
+++ b/docs/blueprint/architecture/decisions/ADR-20260417-upgrade-preflight-required-make-target-checklist.md
@@ -1,0 +1,85 @@
+# ADR-20260417-upgrade-preflight-required-make-target-checklist: Enforce preflight checklist coverage for missing required consumer-owned Make targets
+
+## Metadata
+- Status: approved
+- Date: 2026-04-17
+- Owners: sbonoc
+- Related spec path: specs/2026-04-17-upgrade-preflight-required-make-target-checklist/
+
+## Business Objective and Requirement Summary
+- Business objective: surface missing required consumer-owned Make targets during upgrade preflight instead of late validation stages.
+- Functional requirements summary:
+  - detect all contract-required missing consumer-owned targets from source platform make surfaces.
+  - include deterministic dependency context even when no known invoker reference exists.
+  - include explicit location guidance for where missing targets must be defined.
+- Non-functional requirements summary:
+  - preserve deterministic report structures and existing placeholder safeguards.
+  - avoid schema-breaking changes or new privileged operations.
+- Desired timeline: P0 Issue #102 implementation in current sprint.
+
+## Decision Drivers
+- Driver 1: generated-consumer upgrades currently fail late when required consumer-owned targets are absent.
+- Driver 2: operators need deterministic, early remediation guidance in preflight artifacts.
+
+## Options Considered
+- Option A: keep invoker-reference-only detection (status quo).
+- Option B: include contract-fallback missing-target detection for source-defined required consumer-owned targets.
+
+## Recommended Option
+- Selected option: Option B
+- Rationale: Option B converts late-stage failures into actionable preflight checklist items and aligns with upgrade ergonomics expectations.
+
+## Rejected Options
+- Rejected option 1: Option A
+- Rejection rationale: misses newly introduced required targets that are not yet referenced by known invoker paths.
+
+## Affected Capabilities and Components
+- Capability impact:
+  - upgrade preflight completeness for consumer-owned Make target readiness.
+  - deterministic remediation guidance in manual-action diagnostics.
+- Component impact:
+  - `scripts/lib/blueprint/upgrade_consumer.py`
+  - `tests/blueprint/test_upgrade_consumer.py`
+  - `docs/platform/consumer/quickstart.md`
+  - `docs/platform/consumer/troubleshooting.md`
+
+## Architecture Diagram (Mermaid)
+```mermaid
+flowchart LR
+  C[blueprint/contract.yaml required_targets] --> P[upgrade_consumer planner]
+  M[source make/platform*.mk target definitions] --> P
+  T[target make/platform*.mk definitions] --> P
+  P --> A[required_manual_actions with dependency context]
+  A --> R[upgrade_preflight.json]
+  A --> S[upgrade_summary.md]
+```
+
+## High-Level Work Packages and Timeline (Mermaid Gantt)
+```mermaid
+gantt
+  title Upgrade Preflight Required-Target Checklist
+  dateFormat  YYYY-MM-DD
+  section Work Packages
+  Discover/Architecture/Specify/Plan :a1, 2026-04-17, 1d
+  Red regression test + planner implementation :a2, after a1, 1d
+  Docs sync + validation + publish artifacts :a3, after a2, 1d
+```
+
+## External Dependencies
+- Dependency 1: `blueprint/contract.yaml` required-target and ownership metadata.
+- Dependency 2: existing upgrade report/preflight consumers (`upgrade_preflight.py`, readiness doctor, summary parser flows).
+
+## Risks and Mitigations
+- Risk 1: manual-action count increases for legacy repos with broad make-target drift.
+- Mitigation 1: include exact target names, deterministic locations, and canonical follow-up command.
+- Risk 2: docs template drift after consumer docs update.
+- Mitigation 2: run docs sync check and keep mirrored template docs in sync.
+
+## Validation and Observability Expectations
+- Validation requirements:
+  - `python3 -m unittest tests.blueprint.test_upgrade_consumer`
+  - `python3 -m unittest tests.blueprint.test_upgrade_preflight`
+  - `python3 scripts/lib/docs/sync_blueprint_template_docs.py --check`
+  - `make quality-hooks-fast`
+- Logging/metrics/tracing requirements:
+  - no runtime telemetry additions; required-manual-action reporting remains deterministic and machine-readable.

--- a/docs/platform/consumer/quickstart.md
+++ b/docs/platform/consumer/quickstart.md
@@ -56,10 +56,12 @@ BLUEPRINT_UPGRADE_REF=<tag|branch|commit> BLUEPRINT_UPGRADE_APPLY=true make blue
 make blueprint-upgrade-consumer-validate
 ```
 Use the preflight report `artifacts/blueprint/upgrade_preflight.json` to inspect auto-apply candidates,
-manual-merge/conflict paths, and required follow-up commands before apply mode.
+manual-merge/conflict paths, required follow-up commands, and missing contract-required consumer-owned Make targets before apply mode.
 Inspect `artifacts/blueprint/upgrade_plan.json`, `artifacts/blueprint/upgrade_apply.json`, and
 `artifacts/blueprint/upgrade_summary.md` after each run. When `required_manual_actions` is non-empty,
-resolve the listed platform-owned dependency paths first, then re-run `make blueprint-upgrade-consumer-validate`.
+resolve the listed dependency paths first, then re-run `make blueprint-upgrade-consumer-validate`.
+For missing required consumer-owned Make targets, define the target in `make/platform.mk` or linked includes under `make/platform/*.mk`
+using the exact target name from the manual-action reason.
 When `LOCAL_POST_DEPLOY_HOOK_ENABLED=true`, preflight also flags a blocking manual action if
 `infra-post-deploy-consumer` is still placeholder in `make/platform.mk`.
 Set `BLUEPRINT_UPGRADE_SOURCE` when the blueprint source repository differs from your default `origin` remote.

--- a/docs/platform/consumer/troubleshooting.md
+++ b/docs/platform/consumer/troubleshooting.md
@@ -260,6 +260,7 @@ Common first-day issues for generated repositories.
   - `status=failure reason=command_failed`: hook command failed; with `LOCAL_POST_DEPLOY_HOOK_REQUIRED=false` chain continues, with `true` it fails fast.
 - In generated-consumer repositories, implement deterministic commands in `make/platform.mk` target `infra-post-deploy-consumer` (the seeded target is an intentional fail-fast placeholder until you replace it).
 - Upgrade preflight guardrail: when `LOCAL_POST_DEPLOY_HOOK_ENABLED=true`, `make blueprint-upgrade-consumer-preflight` reports a required manual action if `infra-post-deploy-consumer` is still placeholder.
+- Upgrade preflight required-target checklist: when a contract-required consumer-owned Make target is missing, preflight reports a required manual action with the exact target name; implement it in `make/platform.mk` or `make/platform/*.mk`, then rerun `make blueprint-upgrade-consumer-validate`.
 
 ## CI test lanes fail on clean runners with missing `fastapi`, `vitest`, or Playwright browsers
 - Ensure your workflow uses `.github/actions/prepare-blueprint-ci/action.yml` before test lanes.

--- a/scripts/lib/blueprint/upgrade_consumer.py
+++ b/scripts/lib/blueprint/upgrade_consumer.py
@@ -692,7 +692,9 @@ def _collect_platform_make_paths(root: Path, contract: BlueprintContract) -> lis
     if editable_include_dir:
         include_root = root / editable_include_dir
         if include_root.is_dir():
-            for include_file in sorted(include_root.rglob("*.mk")):
+            # Keep discovery aligned with root Makefile include contract:
+            # -include $(wildcard $(PLATFORM_MAKEFILES_DIR)/*.mk)
+            for include_file in sorted(include_root.glob("*.mk")):
                 if not include_file.is_file():
                     continue
                 rel_path = include_file.relative_to(root).as_posix()

--- a/scripts/lib/blueprint/upgrade_consumer.py
+++ b/scripts/lib/blueprint/upgrade_consumer.py
@@ -781,6 +781,19 @@ def _source_make_target_reference(source_repo: Path, target_name: str) -> str | 
     return None
 
 
+def _platform_make_location_hint(contract: BlueprintContract) -> str:
+    ownership = contract.make_contract.ownership
+    platform_makefile = ownership.platform_editable_file.strip()
+    include_dir = ownership.platform_editable_include_dir.strip()
+    if platform_makefile and include_dir:
+        return f"`{platform_makefile}` or linked includes under `{include_dir}/*.mk`"
+    if platform_makefile:
+        return f"`{platform_makefile}`"
+    if include_dir:
+        return f"linked includes under `{include_dir}/*.mk`"
+    return "platform-owned make surfaces"
+
+
 def _collect_missing_platform_make_target_actions(
     repo_root: Path,
     source_repo: Path,
@@ -796,6 +809,7 @@ def _collect_missing_platform_make_target_actions(
     target_targets = set(target_target_definitions.keys())
     required_targets = set(source_scope_contract.make_contract.required_targets)
     platform_makefile = contract.make_contract.ownership.platform_editable_file
+    location_hint = _platform_make_location_hint(contract)
 
     actions: list[RequiredManualAction] = []
     for target_name in sorted(source_target_definitions.keys()):
@@ -804,15 +818,24 @@ def _collect_missing_platform_make_target_actions(
         if target_name in target_targets:
             continue
         reference_path = _source_make_target_reference(source_repo, target_name)
-        if reference_path is None:
-            continue
+        dependency_of = (
+            f"{reference_path}: make {target_name}"
+            if reference_path is not None
+            else f"blueprint/contract.yaml: spec.make_contract.required_targets -> {target_name}"
+        )
+        reference_reason = (
+            f"; `{reference_path}` invokes it and validation will fail until the target is added"
+            if reference_path is not None
+            else "; contract validation enforces this target for generated-consumer repositories"
+        )
         actions.append(
             RequiredManualAction(
                 dependency_path=platform_makefile,
-                dependency_of=f"{reference_path}: make {target_name}",
+                dependency_of=dependency_of,
                 reason=(
-                    f"required make target `{target_name}` is missing from platform-owned make surfaces; "
-                    f"{reference_path} invokes it and validation will fail until the target is added"
+                    f"required make target `{target_name}` is missing from consumer-owned platform make surfaces; "
+                    f"define `{target_name}` in {location_hint} before running upgrade validation"
+                    f"{reference_reason}"
                 ),
                 required_follow_up_commands=("make blueprint-upgrade-consumer-validate",),
             )
@@ -830,7 +853,7 @@ def _collect_missing_platform_make_target_actions(
                     reason=(
                         f"required consumer-owned make target `{APPS_CI_BOOTSTRAP_CONSUMER_TARGET}` is missing; "
                         f"`{APPS_CI_BOOTSTRAP_TARGET}` invokes it and CI dependency bootstrap cannot be completed "
-                        "until the target is implemented"
+                        f"until the target is implemented; define it in {location_hint}"
                     ),
                     required_follow_up_commands=("make blueprint-upgrade-consumer-validate",),
                 )
@@ -845,7 +868,8 @@ def _collect_missing_platform_make_target_actions(
                     dependency_of=bootstrap_dependency_of,
                     reason=(
                         f"required consumer-owned make target `{APPS_CI_BOOTSTRAP_CONSUMER_TARGET}` is still "
-                        "placeholder; replace it with deterministic repository-specific dependency bootstrap commands"
+                        "placeholder; replace it with deterministic repository-specific dependency bootstrap commands "
+                        f"in {location_hint}"
                     ),
                     required_follow_up_commands=("make blueprint-upgrade-consumer-validate",),
                 )
@@ -868,7 +892,7 @@ def _collect_missing_platform_make_target_actions(
                     reason=(
                         f"required consumer-owned make target `{LOCAL_POST_DEPLOY_HOOK_CONSUMER_TARGET}` is missing "
                         f"while {LOCAL_POST_DEPLOY_HOOK_ENABLE_FLAG}=true; "
-                        f"{LOCAL_POST_DEPLOY_HOOK_COMMAND_ENV} invokes it by default"
+                        f"{LOCAL_POST_DEPLOY_HOOK_COMMAND_ENV} invokes it by default; define it in {location_hint}"
                     ),
                     required_follow_up_commands=("make blueprint-upgrade-consumer-validate",),
                 )
@@ -884,7 +908,7 @@ def _collect_missing_platform_make_target_actions(
                     reason=(
                         f"required consumer-owned make target `{LOCAL_POST_DEPLOY_HOOK_CONSUMER_TARGET}` is still "
                         f"placeholder while {LOCAL_POST_DEPLOY_HOOK_ENABLE_FLAG}=true; replace it with deterministic "
-                        "repository-specific post-deploy reconciliation commands"
+                        f"repository-specific post-deploy reconciliation commands in {location_hint}"
                     ),
                     required_follow_up_commands=("make blueprint-upgrade-consumer-validate",),
                 )

--- a/scripts/templates/blueprint/bootstrap/docs/platform/consumer/quickstart.md
+++ b/scripts/templates/blueprint/bootstrap/docs/platform/consumer/quickstart.md
@@ -56,10 +56,12 @@ BLUEPRINT_UPGRADE_REF=<tag|branch|commit> BLUEPRINT_UPGRADE_APPLY=true make blue
 make blueprint-upgrade-consumer-validate
 ```
 Use the preflight report `artifacts/blueprint/upgrade_preflight.json` to inspect auto-apply candidates,
-manual-merge/conflict paths, and required follow-up commands before apply mode.
+manual-merge/conflict paths, required follow-up commands, and missing contract-required consumer-owned Make targets before apply mode.
 Inspect `artifacts/blueprint/upgrade_plan.json`, `artifacts/blueprint/upgrade_apply.json`, and
 `artifacts/blueprint/upgrade_summary.md` after each run. When `required_manual_actions` is non-empty,
-resolve the listed platform-owned dependency paths first, then re-run `make blueprint-upgrade-consumer-validate`.
+resolve the listed dependency paths first, then re-run `make blueprint-upgrade-consumer-validate`.
+For missing required consumer-owned Make targets, define the target in `make/platform.mk` or linked includes under `make/platform/*.mk`
+using the exact target name from the manual-action reason.
 When `LOCAL_POST_DEPLOY_HOOK_ENABLED=true`, preflight also flags a blocking manual action if
 `infra-post-deploy-consumer` is still placeholder in `make/platform.mk`.
 Set `BLUEPRINT_UPGRADE_SOURCE` when the blueprint source repository differs from your default `origin` remote.

--- a/scripts/templates/blueprint/bootstrap/docs/platform/consumer/troubleshooting.md
+++ b/scripts/templates/blueprint/bootstrap/docs/platform/consumer/troubleshooting.md
@@ -260,6 +260,7 @@ Common first-day issues for generated repositories.
   - `status=failure reason=command_failed`: hook command failed; with `LOCAL_POST_DEPLOY_HOOK_REQUIRED=false` chain continues, with `true` it fails fast.
 - In generated-consumer repositories, implement deterministic commands in `make/platform.mk` target `infra-post-deploy-consumer` (the seeded target is an intentional fail-fast placeholder until you replace it).
 - Upgrade preflight guardrail: when `LOCAL_POST_DEPLOY_HOOK_ENABLED=true`, `make blueprint-upgrade-consumer-preflight` reports a required manual action if `infra-post-deploy-consumer` is still placeholder.
+- Upgrade preflight required-target checklist: when a contract-required consumer-owned Make target is missing, preflight reports a required manual action with the exact target name; implement it in `make/platform.mk` or `make/platform/*.mk`, then rerun `make blueprint-upgrade-consumer-validate`.
 
 ## CI test lanes fail on clean runners with missing `fastapi`, `vitest`, or Playwright browsers
 - Ensure your workflow uses `.github/actions/prepare-blueprint-ci/action.yml` before test lanes.

--- a/specs/2026-04-17-upgrade-preflight-required-make-target-checklist/architecture.md
+++ b/specs/2026-04-17-upgrade-preflight-required-make-target-checklist/architecture.md
@@ -1,0 +1,52 @@
+# Architecture
+
+## Context
+- Work item: 2026-04-17-upgrade-preflight-required-make-target-checklist
+- Owner: sbonoc
+- Date: 2026-04-17
+
+## Stack and Execution Model
+- Backend stack profile: python_plus_fastapi_pydantic_v2
+- Frontend stack profile: vue_router_pinia_onyx
+- Test automation profile: pytest_vitest_playwright_pact
+- Agent execution model: specialized-subagents-isolated-worktrees
+
+## Problem Statement
+- What needs to change and why: preflight diagnostics currently miss some contract-required consumer-owned Make target gaps when targets are not yet referenced by known invoker paths, which causes late validation failures.
+- Scope boundaries: upgrade planning manual-action detection, targeted tests, and consumer upgrade documentation.
+- Out of scope: upgrade apply conflict engine, template ownership boundaries, and Make contract schema redesign.
+
+## Bounded Contexts and Responsibilities
+- Upgrade planning context (`scripts/lib/blueprint/upgrade_consumer.py`): detect missing required consumer-owned Make targets and generate deterministic manual-action records.
+- Contract context (`blueprint/contract.yaml`): canonical source for required Make targets and platform make ownership paths.
+- Validation context (`tests/blueprint/test_upgrade_consumer.py`): enforce red->green regression coverage for missing required-target detection and existing placeholder safeguards.
+- Consumer documentation context (`docs/platform/consumer/**`): explain preflight checklist expectations and remediation location.
+
+## High-Level Component Design
+- Domain layer: required target coverage rules for consumer-owned Make surfaces.
+- Application layer: `upgrade_consumer` planning composes manual actions with dependency source, reason, and follow-up commands.
+- Infrastructure adapters: parser over `make/platform.mk` and `make/platform/*.mk`; source invoker-path scanning for dependency context.
+- Presentation/API/workflow boundaries: `upgrade_plan.json`, `upgrade_apply.json`, `upgrade_preflight.json`, and `upgrade_summary.md` surface actionable findings.
+
+## Integration and Dependency Edges
+- Upstream dependencies:
+  - `blueprint/contract.yaml` (`spec.make_contract.required_targets`, ownership paths)
+  - source blueprint repository checkout used by upgrade planner
+- Downstream dependencies:
+  - `make blueprint-upgrade-consumer-preflight`
+  - `make blueprint-upgrade-consumer-validate`
+  - `make blueprint-upgrade-readiness-doctor`
+- Data/API/event contracts touched:
+  - `required_manual_actions[*].dependency_of`
+  - `required_manual_actions[*].reason`
+  - `required_manual_actions[*].required_follow_up_commands`
+
+## Non-Functional Architecture Notes
+- Security: no new mutable actions or credential scopes; detection remains file-content only.
+- Observability: manual-action reasons become more deterministic, including expected target definition locations.
+- Reliability and rollback: behavior is isolated to planning diagnostics; rollback is revert of planner/test/docs changes.
+- Monitoring/alerting: existing upgrade report summary counts continue to reflect required manual actions.
+
+## Risks and Tradeoffs
+- Risk 1: legacy repositories with heavily diverged `make/platform.mk` may report many missing required targets at once.
+- Tradeoff 1: broader early visibility is preferred over late validation failures and iterative trial-and-error.

--- a/specs/2026-04-17-upgrade-preflight-required-make-target-checklist/context_pack.md
+++ b/specs/2026-04-17-upgrade-preflight-required-make-target-checklist/context_pack.md
@@ -1,0 +1,31 @@
+# Work Item Context Pack
+
+## Context Snapshot
+- Work item: `specs/2026-04-17-upgrade-preflight-required-make-target-checklist`
+- Generated at (UTC): `2026-04-17T20:54:02Z`
+- SPEC_READY: `true`
+- ADR path: `docs/blueprint/architecture/decisions/ADR-20260417-upgrade-preflight-required-make-target-checklist.md`
+- ADR status: `approved`
+
+## Guardrail Controls
+- Applicable control IDs: `SDD-C-001`, `SDD-C-002`, `SDD-C-003`, `SDD-C-004`, `SDD-C-005`, `SDD-C-006`, `SDD-C-007`, `SDD-C-008`, `SDD-C-009`, `SDD-C-010`, `SDD-C-011`, `SDD-C-012`, `SDD-C-014`, `SDD-C-019`, `SDD-C-020`, `SDD-C-021`, `SDD-C-024`
+
+## Required Commands
+- `make quality-sdd-check`
+- `make quality-sdd-check-all`
+- `make quality-hooks-run`
+- `make infra-validate`
+- `make docs-build`
+- `make docs-smoke`
+
+## Artifact Index
+- `architecture.md`
+- `spec.md`
+- `plan.md`
+- `tasks.md`
+- `traceability.md`
+- `graph.yaml`
+- `evidence_manifest.json`
+- `context_pack.md`
+- `pr_context.md`
+- `hardening_review.md`

--- a/specs/2026-04-17-upgrade-preflight-required-make-target-checklist/evidence_manifest.json
+++ b/specs/2026-04-17-upgrade-preflight-required-make-target-checklist/evidence_manifest.json
@@ -1,0 +1,58 @@
+{
+  "manifest_version": 1,
+  "work_item": "specs/2026-04-17-upgrade-preflight-required-make-target-checklist",
+  "generated_by": "spec-evidence-manifest",
+  "generated_at_utc": "2026-04-17T20:54:58Z",
+  "files": [
+    {
+      "path": "specs/2026-04-17-upgrade-preflight-required-make-target-checklist/architecture.md",
+      "sha256": "41563e693d4aa84817242aaf4e52edc3ec5f2949bc57332a62c6eb399e888075",
+      "bytes": 3363
+    },
+    {
+      "path": "specs/2026-04-17-upgrade-preflight-required-make-target-checklist/context_pack.md",
+      "sha256": "fc4202ba5c452d01242241131cffb0e409bf1bd63022e3d3fdcb7b8a1a43c1ea",
+      "bytes": 975
+    },
+    {
+      "path": "specs/2026-04-17-upgrade-preflight-required-make-target-checklist/evidence_manifest.json",
+      "sha256": "cab4b60c60b26d63a987c44b0a963f3c5ddd16014d1b2120689dd4b8383289fa",
+      "bytes": 2357
+    },
+    {
+      "path": "specs/2026-04-17-upgrade-preflight-required-make-target-checklist/graph.yaml",
+      "sha256": "8c8a3fc5162242373d2d3184e1eb1a1b417d81e8debb0926939aa54ef94a5ead",
+      "bytes": 2953
+    },
+    {
+      "path": "specs/2026-04-17-upgrade-preflight-required-make-target-checklist/hardening_review.md",
+      "sha256": "8104eacc672ca0beb2093f2d20a571b64717b07be237f93b3bf2a91d068b6637",
+      "bytes": 1629
+    },
+    {
+      "path": "specs/2026-04-17-upgrade-preflight-required-make-target-checklist/plan.md",
+      "sha256": "dcd42493857941f8c562932a3ef55fa0123b85c1e7303ca769d483b5510dc75b",
+      "bytes": 4463
+    },
+    {
+      "path": "specs/2026-04-17-upgrade-preflight-required-make-target-checklist/pr_context.md",
+      "sha256": "f9d873de2b19c8615eaf967ca9ee8418a661f9952c1df8c2c8139c2778973dc0",
+      "bytes": 2247
+    },
+    {
+      "path": "specs/2026-04-17-upgrade-preflight-required-make-target-checklist/spec.md",
+      "sha256": "aea707d3bca943ba21d039d2d5ac0994e55c55115868f63853443fbdbf889a19",
+      "bytes": 5919
+    },
+    {
+      "path": "specs/2026-04-17-upgrade-preflight-required-make-target-checklist/tasks.md",
+      "sha256": "77fedde3546afcf489ea2c6b8496c31591ad271c432f16933c2a166297352b6d",
+      "bytes": 2885
+    },
+    {
+      "path": "specs/2026-04-17-upgrade-preflight-required-make-target-checklist/traceability.md",
+      "sha256": "992f3a1b57c5d8da50266b2daafb584b1a6c52a9e2c24e467b8dde5ea8b4dd61",
+      "bytes": 6141
+    }
+  ]
+}

--- a/specs/2026-04-17-upgrade-preflight-required-make-target-checklist/graph.yaml
+++ b/specs/2026-04-17-upgrade-preflight-required-make-target-checklist/graph.yaml
@@ -1,0 +1,123 @@
+{
+  "graph_version": 1,
+  "work_item": "2026-04-17-upgrade-preflight-required-make-target-checklist",
+  "nodes": [
+    {
+      "id": "FR-001",
+      "type": "requirement",
+      "summary": "Emit manual action for each missing contract-required consumer-owned make target"
+    },
+    {
+      "id": "FR-002",
+      "type": "requirement",
+      "summary": "Emit missing-target action even without known invoker reference"
+    },
+    {
+      "id": "FR-003",
+      "type": "requirement",
+      "summary": "Include deterministic target-location guidance in reason"
+    },
+    {
+      "id": "FR-004",
+      "type": "requirement",
+      "summary": "Use invoker dependency context when available, fallback to contract reference otherwise"
+    },
+    {
+      "id": "FR-005",
+      "type": "requirement",
+      "summary": "Retain placeholder safeguards with location guidance"
+    },
+    {
+      "id": "NFR-SEC-001",
+      "type": "requirement",
+      "summary": "No new privileged operations in detection path"
+    },
+    {
+      "id": "NFR-OBS-001",
+      "type": "requirement",
+      "summary": "Deterministic machine-readable diagnostics"
+    },
+    {
+      "id": "NFR-REL-001",
+      "type": "requirement",
+      "summary": "Regression-safe preservation of existing behavior"
+    },
+    {
+      "id": "NFR-OPS-001",
+      "type": "requirement",
+      "summary": "Operator remediation flow remains deterministic"
+    },
+    {
+      "id": "AC-001",
+      "type": "acceptance",
+      "summary": "Red-green regression test covers missing required target gap"
+    },
+    {
+      "id": "AC-002",
+      "type": "acceptance",
+      "summary": "Reason includes target and expected location guidance"
+    },
+    {
+      "id": "AC-003",
+      "type": "acceptance",
+      "summary": "Dependency context uses invoker or contract fallback"
+    },
+    {
+      "id": "AC-004",
+      "type": "acceptance",
+      "summary": "Existing placeholder safeguards stay green"
+    },
+    {
+      "id": "AC-005",
+      "type": "acceptance",
+      "summary": "Consumer docs explain required-target checklist behavior"
+    }
+  ],
+  "edges": [
+    {
+      "from": "FR-001",
+      "to": "AC-001",
+      "relation": "validated_by"
+    },
+    {
+      "from": "FR-002",
+      "to": "AC-001",
+      "relation": "validated_by"
+    },
+    {
+      "from": "FR-003",
+      "to": "AC-002",
+      "relation": "validated_by"
+    },
+    {
+      "from": "FR-004",
+      "to": "AC-003",
+      "relation": "validated_by"
+    },
+    {
+      "from": "FR-005",
+      "to": "AC-004",
+      "relation": "validated_by"
+    },
+    {
+      "from": "NFR-SEC-001",
+      "to": "AC-004",
+      "relation": "constrains"
+    },
+    {
+      "from": "NFR-OBS-001",
+      "to": "AC-002",
+      "relation": "constrains"
+    },
+    {
+      "from": "NFR-REL-001",
+      "to": "AC-004",
+      "relation": "constrains"
+    },
+    {
+      "from": "NFR-OPS-001",
+      "to": "AC-005",
+      "relation": "constrains"
+    }
+  ]
+}

--- a/specs/2026-04-17-upgrade-preflight-required-make-target-checklist/hardening_review.md
+++ b/specs/2026-04-17-upgrade-preflight-required-make-target-checklist/hardening_review.md
@@ -1,0 +1,22 @@
+# Hardening Review
+
+## Repository-Wide Findings Fixed
+- Added red->green regression for missing contract-required consumer-owned target detection when no known invoker path exists.
+- Extended upgrade planner manual-action generation to include contract fallback dependency context and deterministic target-location guidance.
+- Kept existing placeholder safeguards (`apps-ci-bootstrap-consumer`, `infra-post-deploy-consumer`) active while adding location guidance.
+- Updated consumer upgrade runbook docs to explain required-target checklist behavior and remediation locations.
+
+## Observability and Diagnostics Changes
+- Manual action diagnostics now include deterministic location hints for missing required targets (`make/platform.mk` or `make/platform/*.mk`).
+- Fallback `dependency_of` context now remains explicit when invoker path is unavailable: `blueprint/contract.yaml: spec.make_contract.required_targets -> <target>`.
+
+## Architecture and Code Quality Compliance
+- SOLID / Clean Architecture / Clean Code / DDD checks:
+  - change remains localized to upgrade planner helper functions and preserves existing `RequiredManualAction` contract shape.
+- Test-automation and pyramid checks:
+  - unit-level regression first (red->green) plus existing unit suite coverage preserved.
+- Documentation/diagram/CI/skill consistency checks:
+  - consumer docs updated and synced to bootstrap template mirror.
+
+## Proposals Only (Not Implemented)
+- Proposal 1: add optional `suggested_target_stub` field in required manual actions for direct boilerplate generation without changing current schema consumers until explicitly approved.

--- a/specs/2026-04-17-upgrade-preflight-required-make-target-checklist/plan.md
+++ b/specs/2026-04-17-upgrade-preflight-required-make-target-checklist/plan.md
@@ -1,0 +1,110 @@
+# Implementation Plan
+
+## Implementation Start Gate
+- Implementation is allowed with `SPEC_READY=true` and required sign-offs approved in `spec.md`.
+- Missing-input blocker token is not active for this work item.
+
+## Constitution Gates (Pre-Implementation)
+- Simplicity gate:
+  - Keep changes scoped to preflight/manual-action diagnostics, tests, and consumer-facing upgrade docs.
+  - Reuse existing contract metadata and follow-up command surfaces.
+- Anti-abstraction gate:
+  - Extend existing planner functions instead of introducing a new diagnostics subsystem.
+  - Preserve existing `RequiredManualAction` payload shape.
+- Integration-first testing gate:
+  - Add failing regression for missing contract-required consumer target without invoker reference, then implement fix.
+- Positive-path filter/transform test gate:
+  - Not applicable for this work item; no route/filter payload logic changes.
+- Finding-to-test translation gate:
+  - Reproducible finding (`missing target undetected in preflight`) is translated to a failing unit test first and turned green with implementation.
+
+## Delivery Slices
+1. Slice 1: finalize Discover/Architecture/Specify artifacts with approved ADR linkage.
+2. Slice 2: add failing regression test for contract-required missing consumer-owned Make target detection gap.
+3. Slice 3: implement planner logic for fallback contract dependency context and deterministic location guidance.
+4. Slice 4: update consumer upgrade docs, execute validation, and finalize publish artifacts.
+
+## Change Strategy
+- Migration/rollout sequence:
+  - add regression test (red).
+  - implement planner fix (green).
+  - update docs to explain checklist guarantees.
+  - run validation bundles and package publish artifacts.
+- Backward compatibility policy:
+  - no contract schema changes; existing required-manual-action consumers remain compatible.
+- Rollback plan:
+  - revert planner/test/docs changes and rerun targeted validation.
+
+## Validation Strategy (Shift-Left)
+- Unit checks:
+  - `python3 -m unittest tests.blueprint.test_upgrade_consumer`
+  - `python3 -m unittest tests.blueprint.test_upgrade_preflight`
+- Contract checks:
+  - `python3 scripts/lib/docs/sync_blueprint_template_docs.py --check`
+- Integration checks:
+  - `make quality-hooks-fast`
+- E2E checks:
+  - not applicable for this planner/docs scope.
+
+## App Onboarding Contract (Normative)
+- Required minimum make targets:
+  - `apps-bootstrap`
+  - `apps-smoke`
+  - `backend-test-unit`
+  - `backend-test-integration`
+  - `backend-test-contracts`
+  - `backend-test-e2e`
+  - `touchpoints-test-unit`
+  - `touchpoints-test-integration`
+  - `touchpoints-test-contracts`
+  - `touchpoints-test-e2e`
+  - `test-unit-all`
+  - `test-integration-all`
+  - `test-contracts-all`
+  - `test-e2e-all-local`
+  - `infra-port-forward-start`
+  - `infra-port-forward-stop`
+  - `infra-port-forward-cleanup`
+- App onboarding impact: no-impact
+- Notes: this work item touches upgrade planning diagnostics and docs only.
+
+## Documentation Plan (Document Phase)
+- Blueprint docs updates:
+  - none.
+- Consumer docs updates:
+  - `docs/platform/consumer/quickstart.md`
+  - `docs/platform/consumer/troubleshooting.md`
+- Mermaid diagrams updated:
+  - not required.
+- Docs validation commands:
+  - `python3 scripts/lib/docs/sync_blueprint_template_docs.py --check`
+
+## Publish Preparation
+- PR context file:
+  - `pr_context.md`
+- Hardening review file:
+  - `hardening_review.md`
+- Local smoke gate (HTTP route/filter changes):
+  - not applicable; no HTTP route/filter/new endpoint changes.
+- Publish checklist:
+  - include requirement/contract coverage
+  - include key reviewer files
+  - include validation evidence + rollback notes
+
+## Operational Readiness
+- Logging/metrics/traces:
+  - no runtime telemetry changes; deterministic required-manual-action diagnostics are enhanced.
+- Alerts/ownership:
+  - upgrade operators own manual-action resolution before validate/apply.
+- Runbook updates:
+  - consumer quickstart/troubleshooting clarify missing-target checklist behavior.
+
+## Risks and Mitigations
+- Risk 1: higher manual-action volume on legacy consumer repos can overwhelm operators.
+- Mitigation 1: include exact target names, expected location guidance, and canonical follow-up command.
+
+## Rollback Notes
+- Revert this work-item diff and rerun:
+  - `python3 -m unittest tests.blueprint.test_upgrade_consumer`
+  - `python3 -m unittest tests.blueprint.test_upgrade_preflight`
+  - `make quality-hooks-fast`

--- a/specs/2026-04-17-upgrade-preflight-required-make-target-checklist/pr_context.md
+++ b/specs/2026-04-17-upgrade-preflight-required-make-target-checklist/pr_context.md
@@ -1,0 +1,41 @@
+# PR Context
+
+## Summary
+- Work item: `specs/2026-04-17-upgrade-preflight-required-make-target-checklist`
+- Objective: detect missing contract-required consumer-owned Make targets during upgrade preflight with deterministic remediation guidance.
+- Scope boundaries: upgrade planner diagnostics, unit regressions, and consumer upgrade docs sync.
+
+## Requirement Coverage
+- Requirements (FR/NFR): `FR-001`, `FR-002`, `FR-003`, `FR-004`, `FR-005`, `NFR-SEC-001`, `NFR-OBS-001`, `NFR-REL-001`, `NFR-OPS-001`
+- Acceptance criteria (AC): `AC-001`, `AC-002`, `AC-003`, `AC-004`, `AC-005`
+- Contract surfaces changed:
+  - `required_manual_actions[*].dependency_of`
+  - `required_manual_actions[*].reason`
+  - consumer upgrade docs around `upgrade_preflight.json` interpretation
+
+## Key Reviewer Files
+- `scripts/lib/blueprint/upgrade_consumer.py`
+- `tests/blueprint/test_upgrade_consumer.py`
+- `docs/platform/consumer/quickstart.md`
+- `docs/platform/consumer/troubleshooting.md`
+- `scripts/templates/blueprint/bootstrap/docs/platform/consumer/quickstart.md`
+- `scripts/templates/blueprint/bootstrap/docs/platform/consumer/troubleshooting.md`
+- `specs/2026-04-17-upgrade-preflight-required-make-target-checklist/spec.md`
+- `specs/2026-04-17-upgrade-preflight-required-make-target-checklist/traceability.md`
+
+## Validation Evidence
+- `python3 -m unittest tests.blueprint.test_upgrade_consumer` (22 tests passed)
+- `python3 -m unittest tests.blueprint.test_upgrade_preflight` (4 tests passed)
+- `python3 scripts/lib/docs/sync_blueprint_template_docs.py --check` (pass)
+- `python3 scripts/lib/docs/sync_platform_seed_docs.py --check` (pass)
+- `make quality-hooks-fast` (pass; includes `infra-validate` and `infra-contract-test-fast`)
+- `make quality-hardening-review` (pass)
+
+## Risk and Rollback
+- Main risks:
+  - legacy consumer repos may now see larger manual-action lists when many required targets are missing.
+- Rollback strategy:
+  - revert planner/test/docs changes and rerun `python3 -m unittest tests.blueprint.test_upgrade_consumer tests.blueprint.test_upgrade_preflight && make quality-hooks-fast`.
+
+## Deferred Proposals
+- Add optional boilerplate/skeleton target snippets to required manual actions once schema extension is explicitly approved.

--- a/specs/2026-04-17-upgrade-preflight-required-make-target-checklist/spec.md
+++ b/specs/2026-04-17-upgrade-preflight-required-make-target-checklist/spec.md
@@ -1,0 +1,88 @@
+# Specification
+
+## Spec Readiness Gate (Blocking)
+- SPEC_READY: true
+- Open questions count: 0
+- Unresolved alternatives count: 0
+- Unresolved TODO markers count: 0
+- Pending assumptions count: 0
+- Open clarification markers count: 0
+- Product sign-off: approved
+- Architecture sign-off: approved
+- Security sign-off: approved
+- Operations sign-off: approved
+- Missing input blocker token: none
+- ADR path: docs/blueprint/architecture/decisions/ADR-20260417-upgrade-preflight-required-make-target-checklist.md
+- ADR status: approved
+
+## Applicable Guardrail Controls (Normative)
+- Applicable control IDs: SDD-C-001, SDD-C-002, SDD-C-003, SDD-C-004, SDD-C-005, SDD-C-006, SDD-C-007, SDD-C-008, SDD-C-009, SDD-C-010, SDD-C-011, SDD-C-012, SDD-C-014, SDD-C-019, SDD-C-020, SDD-C-021, SDD-C-024
+- Control exception rationale: none
+
+## Implementation Stack Profile (Normative)
+- Backend stack profile: python_plus_fastapi_pydantic_v2
+- Frontend stack profile: vue_router_pinia_onyx
+- Test automation profile: pytest_vitest_playwright_pact
+- Agent execution model: specialized-subagents-isolated-worktrees
+- Managed service preference: stackit-managed-first
+- Managed service exception rationale: none
+- Runtime profile: local-first-docker-desktop-kubernetes
+- Local Kubernetes context policy: docker-desktop-preferred
+- Local provisioning stack: crossplane-plus-helm
+- Runtime identity baseline: eso-plus-argocd-plus-keycloak
+- Local-first exception rationale: none
+
+## Objective
+- Business outcome: convert missing consumer-owned required Make targets from a late validate failure into an explicit preflight checklist with deterministic remediation guidance.
+- Success metric: upgrade preflight reports contract-required consumer Make target gaps before apply/validate, with exact target identifiers and expected definition surfaces.
+
+## Normative Requirements
+
+### Functional Requirements (Normative)
+- FR-001: Upgrade planning MUST emit a required manual action for every source-defined consumer-owned Make target that is listed in `spec.make_contract.required_targets` and missing from target consumer-owned Make surfaces.
+- FR-002: Missing-target manual actions MUST be emitted even when no known blueprint invoker path references the target yet.
+- FR-003: Each missing-target manual action reason MUST include both the exact target name and deterministic expected definition surfaces (`make/platform.mk` or linked includes under `make/platform/*.mk`).
+- FR-004: If a known invoker reference path exists, manual action `dependency_of` MUST point to that invoker; otherwise it MUST fall back to `blueprint/contract.yaml: spec.make_contract.required_targets -> <target>`.
+- FR-005: Existing placeholder/manual-action checks for `apps-ci-bootstrap-consumer` and `infra-post-deploy-consumer` MUST remain active and include deterministic target-location guidance.
+
+### Non-Functional Requirements (Normative)
+- NFR-SEC-001: The feature MUST remain contract/read-only for detection logic and MUST NOT introduce new privileged operations or secret reads beyond existing upgrade planning behavior.
+- NFR-OBS-001: Manual action messages MUST remain structured and deterministic so `upgrade_preflight.json` and `upgrade_summary.md` stay machine- and operator-readable.
+- NFR-REL-001: Existing upgrade manual-action regressions MUST remain green while adding new missing-target coverage.
+- NFR-OPS-001: Operator remediation text MUST remain command-compatible with existing follow-up flow (`make blueprint-upgrade-consumer-validate`).
+
+## Normative Option Decision
+- Option A: keep missing-target reporting gated by known invoker references only.
+- Option B: report all contract-required missing consumer-owned targets from source-defined platform make surfaces, using contract fallback dependency context when no invoker exists.
+- Selected option: OPTION_B
+- Rationale: Option B satisfies preflight ergonomics by surfacing actionable gaps before late validation failures, including newly introduced required targets.
+
+## Contract Changes (Normative)
+- Config/Env contract: no new variables.
+- API contract: no external API changes.
+- Event contract: no event changes.
+- Make/CLI contract: no new targets; enhanced manual-action diagnostics in existing upgrade/preflight flow.
+- Docs contract: consumer upgrade docs MUST describe missing required target checklist behavior and expected definition locations.
+
+## Blueprint Upstream Defect Escalation (Normative)
+- Upstream issue URL: none
+- Temporary workaround path: none
+- Replacement trigger: none
+- Workaround review date: none
+
+## Normative Acceptance Criteria
+- AC-001: A regression test fails red->green when a source contract introduces a new required consumer-owned Make target defined in source platform make surfaces but missing in the target repo.
+- AC-002: The resulting manual action includes the exact target name and expected location guidance (`make/platform.mk` or `make/platform/*.mk`).
+- AC-003: `dependency_of` uses invoker-path reference when available and contract-fallback reference when invoker-path reference is unavailable.
+- AC-004: Existing CI/bootstrap and local-post-deploy placeholder manual-action behaviors remain green.
+- AC-005: Consumer upgrade docs state that preflight includes required-target checklist findings and where to define missing targets.
+
+## Informative Notes (Non-Normative)
+- Context: Issue #102 reported that generated-consumer upgrades hit late validation failures due to missing consumer-owned required Make targets.
+- Tradeoffs: broader preflight checklist output can include multiple actionable missing targets in legacy consumer makefiles.
+- Clarifications:
+  - user explicitly requested strict SDD lifecycle execution for this work item.
+
+## Explicit Exclusions
+- Excluded item 1: no schema version changes in `blueprint/contract.yaml`.
+- Excluded item 2: no changes to upgrade apply merge/conflict resolution behavior.

--- a/specs/2026-04-17-upgrade-preflight-required-make-target-checklist/tasks.md
+++ b/specs/2026-04-17-upgrade-preflight-required-make-target-checklist/tasks.md
@@ -1,0 +1,40 @@
+# Tasks
+
+## Gate Checks (Required Before Implementation)
+- [x] G-001 Confirm `SPEC_READY=true` in `spec.md`
+- [x] G-002 Confirm open questions and unresolved alternatives are `0`
+- [x] G-003 Confirm required sign-offs are approved
+- [x] G-004 Confirm `Applicable Guardrail Controls` section includes `SDD-C-###` IDs
+- [x] G-005 Confirm `Implementation Stack Profile` section is fully populated
+
+## Implementation
+- [x] T-001 Update upgrade planner diagnostics for missing required consumer-owned make targets
+- [x] T-002 Preserve invoker-path dependency context and add deterministic contract fallback dependency context
+- [x] T-003 Update consumer-facing upgrade docs with preflight checklist guarantee and remediation location guidance
+- [x] T-004 Update publish artifacts and traceability references for changed planner/test/docs scope
+
+## Test Automation
+- [x] T-101 Add red->green regression test for missing contract-required consumer make target without known invoker path
+- [x] T-102 Keep existing upgrade manual-action tests green after planner changes
+- [x] T-103 Positive-path filter/payload-transform unit test gate is not applicable for this work item (no filter/transform scope)
+- [x] T-104 Translate reproducible pre-PR finding into failing automated test first, then green with fix in same work item
+- [x] T-105 Run additional preflight report tests to confirm downstream report compatibility
+
+## Validation and Release Readiness
+- [x] T-201 Run required validation bundles for touched scope
+- [x] T-202 Attach command/test evidence in `traceability.md`
+- [x] T-203 Confirm no stale unresolved markers/dead code/drift in touched scope
+- [x] T-204 Run documentation sync validation (`python3 scripts/lib/docs/sync_blueprint_template_docs.py --check`)
+- [x] T-205 Run hardening review validation bundle (`make quality-hardening-review`)
+
+## Publish
+- [x] P-001 Update `hardening_review.md` with repository-wide findings fixed and proposals-only section
+- [x] P-002 Update `pr_context.md` with requirement/contract coverage, key reviewer files, validation evidence, and rollback notes
+- [x] P-003 Ensure PR description references generated `pr_context.md`
+
+## App Onboarding Minimum Targets (Normative)
+- [x] A-001 `apps-bootstrap` and `apps-smoke` remain available for affected app scope
+- [x] A-002 Backend app lanes (`backend-test-unit`, `backend-test-integration`, `backend-test-contracts`, `backend-test-e2e`) remain available
+- [x] A-003 Frontend app lanes (`touchpoints-test-unit`, `touchpoints-test-integration`, `touchpoints-test-contracts`, `touchpoints-test-e2e`) remain available
+- [x] A-004 Aggregate gates (`test-unit-all`, `test-integration-all`, `test-contracts-all`, `test-e2e-all-local`) remain available
+- [x] A-005 Port-forward operational wrappers (`infra-port-forward-start`, `infra-port-forward-stop`, `infra-port-forward-cleanup`) remain available

--- a/specs/2026-04-17-upgrade-preflight-required-make-target-checklist/traceability.md
+++ b/specs/2026-04-17-upgrade-preflight-required-make-target-checklist/traceability.md
@@ -1,0 +1,66 @@
+# Traceability Matrix
+
+## Requirement-to-Delivery Mapping
+
+| Requirement ID | Control IDs | Design Element | Implementation Path(s) | Test Evidence | Documentation Evidence | Operational Evidence |
+|---|---|---|---|---|---|---|
+| FR-001 | SDD-C-005 | Missing required consumer-owned target detection from source platform make surfaces | `scripts/lib/blueprint/upgrade_consumer.py` (`_collect_missing_platform_make_target_actions`) | `python3 -m unittest tests.blueprint.test_upgrade_consumer` | n/a | `artifacts/blueprint/upgrade_plan.json` required_manual_actions |
+| FR-002 | SDD-C-005 | Contract-fallback manual action when invoker reference is unavailable | `scripts/lib/blueprint/upgrade_consumer.py` (`dependency_of` fallback) | `test_upgrade_plan_flags_manual_action_for_missing_required_consumer_make_target_from_contract` | n/a | `make blueprint-upgrade-consumer-preflight` report includes fallback dependency context |
+| FR-003 | SDD-C-005 | Deterministic location guidance in manual-action reason | `scripts/lib/blueprint/upgrade_consumer.py` (`_platform_make_location_hint`) | `test_upgrade_plan_flags_manual_action_for_missing_required_consumer_make_target_from_contract` | `docs/platform/consumer/quickstart.md`, `docs/platform/consumer/troubleshooting.md` | required manual action reasons include expected target surfaces |
+| FR-004 | SDD-C-005 | Preserve invoker path context with fallback behavior | `scripts/lib/blueprint/upgrade_consumer.py` | `test_upgrade_plan_flags_manual_action_for_missing_platform_ci_bootstrap_target` | n/a | upgrade preflight/readiness doctor consume dependency_of consistently |
+| FR-005 | SDD-C-005 | Placeholder safeguards stay active with location guidance | `scripts/lib/blueprint/upgrade_consumer.py` | `test_upgrade_plan_flags_manual_action_for_placeholder_platform_ci_bootstrap_consumer_target`; `test_upgrade_plan_flags_manual_action_for_placeholder_local_post_deploy_consumer_target_when_enabled` | `docs/platform/consumer/troubleshooting.md` | `make blueprint-upgrade-consumer-validate` follow-up command preserved |
+| NFR-SEC-001 | SDD-C-009 | Read-only detection path with no new privilege surface | `scripts/lib/blueprint/upgrade_consumer.py` | `python3 -m unittest tests.blueprint.test_upgrade_consumer` | n/a | plan-only diagnostics remain non-mutating |
+| NFR-OBS-001 | SDD-C-010 | Deterministic reason/dependency context for machine-readable reports | `scripts/lib/blueprint/upgrade_consumer.py`; `scripts/lib/blueprint/upgrade_preflight.py` | `python3 -m unittest tests.blueprint.test_upgrade_preflight` | docs update explains report usage | `upgrade_preflight.json` fields remain stable |
+| NFR-REL-001 | SDD-C-008 | Regression-safe evolution of existing manual-action behavior | `tests/blueprint/test_upgrade_consumer.py` | `python3 -m unittest tests.blueprint.test_upgrade_consumer` | n/a | stable required manual action counts and follow-up commands |
+| NFR-OPS-001 | SDD-C-010 | Deterministic remediation guidance and canonical follow-up command | `scripts/lib/blueprint/upgrade_consumer.py` | `python3 -m unittest tests.blueprint.test_upgrade_consumer` | `docs/platform/consumer/quickstart.md`; `docs/platform/consumer/troubleshooting.md` | `make blueprint-upgrade-consumer-validate` |
+| AC-001 | SDD-C-012 | Red->green test coverage for new missing-target gap | `tests/blueprint/test_upgrade_consumer.py` | `test_upgrade_plan_flags_manual_action_for_missing_required_consumer_make_target_from_contract` | n/a | CI/unit lane |
+| AC-002 | SDD-C-012 | Manual action reason includes target + location guidance | `scripts/lib/blueprint/upgrade_consumer.py` | same as AC-001 | docs mention expected definition locations | preflight checklist readability |
+| AC-003 | SDD-C-012 | Invoker-path context + contract fallback behavior | `scripts/lib/blueprint/upgrade_consumer.py` | `test_upgrade_plan_flags_manual_action_for_missing_platform_ci_bootstrap_target`; AC-001 test | n/a | upgrade_preflight manual actions preserve dependency_of semantics |
+| AC-004 | SDD-C-012 | Existing placeholder guardrails preserved | `scripts/lib/blueprint/upgrade_consumer.py` | placeholder tests in `tests/blueprint/test_upgrade_consumer.py` | troubleshooting guidance retained | follow-up validate command unchanged |
+| AC-005 | SDD-C-012 | Consumer docs clarify preflight required-target checklist behavior | `docs/platform/consumer/quickstart.md`; `docs/platform/consumer/troubleshooting.md` | docs sync checks | same paths | runbook-level guidance for operators |
+
+## Graph Linkage
+- Graph file: `graph.yaml`
+- Every `FR-###`, `NFR-*-###`, and `AC-###` listed in this file MUST have a corresponding node in `graph.yaml`.
+- Node IDs referenced:
+  - FR-001
+  - FR-002
+  - FR-003
+  - FR-004
+  - FR-005
+  - NFR-SEC-001
+  - NFR-OBS-001
+  - NFR-REL-001
+  - NFR-OPS-001
+  - AC-001
+  - AC-002
+  - AC-003
+  - AC-004
+  - AC-005
+
+## Validation Summary
+- Required bundles executed:
+  - `python3 -m unittest tests.blueprint.test_upgrade_consumer`
+  - `python3 -m unittest tests.blueprint.test_upgrade_preflight`
+  - `python3 scripts/lib/docs/sync_blueprint_template_docs.py --check`
+  - `python3 scripts/lib/docs/sync_platform_seed_docs.py --check`
+  - `make quality-hooks-fast`
+  - `make quality-hardening-review`
+- Result summary:
+  - `tests.blueprint.test_upgrade_consumer`: 22 tests passed.
+  - `tests.blueprint.test_upgrade_preflight`: 4 tests passed.
+  - docs sync checks passed for blueprint template and platform seed mirrors.
+  - `make quality-hooks-fast` passed, including `infra-validate` and `infra-contract-test-fast` (21 tests passed, 2 subtests passed).
+  - `make quality-hardening-review` passed.
+- Documentation validation:
+  - `python3 scripts/lib/docs/sync_blueprint_template_docs.py --check`
+  - `python3 scripts/lib/docs/sync_platform_seed_docs.py --check`
+
+## Evidence Manifest
+- Manifest file: `evidence_manifest.json`
+- Context export: `context_pack.md`
+- PR context export: `pr_context.md`
+- Hardening review export: `hardening_review.md`
+
+## Open Risks and Follow-Ups
+- Follow-up 1: monitor operator feedback for checklist volume on legacy repositories with broad target drift.

--- a/tests/blueprint/test_upgrade_consumer.py
+++ b/tests/blueprint/test_upgrade_consumer.py
@@ -461,12 +461,91 @@ class UpgradeConsumerTests(unittest.TestCase):
                 "make blueprint-upgrade-consumer-validate",
                 ci_bootstrap_action.get("required_follow_up_commands", []),
             )
-            self.assertEqual(plan.get("summary", {}).get("required_manual_action_count"), 1)
+            self.assertGreaterEqual(plan.get("summary", {}).get("required_manual_action_count", 0), 1)
 
             apply_report = _load_json(target_repo / "artifacts/blueprint/upgrade_apply.json")
             apply_manual_actions = apply_report.get("required_manual_actions", [])
-            self.assertEqual(len(apply_manual_actions), 1)
-            self.assertEqual(apply_report.get("summary", {}).get("required_manual_action_count"), 1)
+            self.assertGreaterEqual(len(apply_manual_actions), 1)
+            self.assertEqual(
+                apply_report.get("summary", {}).get("required_manual_action_count"),
+                len(apply_manual_actions),
+            )
+
+    def test_upgrade_plan_flags_manual_action_for_missing_required_consumer_make_target_from_contract(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_root = Path(tmpdir)
+            source_repo = tmp_root / "source"
+            _init_git_repo(source_repo)
+
+            source_contract = (REPO_ROOT / "blueprint/contract.yaml").read_text(encoding="utf-8").replace(
+                "      - quality-hardening-review\n",
+                "      - quality-hardening-review\n      - consumer-upgrade-prereq\n",
+                1,
+            )
+            _write(source_repo / "blueprint/contract.yaml", source_contract)
+            _write(source_repo / "make/platform.mk", (REPO_ROOT / "make/platform.mk").read_text(encoding="utf-8"))
+            _write(
+                source_repo / "make/platform/consumer_upgrade.mk",
+                (
+                    ".PHONY: consumer-upgrade-prereq\n"
+                    "\n"
+                    "consumer-upgrade-prereq:\n"
+                    "\t@echo consumer upgrade prerequisite target\n"
+                ),
+            )
+            _write(source_repo / MANAGED_TEST_PATH, "baseline\n")
+            _commit_all(source_repo, "baseline")
+            _require_success(_git(source_repo, "tag", f"v{_template_version()}"), "git tag template version")
+            _write(source_repo / MANAGED_TEST_PATH, "baseline\nhead\n")
+            _commit_all(source_repo, "head")
+
+            target_repo = _create_generated_repo(tmp_root, MANAGED_TEST_PATH, "baseline\n")
+            _write(target_repo / "make/platform.mk", (REPO_ROOT / "make/platform.mk").read_text(encoding="utf-8"))
+            _commit_all(target_repo, "target missing new consumer required target")
+
+            result = _run(
+                [
+                    sys.executable,
+                    str(UPGRADE_SCRIPT),
+                    "--repo-root",
+                    str(target_repo),
+                    "--source",
+                    str(source_repo),
+                    "--ref",
+                    "HEAD",
+                ],
+                cwd=REPO_ROOT,
+            )
+            self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+
+            plan = _load_json(target_repo / "artifacts/blueprint/upgrade_plan.json")
+            required_manual_actions = plan.get("required_manual_actions", [])
+            missing_target_action = None
+            for action in required_manual_actions:
+                if not isinstance(action, dict):
+                    continue
+                if "consumer-upgrade-prereq" not in str(action.get("reason", "")):
+                    continue
+                missing_target_action = action
+                break
+
+            self.assertIsNotNone(
+                missing_target_action,
+                msg=f"missing contract-required consumer make target action: {required_manual_actions}",
+            )
+            self.assertEqual(missing_target_action.get("dependency_path"), "make/platform.mk")
+            self.assertIn(
+                "blueprint/contract.yaml: spec.make_contract.required_targets",
+                str(missing_target_action.get("dependency_of", "")),
+            )
+            self.assertIn(
+                "required make target `consumer-upgrade-prereq` is missing",
+                str(missing_target_action.get("reason", "")),
+            )
+            self.assertIn(
+                "`make/platform.mk` or linked includes under `make/platform/*.mk`",
+                str(missing_target_action.get("reason", "")),
+            )
 
     def test_upgrade_plan_flags_manual_action_for_placeholder_platform_ci_bootstrap_consumer_target(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/blueprint/test_upgrade_consumer.py
+++ b/tests/blueprint/test_upgrade_consumer.py
@@ -462,6 +462,10 @@ class UpgradeConsumerTests(unittest.TestCase):
                 ci_bootstrap_action.get("required_follow_up_commands", []),
             )
             self.assertGreaterEqual(plan.get("summary", {}).get("required_manual_action_count", 0), 1)
+            self.assertEqual(
+                plan.get("summary", {}).get("required_manual_action_count"),
+                len(required_manual_actions),
+            )
 
             apply_report = _load_json(target_repo / "artifacts/blueprint/upgrade_apply.json")
             apply_manual_actions = apply_report.get("required_manual_actions", [])
@@ -545,6 +549,73 @@ class UpgradeConsumerTests(unittest.TestCase):
             self.assertIn(
                 "`make/platform.mk` or linked includes under `make/platform/*.mk`",
                 str(missing_target_action.get("reason", "")),
+            )
+
+    def test_upgrade_plan_treats_nested_platform_make_includes_as_missing_targets(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_root = Path(tmpdir)
+            source_repo = tmp_root / "source"
+            _init_git_repo(source_repo)
+
+            source_contract = (REPO_ROOT / "blueprint/contract.yaml").read_text(encoding="utf-8").replace(
+                "      - quality-hardening-review\n",
+                "      - quality-hardening-review\n      - nested-only-target\n",
+                1,
+            )
+            _write(source_repo / "blueprint/contract.yaml", source_contract)
+            _write(source_repo / "make/platform.mk", (REPO_ROOT / "make/platform.mk").read_text(encoding="utf-8"))
+            _write(
+                source_repo / "make/platform/base.mk",
+                ".PHONY: nested-only-target\nnested-only-target:\n\t@echo nested source target\n",
+            )
+            _write(source_repo / MANAGED_TEST_PATH, "baseline\n")
+            _commit_all(source_repo, "baseline")
+            _require_success(_git(source_repo, "tag", f"v{_template_version()}"), "git tag template version")
+            _write(source_repo / MANAGED_TEST_PATH, "baseline\nhead\n")
+            _commit_all(source_repo, "head")
+
+            target_repo = _create_generated_repo(tmp_root, MANAGED_TEST_PATH, "baseline\n")
+            _write(target_repo / "make/platform.mk", (REPO_ROOT / "make/platform.mk").read_text(encoding="utf-8"))
+            _write(
+                target_repo / "make/platform/nested/custom.mk",
+                ".PHONY: nested-only-target\nnested-only-target:\n\t@echo nested target only\n",
+            )
+            _commit_all(target_repo, "target defines nested-only-target in nested include only")
+
+            result = _run(
+                [
+                    sys.executable,
+                    str(UPGRADE_SCRIPT),
+                    "--repo-root",
+                    str(target_repo),
+                    "--source",
+                    str(source_repo),
+                    "--ref",
+                    "HEAD",
+                ],
+                cwd=REPO_ROOT,
+            )
+            self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+
+            plan = _load_json(target_repo / "artifacts/blueprint/upgrade_plan.json")
+            required_manual_actions = plan.get("required_manual_actions", [])
+            nested_target_action = None
+            for action in required_manual_actions:
+                if not isinstance(action, dict):
+                    continue
+                if "nested-only-target" not in str(action.get("reason", "")):
+                    continue
+                nested_target_action = action
+                break
+
+            self.assertIsNotNone(
+                nested_target_action,
+                msg=f"missing manual action for nested-only-target: {required_manual_actions}",
+            )
+            self.assertEqual(nested_target_action.get("dependency_path"), "make/platform.mk")
+            self.assertIn(
+                "define `nested-only-target` in `make/platform.mk` or linked includes under `make/platform/*.mk`",
+                str(nested_target_action.get("reason", "")),
             )
 
     def test_upgrade_plan_flags_manual_action_for_placeholder_platform_ci_bootstrap_consumer_target(self) -> None:


### PR DESCRIPTION
## Summary
- Implement Issue #102 by extending upgrade preflight/planning to detect missing contract-required consumer-owned Make targets earlier.
- Added deterministic remediation guidance and fallback dependency context when no known invoker path exists.
- Work item: `specs/2026-04-17-upgrade-preflight-required-make-target-checklist/`

## Requirement and Contract Coverage
- Requirement IDs covered: `FR-001`, `FR-002`, `FR-003`, `FR-004`, `FR-005`, `NFR-SEC-001`, `NFR-OBS-001`, `NFR-REL-001`, `NFR-OPS-001`
- Acceptance criteria covered: `AC-001`, `AC-002`, `AC-003`, `AC-004`, `AC-005`
- Contract surfaces changed:
  - [ ] `blueprint/contract.yaml` changed
  - [x] docs/templates/tests were synchronized
  - [x] generated consumer behavior changed

## Key Reviewer Files
- Primary files to review first:
  - `scripts/lib/blueprint/upgrade_consumer.py`
  - `tests/blueprint/test_upgrade_consumer.py`
  - `docs/platform/consumer/quickstart.md`
  - `docs/platform/consumer/troubleshooting.md`
- High-risk files:
  - `scripts/lib/blueprint/upgrade_consumer.py`

## Validation Evidence
- `python3 -m unittest tests.blueprint.test_upgrade_consumer` (22 tests passed)
- `python3 -m unittest tests.blueprint.test_upgrade_preflight` (4 tests passed)
- `python3 scripts/lib/docs/sync_blueprint_template_docs.py --check` (pass)
- `python3 scripts/lib/docs/sync_platform_seed_docs.py --check` (pass)
- `make quality-hooks-fast` (pass; includes `infra-validate` and `infra-contract-test-fast`)
- `make quality-hardening-review` (pass)

## Risk and Rollback
- Main risk(s): legacy generated-consumer repositories with larger drift may now surface more manual actions in preflight.
- Rollback strategy: revert this PR and rerun `python3 -m unittest tests.blueprint.test_upgrade_consumer tests.blueprint.test_upgrade_preflight && make quality-hooks-fast`.

## Deferred Proposals (Not Implemented)
- Add optional skeleton/stub snippets in manual-action output for missing targets after explicit schema approval.

## Follow-Up
- Next P0 after merge: Issue #129 (upgrade validation determinism).