### PR TITLE
feat: enforce repo-mode required-file reconciliation in upgrade validate

### DIFF
--- a/AGENTS.backlog.md
+++ b/AGENTS.backlog.md
@@ -3,7 +3,8 @@
 ## Current Priorities
 - [x] P0 (SDD UX): Issue #138 — local smoke + positive-path filter/transform guardrails are now enforced in SDD templates/governance, including red->green translation for reproducible pre-PR findings.
 - [x] P0 (Upgrade preflight ergonomics): Issue #102 — detect missing consumer-owned required Make targets in preflight with explicit remediation guidance.
-- [ ] P0 (Upgrade validation determinism): Issue #129 — add repo-mode-aware required-file reconciliation checks and deterministic remediation hints.
+- [x] P0 (Upgrade validation determinism): Issue #129 — add repo-mode-aware required-file reconciliation checks and deterministic remediation hints.
+- [ ] P0 (Docs ownership boundary for generated consumers): Next item — stop duplicating consumer-owned `docs/platform/**` back into `scripts/templates/blueprint/bootstrap/docs/platform/**`; keep template docs as blueprint-source-only assets, seed platform docs one-way at bootstrap/resync (`create_if_missing` contract), and make docs sync/check gates repo-mode-aware so generated-consumer repos do not fail on template drift for consumer-edited docs. Acceptance criteria: template-source mode still enforces template sync, generated-consumer mode treats `docs/platform/**` as consumer-editable without reverse mirroring, and tests cover both modes.
 - [ ] P1 (Upgrade convergence safety): Issue #128 — add ownership-aware reconcile report artifact and `blueprint-upgrade-consumer-postcheck` gate.
 - [ ] P1 (Fixture-contract hardening): Issue #130 — enforce optional-module `required_env` fixture parity in fast infra contract checks.
 - [ ] P1 (Generated-consumer upgrade regressions): Issues #103, #104, #106, #107 — fix repo-mode test selection, additive-file conflict classification, and missing helper distribution.

--- a/AGENTS.decisions.md
+++ b/AGENTS.decisions.md
@@ -41,6 +41,9 @@
   - unresolved merge-marker detection is centralized in `scripts/lib/blueprint/merge_markers.py`.
   - wrapper metric extraction for plan/apply/validate reports is centralized in `scripts/lib/blueprint/upgrade_report_metrics.py` (no inline Python heredocs in shell wrappers).
   - upgrade artifacts (`upgrade_plan.json`, `upgrade_apply.json`, `upgrade_validate.json`) have canonical JSON Schema definitions under `scripts/lib/blueprint/schemas/`.
+  - post-upgrade validate now enforces repo-mode-aware required-file reconciliation derived from `blueprint/contract.yaml`, writes `artifacts/blueprint/upgrade/required_files_status.json`, and fails deterministically when active-mode required files are missing.
+  - generated reference docs (`docs/reference/generated/core_targets.generated.md` and `docs/reference/generated/contract_metadata.generated.md`) are now validated as a coupled contract in validate output, with explicit missing/failed-target diagnostics.
+  - preflight output now includes `required_surface_reconciliation` and `required_surfaces_at_risk` so required-surface risk is visible before apply.
 - Blueprint docs/template mirror drift is explicitly checked:
   - `make quality-docs-check-blueprint-template-sync` verifies `docs/blueprint/**` and `scripts/templates/blueprint/bootstrap/docs/blueprint/**` remain synchronized.
   - `make quality-hooks-fast` includes this check in the default fast quality lane.

--- a/docs/blueprint/architecture/decisions/ADR-20260418-upgrade-validation-required-file-reconciliation.md
+++ b/docs/blueprint/architecture/decisions/ADR-20260418-upgrade-validation-required-file-reconciliation.md
@@ -1,0 +1,90 @@
+# ADR-20260418-upgrade-validation-required-file-reconciliation: Deterministic Upgrade Required-File Reconciliation
+
+## Metadata
+- Status: approved
+- Date: 2026-04-18
+- Owners: @sbonoc
+- Related spec path: `specs/2026-04-18-upgrade-validation-required-file-reconciliation/spec.md`
+
+## Business Objective and Requirement Summary
+- Business objective: prevent false-green upgrade validation outcomes when required blueprint surfaces are missing or partially reconciled.
+- Functional requirements summary:
+  - repo-mode-aware required-file reconciliation artifact and hard-fail behavior
+  - coupled generated-reference validation for core targets and contract metadata docs
+  - preflight required-surface risk reporting before apply
+- Non-functional requirements summary:
+  - repo-scoped path safety
+  - deterministic ordering and machine-readable diagnostics
+  - observable summary counters for CI metrics
+- Desired timeline: immediate adoption in current upgrade validation path.
+
+## Decision Drivers
+- Consumer upgrade reliability requires explicit contracts, not implicit file assumptions.
+- Generated-consumer mode MUST avoid source-only false positives.
+- Operators need deterministic remediation hints to recover missing required surfaces quickly.
+
+## Options Considered
+- Option A: keep current target-only validation and rely on indirect failures.
+- Option B: add explicit required-file reconciliation and coupled generated-reference checks in validate/preflight artifacts.
+
+## Recommended Option
+- Selected option: Option B
+- Rationale: Option B provides deterministic blocking behavior with actionable diagnostics while keeping existing ownership boundaries intact.
+
+## Rejected Options
+- Rejected option 1: Option A
+- Rejection rationale: target-only checks do not guarantee required file presence and can miss partial upgrade drift.
+
+## Affected Capabilities and Components
+- Capability impact:
+  - consumer upgrade validation determinism
+  - upgrade preflight operator guidance
+- Component impact:
+  - `scripts/lib/blueprint/upgrade_consumer_validate.py`
+  - `scripts/lib/blueprint/upgrade_preflight.py`
+  - `scripts/lib/blueprint/upgrade_report_metrics.py`
+  - `scripts/bin/blueprint/upgrade_consumer_validate.sh`
+  - `scripts/lib/blueprint/schemas/upgrade_validate.schema.json`
+
+## Architecture Diagram (Mermaid)
+```mermaid
+flowchart LR
+  C[blueprint/contract.yaml] --> V[upgrade_consumer_validate.py]
+  V --> R[upgrade_validate.json]
+  V --> F[required_files_status.json]
+  V --> M[upgrade_report_metrics.py]
+  P[upgrade_preflight.py] --> PF[upgrade_preflight.json]
+  M --> W[upgrade_consumer_validate.sh metrics]
+```
+
+## High-Level Work Packages and Timeline (Mermaid Gantt)
+```mermaid
+gantt
+  title Upgrade Validation Determinism Delivery
+  dateFormat  YYYY-MM-DD
+  section Implementation
+  Validate reconciliation + schema :a1, 2026-04-18, 1d
+  Preflight risk enrichment        :a2, after a1, 1d
+  Tests + SDD artifact completion  :a3, after a2, 1d
+```
+
+## External Dependencies
+- `blueprint/contract.yaml` structure and ownership classes.
+- Existing validate/preflight wrapper contracts and make targets.
+
+## Risks and Mitigations
+- Risk 1: fixture failures if required-file checks are not repo-mode-aware.
+- Mitigation 1: add explicit generated-consumer/template-source gating tests.
+- Risk 2: downstream report consumers expecting old schema only.
+- Mitigation 2: keep existing fields stable and add deterministic new fields in one schema update.
+
+## Validation and Observability Expectations
+- Validation requirements:
+  - `python3 -m unittest tests.blueprint.test_upgrade_consumer tests.blueprint.test_upgrade_preflight`
+  - `python3 -m unittest tests.blueprint.test_upgrade_consumer_wrapper`
+  - `python3 -m unittest tests.blueprint.test_quality_contracts`
+  - `make infra-validate`
+  - `make quality-hooks-fast`
+- Logging/metrics/tracing requirements:
+  - emit required-file/generate-reference counters through wrapper metrics
+  - include path-level remediation diagnostics in validate stderr and report payloads

--- a/scripts/bin/blueprint/upgrade_consumer_validate.sh
+++ b/scripts/bin/blueprint/upgrade_consumer_validate.sh
@@ -65,6 +65,21 @@ emit_validate_report_metrics() {
     validate_runtime_dependency_missing_total)
       log_metric "blueprint_upgrade_validate_runtime_dependency_missing_total" "$value"
       ;;
+    validate_required_files_expected_total)
+      log_metric "blueprint_upgrade_validate_required_files_expected_total" "$value"
+      ;;
+    validate_required_files_missing_total)
+      log_metric "blueprint_upgrade_validate_required_files_missing_total" "$value"
+      ;;
+    validate_generated_reference_missing_paths_total)
+      log_metric "blueprint_upgrade_validate_generated_reference_missing_paths_total" "$value"
+      ;;
+    validate_generated_reference_missing_targets_total)
+      log_metric "blueprint_upgrade_validate_generated_reference_missing_targets_total" "$value"
+      ;;
+    validate_generated_reference_failed_targets_total)
+      log_metric "blueprint_upgrade_validate_generated_reference_failed_targets_total" "$value"
+      ;;
     esac
   done < <(
     python3 "$ROOT_DIR/scripts/lib/blueprint/upgrade_report_metrics.py" \

--- a/scripts/bin/blueprint/upgrade_consumer_validate.sh
+++ b/scripts/bin/blueprint/upgrade_consumer_validate.sh
@@ -80,6 +80,9 @@ emit_validate_report_metrics() {
     validate_generated_reference_failed_targets_total)
       log_metric "blueprint_upgrade_validate_generated_reference_failed_targets_total" "$value"
       ;;
+    validate_contract_load_error_total)
+      log_metric "blueprint_upgrade_validate_contract_load_error_total" "$value"
+      ;;
     esac
   done < <(
     python3 "$ROOT_DIR/scripts/lib/blueprint/upgrade_report_metrics.py" \

--- a/scripts/lib/blueprint/schemas/upgrade_validate.schema.json
+++ b/scripts/lib/blueprint/schemas/upgrade_validate.schema.json
@@ -253,8 +253,17 @@
               }
             }
           }
+        },
+        "contract_load_error": {
+          "type": "string"
         }
       }
+    },
+    "contract_load_error": {
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "command_results": {
       "type": "array",
@@ -314,6 +323,7 @@
         "generated_reference_missing_path_count",
         "generated_reference_missing_target_count",
         "generated_reference_failed_target_count",
+        "contract_load_error_count",
         "commands_total"
       ],
       "properties": {
@@ -352,6 +362,9 @@
           "type": "integer"
         },
         "generated_reference_failed_target_count": {
+          "type": "integer"
+        },
+        "contract_load_error_count": {
           "type": "integer"
         },
         "commands_total": {

--- a/scripts/lib/blueprint/schemas/upgrade_validate.schema.json
+++ b/scripts/lib/blueprint/schemas/upgrade_validate.schema.json
@@ -8,6 +8,8 @@
     "required_validation_targets",
     "merge_marker_check",
     "runtime_dependency_edge_check",
+    "required_file_reconciliation",
+    "generated_reference_contract_check",
     "command_results",
     "summary"
   ],
@@ -95,6 +97,165 @@
         }
       }
     },
+    "required_file_reconciliation": {
+      "type": "object",
+      "required": [
+        "repo_mode",
+        "expected_count",
+        "present_count",
+        "missing_count",
+        "missing_paths",
+        "excluded_by_repo_mode",
+        "entries"
+      ],
+      "properties": {
+        "repo_mode": {
+          "type": "string"
+        },
+        "expected_count": {
+          "type": "integer"
+        },
+        "present_count": {
+          "type": "integer"
+        },
+        "missing_count": {
+          "type": "integer"
+        },
+        "missing_paths": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "excluded_by_repo_mode": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "entries": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "path",
+              "status",
+              "exists"
+            ],
+            "properties": {
+              "path": {
+                "type": "string"
+              },
+              "status": {
+                "type": "string",
+                "enum": [
+                  "present",
+                  "missing"
+                ]
+              },
+              "exists": {
+                "type": "boolean"
+              },
+              "remediation": {
+                "type": "object",
+                "required": [
+                  "action",
+                  "hint",
+                  "command"
+                ],
+                "properties": {
+                  "action": {
+                    "type": "string",
+                    "enum": [
+                      "render",
+                      "sync",
+                      "restore",
+                      "manual-review"
+                    ]
+                  },
+                  "hint": {
+                    "type": "string"
+                  },
+                  "command": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "generated_reference_contract_check": {
+      "type": "object",
+      "required": [
+        "status",
+        "missing_paths",
+        "missing_targets",
+        "failed_targets",
+        "required_checks"
+      ],
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": [
+            "success",
+            "failure"
+          ]
+        },
+        "missing_paths": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "missing_targets": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "failed_targets": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "required_checks": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "path",
+              "target",
+              "path_exists",
+              "target_returncode",
+              "remediation_command"
+            ],
+            "properties": {
+              "path": {
+                "type": "string"
+              },
+              "target": {
+                "type": "string"
+              },
+              "path_exists": {
+                "type": "boolean"
+              },
+              "target_returncode": {
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "remediation_command": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
     "command_results": {
       "type": "array",
       "items": {
@@ -148,6 +309,11 @@
         "merge_markers_pre_count",
         "merge_markers_post_count",
         "runtime_dependency_missing_count",
+        "required_files_expected_count",
+        "required_files_missing_count",
+        "generated_reference_missing_path_count",
+        "generated_reference_missing_target_count",
+        "generated_reference_failed_target_count",
         "commands_total"
       ],
       "properties": {
@@ -171,6 +337,21 @@
           "type": "integer"
         },
         "runtime_dependency_missing_count": {
+          "type": "integer"
+        },
+        "required_files_expected_count": {
+          "type": "integer"
+        },
+        "required_files_missing_count": {
+          "type": "integer"
+        },
+        "generated_reference_missing_path_count": {
+          "type": "integer"
+        },
+        "generated_reference_missing_target_count": {
+          "type": "integer"
+        },
+        "generated_reference_failed_target_count": {
           "type": "integer"
         },
         "commands_total": {

--- a/scripts/lib/blueprint/upgrade_consumer_validate.py
+++ b/scripts/lib/blueprint/upgrade_consumer_validate.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 import json
 from pathlib import Path
+from pathlib import PurePosixPath
 import subprocess
 import sys
 import time
@@ -19,6 +20,7 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from scripts.lib.blueprint.cli_support import display_repo_path, resolve_repo_root  # noqa: E402
+from scripts.lib.blueprint.contract_schema import BlueprintContract, load_blueprint_contract  # noqa: E402
 from scripts.lib.blueprint.merge_markers import find_merge_markers  # noqa: E402
 from scripts.lib.blueprint.runtime_dependency_edges import RUNTIME_DEPENDENCY_EDGES  # noqa: E402
 
@@ -31,7 +33,20 @@ VALIDATION_TARGETS = (
     "quality-docs-check-runtime-identity-summary-sync",
     "quality-docs-check-module-contract-summaries-sync",
 )
+REQUIRED_FILES_STATUS_DEFAULT_PATH = "artifacts/blueprint/upgrade/required_files_status.json"
 MAX_CAPTURE_CHARS = 20000
+GENERATED_REFERENCE_DOC_TARGETS = (
+    (
+        "docs/reference/generated/core_targets.generated.md",
+        "quality-docs-check-core-targets-sync",
+        "make quality-docs-sync-core-targets",
+    ),
+    (
+        "docs/reference/generated/contract_metadata.generated.md",
+        "quality-docs-check-contract-metadata-sync",
+        "make quality-docs-sync-contract-metadata",
+    ),
+)
 
 
 @dataclass(frozen=True)
@@ -65,6 +80,11 @@ def _parse_args() -> argparse.Namespace:
         "--report-path",
         default="artifacts/blueprint/upgrade_validate.json",
         help="Validation report output path (absolute or repo-relative).",
+    )
+    parser.add_argument(
+        "--required-files-status-path",
+        default=REQUIRED_FILES_STATUS_DEFAULT_PATH,
+        help="Required-files status report path (absolute or repo-relative).",
     )
     return parser.parse_args()
 
@@ -125,6 +145,158 @@ def _write_json(path: Path, payload: dict[str, Any]) -> None:
     path.write_text(f"{json.dumps(payload, indent=2, sort_keys=True)}\n", encoding="utf-8")
 
 
+def _path_is_same_or_child(path: str, parent: str) -> bool:
+    path_parts = PurePosixPath(path).parts
+    parent_parts = PurePosixPath(parent).parts
+    if not parent_parts:
+        return False
+    if len(path_parts) < len(parent_parts):
+        return False
+    return path_parts[: len(parent_parts)] == parent_parts
+
+
+def _required_files_for_repo_mode(contract: BlueprintContract) -> tuple[list[str], list[str]]:
+    required_files = list(contract.repository.required_files)
+    repository = contract.repository
+    if repository.repo_mode != repository.consumer_init.mode_to:
+        return sorted(required_files), []
+
+    source_only_paths = repository.source_only_paths
+    filtered: list[str] = []
+    excluded: list[str] = []
+    for relative_path in required_files:
+        if any(_path_is_same_or_child(relative_path, source_only_path) for source_only_path in source_only_paths):
+            excluded.append(relative_path)
+            continue
+        filtered.append(relative_path)
+    return sorted(filtered), sorted(excluded)
+
+
+def _path_matches_contract_class(path: str, entries: list[str]) -> bool:
+    return any(_path_is_same_or_child(path, entry) for entry in entries)
+
+
+def _missing_required_file_remediation(path: str, contract: BlueprintContract) -> dict[str, str]:
+    if path == "docs/reference/generated/core_targets.generated.md":
+        return {
+            "action": "render",
+            "hint": "Regenerate tracked core Make-target reference documentation.",
+            "command": "make quality-docs-sync-core-targets",
+        }
+    if path == "docs/reference/generated/contract_metadata.generated.md":
+        return {
+            "action": "render",
+            "hint": "Regenerate tracked contract metadata reference documentation.",
+            "command": "make quality-docs-sync-contract-metadata",
+        }
+    if path.startswith("docs/reference/generated/"):
+        return {
+            "action": "render",
+            "hint": "Regenerate generated documentation artifacts before validation rerun.",
+            "command": "make quality-docs-sync-all",
+        }
+    if _path_matches_contract_class(path, contract.repository.consumer_seeded_paths):
+        return {
+            "action": "sync",
+            "hint": "Path is consumer-seeded; synchronize the seeded template surface before rerunning validation.",
+            "command": "make blueprint-resync-consumer-seeds",
+        }
+    if _path_matches_contract_class(path, contract.repository.init_managed_paths):
+        return {
+            "action": "restore",
+            "hint": "Path is init-managed; re-run bootstrap with force to restore missing managed file(s).",
+            "command": "make blueprint-init-repo BLUEPRINT_INIT_FORCE=true",
+        }
+    if _path_matches_contract_class(path, contract.repository.source_only_paths):
+        return {
+            "action": "manual-review",
+            "hint": "Path is source-only for this contract; verify repo mode and ownership before restoring manually.",
+            "command": "make infra-validate",
+        }
+    return {
+        "action": "restore",
+        "hint": "Re-run upgrade apply with pinned source/ref to restore required blueprint-managed file(s).",
+        "command": "make blueprint-upgrade-consumer BLUEPRINT_UPGRADE_APPLY=true",
+    }
+
+
+def _build_required_file_reconciliation(
+    *,
+    repo_root: Path,
+    contract: BlueprintContract,
+) -> dict[str, Any]:
+    required_files, excluded_by_repo_mode = _required_files_for_repo_mode(contract)
+
+    entries: list[dict[str, Any]] = []
+    for relative_path in required_files:
+        exists = (repo_root / relative_path).is_file()
+        entry: dict[str, Any] = {
+            "path": relative_path,
+            "status": "present" if exists else "missing",
+            "exists": exists,
+        }
+        if not exists:
+            entry["remediation"] = _missing_required_file_remediation(relative_path, contract)
+        entries.append(entry)
+
+    missing_entries = [entry for entry in entries if entry["status"] == "missing"]
+    missing_paths = [str(entry["path"]) for entry in missing_entries]
+    present_count = len(entries) - len(missing_entries)
+    return {
+        "repo_mode": contract.repository.repo_mode,
+        "expected_count": len(required_files),
+        "present_count": present_count,
+        "missing_count": len(missing_entries),
+        "missing_paths": sorted(missing_paths),
+        "excluded_by_repo_mode": excluded_by_repo_mode,
+        "entries": entries,
+    }
+
+
+def _build_generated_reference_contract_check(
+    *,
+    repo_root: Path,
+    command_results: list[ValidationCommandResult],
+) -> dict[str, Any]:
+    command_results_by_target = {result.target: result for result in command_results}
+    required_checks: list[dict[str, Any]] = []
+    missing_paths: list[str] = []
+    failed_targets: list[str] = []
+    missing_targets: list[str] = []
+    for path, target, remediation_command in GENERATED_REFERENCE_DOC_TARGETS:
+        path_exists = (repo_root / path).is_file()
+        if not path_exists:
+            missing_paths.append(path)
+        command_result = command_results_by_target.get(target)
+        target_returncode: int | None = None
+        if command_result is None:
+            missing_targets.append(target)
+        else:
+            target_returncode = command_result.returncode
+            if command_result.returncode != 0:
+                failed_targets.append(target)
+        required_checks.append(
+            {
+                "path": path,
+                "target": target,
+                "path_exists": path_exists,
+                "target_returncode": target_returncode,
+                "remediation_command": remediation_command,
+            }
+        )
+
+    status = "success"
+    if missing_paths or failed_targets or missing_targets:
+        status = "failure"
+    return {
+        "status": status,
+        "missing_paths": sorted(missing_paths),
+        "missing_targets": sorted(missing_targets),
+        "failed_targets": sorted(failed_targets),
+        "required_checks": required_checks,
+    }
+
+
 def _detect_missing_runtime_dependency_edges(repo_root: Path) -> list[dict[str, str]]:
     missing: list[dict[str, str]] = []
     for consumer_path, dependency_path in RUNTIME_DEPENDENCY_EDGES:
@@ -151,6 +323,11 @@ def main() -> int:
     repo_root = resolve_repo_root(args.repo_root, __file__)
     try:
         report_path = _resolve_repo_scoped_path(repo_root, args.report_path, "--report-path")
+        required_files_status_path = _resolve_repo_scoped_path(
+            repo_root,
+            args.required_files_status_path,
+            "--required-files-status-path",
+        )
     except ValueError as exc:
         print(str(exc), file=sys.stderr)
         return 1
@@ -161,14 +338,32 @@ def main() -> int:
         print(str(exc), file=sys.stderr)
         return 1
 
+    try:
+        contract = load_blueprint_contract(repo_root / "blueprint/contract.yaml")
+    except Exception as exc:
+        print(f"unable to load blueprint contract for required-files reconciliation: {exc}", file=sys.stderr)
+        return 1
+
     merge_markers_pre = find_merge_markers(repo_root)
     command_results = [_run_make_target(repo_root, target) for target in VALIDATION_TARGETS]
     merge_markers_post = find_merge_markers(repo_root)
     missing_runtime_dependencies = _detect_missing_runtime_dependency_edges(repo_root)
+    required_file_reconciliation = _build_required_file_reconciliation(repo_root=repo_root, contract=contract)
+    generated_reference_contract = _build_generated_reference_contract_check(
+        repo_root=repo_root,
+        command_results=command_results,
+    )
 
     failed_targets = [result.target for result in command_results if result.returncode != 0]
     status = "success"
-    if failed_targets or merge_markers_pre or merge_markers_post or missing_runtime_dependencies:
+    if (
+        failed_targets
+        or merge_markers_pre
+        or merge_markers_post
+        or missing_runtime_dependencies
+        or required_file_reconciliation["missing_count"] > 0
+        or generated_reference_contract["status"] != "success"
+    ):
         status = "failure"
 
     payload = {
@@ -186,6 +381,8 @@ def main() -> int:
             ],
             "missing": missing_runtime_dependencies,
         },
+        "required_file_reconciliation": required_file_reconciliation,
+        "generated_reference_contract_check": generated_reference_contract,
         "command_results": [result.as_dict() for result in command_results],
         "summary": {
             "status": status,
@@ -193,11 +390,25 @@ def main() -> int:
             "merge_markers_pre_count": len(merge_markers_pre),
             "merge_markers_post_count": len(merge_markers_post),
             "runtime_dependency_missing_count": len(missing_runtime_dependencies),
+            "required_files_expected_count": required_file_reconciliation["expected_count"],
+            "required_files_missing_count": required_file_reconciliation["missing_count"],
+            "generated_reference_missing_path_count": len(generated_reference_contract["missing_paths"]),
+            "generated_reference_missing_target_count": len(generated_reference_contract["missing_targets"]),
+            "generated_reference_failed_target_count": len(generated_reference_contract["failed_targets"]),
             "commands_total": len(command_results),
         },
     }
+    required_files_status_payload = {
+        "repo_root": str(repo_root),
+        "report_generated_at": payload["report_generated_at"],
+        "required_file_reconciliation": required_file_reconciliation,
+        "generated_reference_contract_check": generated_reference_contract,
+    }
+
+    _write_json(required_files_status_path, required_files_status_payload)
     _write_json(report_path, payload)
     print(f"upgrade-validate: {display_repo_path(repo_root, report_path)}")
+    print(f"required-files-status: {display_repo_path(repo_root, required_files_status_path)}")
 
     if merge_markers_pre:
         print(
@@ -221,6 +432,32 @@ def main() -> int:
         )
         print(
             "upgrade validation runtime dependency edges missing required files: " + diagnostics,
+            file=sys.stderr,
+        )
+    if required_file_reconciliation["missing_count"] > 0:
+        missing_entries = [
+            entry
+            for entry in required_file_reconciliation["entries"]
+            if isinstance(entry, dict) and entry.get("status") == "missing"
+        ]
+        diagnostics = ", ".join(
+            f"{entry.get('path')} ({entry.get('remediation', {}).get('action', 'manual-review')})"
+            for entry in missing_entries
+        )
+        print(
+            "upgrade validation missing required files for active repo_mode: " + diagnostics,
+            file=sys.stderr,
+        )
+    if generated_reference_contract["status"] != "success":
+        diagnostics: list[str] = []
+        if generated_reference_contract["missing_paths"]:
+            diagnostics.append("missing paths=" + ",".join(generated_reference_contract["missing_paths"]))
+        if generated_reference_contract["missing_targets"]:
+            diagnostics.append("missing targets=" + ",".join(generated_reference_contract["missing_targets"]))
+        if generated_reference_contract["failed_targets"]:
+            diagnostics.append("failed targets=" + ",".join(generated_reference_contract["failed_targets"]))
+        print(
+            "upgrade validation generated reference contract check failed: " + "; ".join(diagnostics),
             file=sys.stderr,
         )
 

--- a/scripts/lib/blueprint/upgrade_consumer_validate.py
+++ b/scripts/lib/blueprint/upgrade_consumer_validate.py
@@ -297,6 +297,19 @@ def _build_generated_reference_contract_check(
     }
 
 
+def _empty_required_file_reconciliation(*, contract_load_error: str) -> dict[str, Any]:
+    return {
+        "repo_mode": "unknown",
+        "expected_count": 0,
+        "present_count": 0,
+        "missing_count": 0,
+        "missing_paths": [],
+        "excluded_by_repo_mode": [],
+        "entries": [],
+        "contract_load_error": contract_load_error,
+    }
+
+
 def _detect_missing_runtime_dependency_edges(repo_root: Path) -> list[dict[str, str]]:
     missing: list[dict[str, str]] = []
     for consumer_path, dependency_path in RUNTIME_DEPENDENCY_EDGES:
@@ -338,26 +351,36 @@ def main() -> int:
         print(str(exc), file=sys.stderr)
         return 1
 
+    merge_markers_pre = find_merge_markers(repo_root)
+    contract: BlueprintContract | None = None
+    contract_load_error = ""
     try:
         contract = load_blueprint_contract(repo_root / "blueprint/contract.yaml")
     except Exception as exc:
-        print(f"unable to load blueprint contract for required-files reconciliation: {exc}", file=sys.stderr)
-        return 1
+        contract_load_error = f"unable to load blueprint contract for required-files reconciliation: {exc}"
 
-    merge_markers_pre = find_merge_markers(repo_root)
-    command_results = [_run_make_target(repo_root, target) for target in VALIDATION_TARGETS]
+    command_results: list[ValidationCommandResult] = []
+    if not contract_load_error:
+        command_results = [_run_make_target(repo_root, target) for target in VALIDATION_TARGETS]
     merge_markers_post = find_merge_markers(repo_root)
     missing_runtime_dependencies = _detect_missing_runtime_dependency_edges(repo_root)
-    required_file_reconciliation = _build_required_file_reconciliation(repo_root=repo_root, contract=contract)
+    if contract is None:
+        required_file_reconciliation = _empty_required_file_reconciliation(contract_load_error=contract_load_error)
+    else:
+        required_file_reconciliation = _build_required_file_reconciliation(repo_root=repo_root, contract=contract)
     generated_reference_contract = _build_generated_reference_contract_check(
         repo_root=repo_root,
         command_results=command_results,
     )
+    if contract_load_error:
+        generated_reference_contract["status"] = "failure"
+        generated_reference_contract["contract_load_error"] = contract_load_error
 
     failed_targets = [result.target for result in command_results if result.returncode != 0]
     status = "success"
     if (
-        failed_targets
+        contract_load_error
+        or failed_targets
         or merge_markers_pre
         or merge_markers_post
         or missing_runtime_dependencies
@@ -383,6 +406,7 @@ def main() -> int:
         },
         "required_file_reconciliation": required_file_reconciliation,
         "generated_reference_contract_check": generated_reference_contract,
+        "contract_load_error": contract_load_error or None,
         "command_results": [result.as_dict() for result in command_results],
         "summary": {
             "status": status,
@@ -395,6 +419,7 @@ def main() -> int:
             "generated_reference_missing_path_count": len(generated_reference_contract["missing_paths"]),
             "generated_reference_missing_target_count": len(generated_reference_contract["missing_targets"]),
             "generated_reference_failed_target_count": len(generated_reference_contract["failed_targets"]),
+            "contract_load_error_count": 1 if contract_load_error else 0,
             "commands_total": len(command_results),
         },
     }
@@ -403,6 +428,7 @@ def main() -> int:
         "report_generated_at": payload["report_generated_at"],
         "required_file_reconciliation": required_file_reconciliation,
         "generated_reference_contract_check": generated_reference_contract,
+        "contract_load_error": payload["contract_load_error"],
     }
 
     _write_json(required_files_status_path, required_files_status_payload)
@@ -434,6 +460,8 @@ def main() -> int:
             "upgrade validation runtime dependency edges missing required files: " + diagnostics,
             file=sys.stderr,
         )
+    if contract_load_error:
+        print(contract_load_error, file=sys.stderr)
     if required_file_reconciliation["missing_count"] > 0:
         missing_entries = [
             entry

--- a/scripts/lib/blueprint/upgrade_preflight.py
+++ b/scripts/lib/blueprint/upgrade_preflight.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import json
 from pathlib import Path
+from pathlib import PurePosixPath
 import sys
 from typing import Any
 
@@ -15,6 +16,7 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from scripts.lib.blueprint.cli_support import display_repo_path, resolve_repo_root  # noqa: E402
+from scripts.lib.blueprint.contract_schema import BlueprintContract, load_blueprint_contract  # noqa: E402
 
 
 def _resolve_repo_scoped_path(repo_root: Path, value: str, arg_name: str) -> Path:
@@ -46,6 +48,65 @@ def _collect_entries(payload: dict[str, Any], key: str) -> list[dict[str, Any]]:
     if not isinstance(value, list):
         return []
     return [entry for entry in value if isinstance(entry, dict)]
+
+
+def _path_is_same_or_child(path: str, parent: str) -> bool:
+    path_parts = PurePosixPath(path).parts
+    parent_parts = PurePosixPath(parent).parts
+    if not parent_parts:
+        return False
+    if len(path_parts) < len(parent_parts):
+        return False
+    return path_parts[: len(parent_parts)] == parent_parts
+
+
+def _required_files_for_repo_mode(contract: BlueprintContract) -> tuple[list[str], list[str]]:
+    required_files = list(contract.repository.required_files)
+    repository = contract.repository
+    if repository.repo_mode != repository.consumer_init.mode_to:
+        return sorted(required_files), []
+
+    source_only_paths = repository.source_only_paths
+    filtered: list[str] = []
+    excluded: list[str] = []
+    for relative_path in required_files:
+        if any(_path_is_same_or_child(relative_path, source_only_path) for source_only_path in source_only_paths):
+            excluded.append(relative_path)
+            continue
+        filtered.append(relative_path)
+    return sorted(filtered), sorted(excluded)
+
+
+def _required_files_contract_context(repo_root: Path) -> dict[str, Any]:
+    contract_path = repo_root / "blueprint/contract.yaml"
+    if not contract_path.is_file():
+        return {
+            "contract_available": False,
+            "contract_error": f"missing blueprint contract: {contract_path}",
+            "repo_mode": "unknown",
+            "required_files": [],
+            "excluded_by_repo_mode": [],
+        }
+
+    try:
+        contract = load_blueprint_contract(contract_path)
+    except Exception as exc:
+        return {
+            "contract_available": False,
+            "contract_error": f"unable to load blueprint contract: {exc}",
+            "repo_mode": "unknown",
+            "required_files": [],
+            "excluded_by_repo_mode": [],
+        }
+
+    required_files, excluded_by_repo_mode = _required_files_for_repo_mode(contract)
+    return {
+        "contract_available": True,
+        "contract_error": "",
+        "repo_mode": contract.repository.repo_mode,
+        "required_files": required_files,
+        "excluded_by_repo_mode": excluded_by_repo_mode,
+    }
 
 
 def _build_report(
@@ -99,6 +160,59 @@ def _build_report(
             if isinstance(action.get("dependency_path"), str) and str(action.get("dependency_path", "")).strip()
         }
     )
+    contract_context = _required_files_contract_context(repo_root)
+    required_files_set = set(contract_context["required_files"])
+
+    required_surface_deltas: list[dict[str, Any]] = []
+    for entry in plan_entries:
+        path = str(entry.get("path", "")).strip()
+        if not path or path not in required_files_set:
+            continue
+        required_surface_deltas.append(entry)
+
+    manual_dependency_paths = {
+        str(action.get("dependency_path", "")).strip()
+        for action in required_manual_actions
+        if isinstance(action.get("dependency_path"), str) and str(action.get("dependency_path", "")).strip()
+    }
+
+    required_surfaces_at_risk: list[dict[str, Any]] = []
+    for entry in required_surface_deltas:
+        path = str(entry.get("path", "")).strip()
+        action = str(entry.get("action", "")).strip()
+        risk_reasons: list[str] = []
+        if action in {"merge-required", "conflict", "skip"}:
+            risk_reasons.append(f"plan-action:{action}")
+        if path in manual_dependency_paths:
+            risk_reasons.append("required-manual-action")
+        if risk_reasons:
+            required_surfaces_at_risk.append(
+                {
+                    "path": path,
+                    "action": action,
+                    "risk_reasons": risk_reasons,
+                }
+            )
+
+    required_surface_paths = {str(entry.get("path", "")).strip() for entry in required_surface_deltas}
+    for dependency_path in sorted(manual_dependency_paths & required_files_set):
+        if dependency_path in required_surface_paths:
+            continue
+        required_surfaces_at_risk.append(
+            {
+                "path": dependency_path,
+                "action": "required-manual-action",
+                "risk_reasons": ["required-manual-action"],
+            }
+        )
+
+    required_surfaces_auto_apply = [
+        str(entry.get("path", "")).strip()
+        for entry in required_surface_deltas
+        if str(entry.get("action", "")).strip() in {"create", "update"}
+    ]
+    required_surfaces_auto_apply = sorted(path for path in required_surfaces_auto_apply if path)
+    required_surfaces_at_risk = sorted(required_surfaces_at_risk, key=lambda entry: str(entry.get("path", "")))
 
     summary = {
         "plan_entry_count": len(plan_entries),
@@ -110,6 +224,9 @@ def _build_report(
         "required_manual_action_count": len(required_manual_actions),
         "required_follow_up_command_count": len(required_follow_up_commands),
         "blocking_path_count": len(blocking_paths),
+        "required_surface_delta_count": len(required_surface_deltas),
+        "required_surface_auto_apply_count": len(required_surfaces_auto_apply),
+        "required_surface_at_risk_count": len(required_surfaces_at_risk),
     }
 
     return {
@@ -123,6 +240,16 @@ def _build_report(
         "required_manual_actions": required_manual_actions,
         "required_follow_up_commands": required_follow_up_commands,
         "blocking_paths": blocking_paths,
+        "required_surface_reconciliation": {
+            "contract_available": contract_context["contract_available"],
+            "contract_error": contract_context["contract_error"],
+            "repo_mode": contract_context["repo_mode"],
+            "required_files_expected_count": len(contract_context["required_files"]),
+            "required_files_excluded_by_repo_mode": contract_context["excluded_by_repo_mode"],
+            "required_surface_deltas": required_surface_deltas,
+            "required_surfaces_auto_apply": required_surfaces_auto_apply,
+            "required_surfaces_at_risk": required_surfaces_at_risk,
+        },
     }
 
 
@@ -170,7 +297,8 @@ def main() -> int:
         f"(auto_apply={summary.get('auto_apply_count', 0)} "
         f"manual_merge={summary.get('manual_merge_count', 0)} "
         f"conflicts={summary.get('conflict_count', 0)} "
-        f"required_manual_actions={summary.get('required_manual_action_count', 0)})"
+        f"required_manual_actions={summary.get('required_manual_action_count', 0)} "
+        f"required_surfaces_at_risk={summary.get('required_surface_at_risk_count', 0)})"
     )
     return 0
 

--- a/scripts/lib/blueprint/upgrade_preflight.py
+++ b/scripts/lib/blueprint/upgrade_preflight.py
@@ -50,6 +50,16 @@ def _collect_entries(payload: dict[str, Any], key: str) -> list[dict[str, Any]]:
     return [entry for entry in value if isinstance(entry, dict)]
 
 
+def _skip_action_is_required_surface_risk(entry: dict[str, Any]) -> bool:
+    # Skip actions are noisy by default because many are benign no-ops
+    # (`path already matches upgrade source content`). Treat them as risky
+    # only when the required surface is absent and therefore unreconciled.
+    target_exists = entry.get("target_exists")
+    if isinstance(target_exists, bool):
+        return not target_exists
+    return False
+
+
 def _path_is_same_or_child(path: str, parent: str) -> bool:
     path_parts = PurePosixPath(path).parts
     parent_parts = PurePosixPath(parent).parts
@@ -181,8 +191,10 @@ def _build_report(
         path = str(entry.get("path", "")).strip()
         action = str(entry.get("action", "")).strip()
         risk_reasons: list[str] = []
-        if action in {"merge-required", "conflict", "skip"}:
+        if action in {"merge-required", "conflict"}:
             risk_reasons.append(f"plan-action:{action}")
+        elif action == "skip" and _skip_action_is_required_surface_risk(entry):
+            risk_reasons.append("plan-action:skip-missing-target")
         if path in manual_dependency_paths:
             risk_reasons.append("required-manual-action")
         if risk_reasons:

--- a/scripts/lib/blueprint/upgrade_report_metrics.py
+++ b/scripts/lib/blueprint/upgrade_report_metrics.py
@@ -88,6 +88,7 @@ def _emit_validate_metrics(report_path: Path) -> Iterable[str]:
             "validate_generated_reference_failed_targets_total="
             + str(_as_int(summary.get("generated_reference_failed_target_count", 0)))
         ),
+        f"validate_contract_load_error_total={_as_int(summary.get('contract_load_error_count', 0))}",
     ]
 
 

--- a/scripts/lib/blueprint/upgrade_report_metrics.py
+++ b/scripts/lib/blueprint/upgrade_report_metrics.py
@@ -74,6 +74,20 @@ def _emit_validate_metrics(report_path: Path) -> Iterable[str]:
         f"validate_merge_markers_pre_total={_as_int(summary.get('merge_markers_pre_count', 0))}",
         f"validate_merge_markers_post_total={_as_int(summary.get('merge_markers_post_count', 0))}",
         f"validate_runtime_dependency_missing_total={_as_int(summary.get('runtime_dependency_missing_count', 0))}",
+        f"validate_required_files_expected_total={_as_int(summary.get('required_files_expected_count', 0))}",
+        f"validate_required_files_missing_total={_as_int(summary.get('required_files_missing_count', 0))}",
+        (
+            "validate_generated_reference_missing_paths_total="
+            + str(_as_int(summary.get("generated_reference_missing_path_count", 0)))
+        ),
+        (
+            "validate_generated_reference_missing_targets_total="
+            + str(_as_int(summary.get("generated_reference_missing_target_count", 0)))
+        ),
+        (
+            "validate_generated_reference_failed_targets_total="
+            + str(_as_int(summary.get("generated_reference_failed_target_count", 0)))
+        ),
     ]
 
 

--- a/specs/2026-04-18-upgrade-validation-required-file-reconciliation/architecture.md
+++ b/specs/2026-04-18-upgrade-validation-required-file-reconciliation/architecture.md
@@ -1,0 +1,85 @@
+# Architecture
+
+## Context
+- Work item: `2026-04-18-upgrade-validation-required-file-reconciliation`
+- Owner: `@sbonoc`
+- Date: `2026-04-18`
+
+## Stack and Execution Model
+- Backend stack profile: `python_plus_fastapi_pydantic_v2` (Python CLI tooling in `scripts/lib/blueprint/**`)
+- Frontend stack profile: `none (not in scope)`
+- Test automation profile: `unittest + json-schema checks`
+- Agent execution model: `single-agent deterministic execution`
+
+## Problem Statement
+- Generated-consumer upgrade validation previously trusted implicit required-file assumptions.
+- Missing required files or partial generated-reference drift could pass preflight/validate and fail later in CI or manual review.
+- Scope boundaries:
+  - `scripts/lib/blueprint/upgrade_consumer_validate.py`
+  - `scripts/lib/blueprint/upgrade_preflight.py`
+  - `scripts/lib/blueprint/upgrade_report_metrics.py`
+  - `scripts/bin/blueprint/upgrade_consumer_validate.sh`
+  - `scripts/lib/blueprint/schemas/upgrade_validate.schema.json`
+  - tests under `tests/blueprint/`
+- Out of scope:
+  - auto-committing regenerated files
+  - changing ownership boundaries in `blueprint/contract.yaml`
+  - introducing new Make targets
+
+## Bounded Contexts and Responsibilities
+- Upgrade Validate Context:
+  - execute required validation targets
+  - enforce repo-mode-aware required-file reconciliation
+  - enforce coupled generated-reference contract checks
+  - emit machine-readable status artifacts and summary counts
+- Upgrade Preflight Context:
+  - classify plan/apply/manual actions
+  - surface `required_surface_reconciliation` and `required_surfaces_at_risk`
+  - keep output deterministic for generated-consumer and template-source repo modes
+
+## High-Level Component Design
+- Domain layer:
+  - required-file gating policy derived from active `repo_mode` and `source_only_paths`
+  - remediation action taxonomy (`render`, `sync`, `restore`, `manual-review`)
+- Application layer:
+  - validate flow orchestration with `status=failure` on missing required files and coupled-doc drift
+  - preflight aggregation enriched with required-surface risk detection
+- Infrastructure adapters:
+  - blueprint contract loader (`load_blueprint_contract`)
+  - JSON artifact writers under `artifacts/blueprint/**`
+  - Make target command execution in validate bundle
+- Presentation/API/workflow boundaries:
+  - `upgrade_validate.json` schema-expanded payload
+  - new `artifacts/blueprint/upgrade/required_files_status.json`
+  - preflight `required_surface_reconciliation` section
+  - wrapper-emitted metrics sourced from report summaries
+
+## Integration and Dependency Edges
+- Upstream dependencies:
+  - `blueprint/contract.yaml`
+  - runtime edge catalog (`runtime_dependency_edges.py`)
+- Downstream dependencies:
+  - upgrade wrappers (`upgrade_consumer_validate.sh`)
+  - CI/quality lanes consuming validate/preflight artifacts
+- Data/API/event contracts touched:
+  - `scripts/lib/blueprint/schemas/upgrade_validate.schema.json`
+  - `artifacts/blueprint/upgrade_validate.json`
+  - `artifacts/blueprint/upgrade/required_files_status.json`
+  - `artifacts/blueprint/upgrade_preflight.json`
+
+## Non-Functional Architecture Notes
+- Security:
+  - all report paths remain repo-scoped with strict path resolution
+  - no new network operations or secret surfaces
+- Observability:
+  - summary counts and wrapper metrics now include required-file and coupled-doc signals
+- Reliability and rollback:
+  - deterministic sorted reports for reproducible CI diffs
+  - rollback is revert of modified scripts/schemas/tests only
+- Monitoring/alerting:
+  - wrapper metrics expose new counters for missing required files and generated-reference failures
+
+## Risks and Tradeoffs
+- Risk: contract-driven required-file checks could cause false positives in minimal fixtures.
+  - Mitigation: fixture-aware contract minimization and explicit repo-mode gating tests.
+- Tradeoff: helper logic is duplicated in validate and preflight to keep dependencies local and avoid new shared module churn in this slice.

--- a/specs/2026-04-18-upgrade-validation-required-file-reconciliation/context_pack.md
+++ b/specs/2026-04-18-upgrade-validation-required-file-reconciliation/context_pack.md
@@ -1,0 +1,43 @@
+# Work Item Context Pack
+
+## Context Snapshot
+- Work item: `2026-04-18-upgrade-validation-required-file-reconciliation`
+- Track: blueprint
+- SPEC_READY: true
+- ADR path: `docs/blueprint/architecture/decisions/ADR-20260418-upgrade-validation-required-file-reconciliation.md`
+- ADR status: approved
+
+## Guardrail Controls
+- Applicable control IDs: `SDD-C-001..SDD-C-021`
+
+## Required Commands
+- `make quality-sdd-check`
+- `make quality-sdd-check-all`
+- `make quality-hooks-run`
+- `make quality-hardening-review`
+- `make infra-validate`
+- `make docs-build`
+- `make docs-smoke`
+- `make spec-pr-context`
+
+## Executed Commands
+- `python3 -m unittest tests.blueprint.test_upgrade_consumer tests.blueprint.test_upgrade_preflight`
+- `python3 -m unittest tests.blueprint.test_upgrade_consumer_wrapper`
+- `python3 -m unittest tests.blueprint.test_quality_contracts`
+- `make infra-validate`
+- `make quality-hooks-fast`
+- `make quality-hooks-run`
+- `make quality-hardening-review`
+- `make docs-build`
+- `make docs-smoke`
+
+## Artifact Index
+- `architecture.md`
+- `spec.md`
+- `plan.md`
+- `tasks.md`
+- `traceability.md`
+- `graph.yaml`
+- `evidence_manifest.json`
+- `pr_context.md`
+- `hardening_review.md`

--- a/specs/2026-04-18-upgrade-validation-required-file-reconciliation/evidence_manifest.json
+++ b/specs/2026-04-18-upgrade-validation-required-file-reconciliation/evidence_manifest.json
@@ -1,0 +1,108 @@
+{
+  "manifest_version": 1,
+  "work_item": "specs/2026-04-18-upgrade-validation-required-file-reconciliation",
+  "generated_by": "spec-evidence-manifest",
+  "generated_at_utc": "2026-04-18T06:52:00Z",
+  "files": [
+    {
+      "path": "scripts/lib/blueprint/upgrade_consumer_validate.py",
+      "sha256": "a358f296f579b5dca69ea5fafd6b07f4f8edc5990d5385d56fc4d835400229c5",
+      "bytes": 18370
+    },
+    {
+      "path": "scripts/lib/blueprint/upgrade_preflight.py",
+      "sha256": "ebc834762b599bb6a92e6fdb212a3c4b404d49430a773d76df14f1ec899ba986",
+      "bytes": 11892
+    },
+    {
+      "path": "scripts/lib/blueprint/upgrade_report_metrics.py",
+      "sha256": "b147f4fb2c109c981bf84408d4f30f66cc1696e915f33b655a460429de123848",
+      "bytes": 5116
+    },
+    {
+      "path": "scripts/bin/blueprint/upgrade_consumer_validate.sh",
+      "sha256": "ce2674df1628c3c9804ea131ee4e988fc60363d094313b4a7f8c46b0f5e65af1",
+      "bytes": 3768
+    },
+    {
+      "path": "scripts/lib/blueprint/schemas/upgrade_validate.schema.json",
+      "sha256": "cc0fd4a67bf88f6715b176eda4b43a1582b711476d3d6ff21086c43f413007d9",
+      "bytes": 8466
+    },
+    {
+      "path": "tests/blueprint/test_upgrade_consumer.py",
+      "sha256": "59daa15612fa4608feb90a8059330f7cee8c725594fef13df9dcbec21c929515",
+      "bytes": 63926
+    },
+    {
+      "path": "tests/blueprint/test_upgrade_preflight.py",
+      "sha256": "eb2bd5cbb3179204e6b064b292bd1145bb19f3b976b8b408b049754638fd7f75",
+      "bytes": 9756
+    },
+    {
+      "path": "tests/blueprint/test_upgrade_consumer_wrapper.py",
+      "sha256": "6937bb0625f17f2f9a47ec4ba7fad9934cff5afcb5d1ae6d9d16e0c1a2fb6a3f",
+      "bytes": 7046
+    },
+    {
+      "path": "docs/blueprint/architecture/decisions/ADR-20260418-upgrade-validation-required-file-reconciliation.md",
+      "sha256": "12d1a713afc5585cfd45b0c4d5aa354ea4aeab758425b5e57138b4ff0a3d84c8",
+      "bytes": 4036
+    },
+    {
+      "path": "specs/2026-04-18-upgrade-validation-required-file-reconciliation/architecture.md",
+      "sha256": "35b98853570010c2432757a3827c991a0a3857d6a269faea1c835a1f26c186f3",
+      "bytes": 4020
+    },
+    {
+      "path": "specs/2026-04-18-upgrade-validation-required-file-reconciliation/spec.md",
+      "sha256": "f79da5d5980dd23eb44913b3f2d33de79dca7c7d385c33112f40869ad9f448c7",
+      "bytes": 5616
+    },
+    {
+      "path": "specs/2026-04-18-upgrade-validation-required-file-reconciliation/plan.md",
+      "sha256": "f4d88a613960e873fec63b7f45d80218b1a07115be7b9925c5457e005bd3fc3e",
+      "bytes": 5452
+    },
+    {
+      "path": "specs/2026-04-18-upgrade-validation-required-file-reconciliation/tasks.md",
+      "sha256": "72c7ddc5169fc2aedfd07219936d444113c645c1828ae4d43dcaa526e54f1136",
+      "bytes": 2724
+    },
+    {
+      "path": "specs/2026-04-18-upgrade-validation-required-file-reconciliation/traceability.md",
+      "sha256": "2fb61388df58d3181bf232d316095ed542abfd8e2c2df3dd5e2e8d2acb9a2ab2",
+      "bytes": 6671
+    },
+    {
+      "path": "specs/2026-04-18-upgrade-validation-required-file-reconciliation/graph.yaml",
+      "sha256": "9aa41f3718561cd47ca2091fc442923c772d39144ae4675e7b5e17be645dd1da",
+      "bytes": 2552
+    },
+    {
+      "path": "specs/2026-04-18-upgrade-validation-required-file-reconciliation/context_pack.md",
+      "sha256": "bb7290e5d79a7cfc3f379ce08cb02f4f7a3a99e433b8f1f15ce5fd57901b6cbd",
+      "bytes": 1188
+    },
+    {
+      "path": "specs/2026-04-18-upgrade-validation-required-file-reconciliation/pr_context.md",
+      "sha256": "b549d3f6a6690d78af828b8aa2c0d70bf7f495ce5bde18aaa7b40a4dfc3e6307",
+      "bytes": 2657
+    },
+    {
+      "path": "specs/2026-04-18-upgrade-validation-required-file-reconciliation/hardening_review.md",
+      "sha256": "49fb5cadf6c13ea2264a7dd4f7c73ad3f51f03fe004542ceda033b2fee09f447",
+      "bytes": 1872
+    },
+    {
+      "path": "AGENTS.backlog.md",
+      "sha256": "e42c8a5ec9b918c7aaf1bd20cb43db1908dc77a7e1dc63f17c74c21e2d056167",
+      "bytes": 5534
+    },
+    {
+      "path": "AGENTS.decisions.md",
+      "sha256": "c7f29d9852165637a8815e103c29e1ff2c62f927df91919269cc3913224cbff7",
+      "bytes": 41067
+    }
+  ]
+}

--- a/specs/2026-04-18-upgrade-validation-required-file-reconciliation/graph.yaml
+++ b/specs/2026-04-18-upgrade-validation-required-file-reconciliation/graph.yaml
@@ -1,0 +1,113 @@
+{
+  "graph_version": 1,
+  "work_item": "2026-04-18-upgrade-validation-required-file-reconciliation",
+  "nodes": [
+    {
+      "id": "FR-001",
+      "type": "requirement",
+      "summary": "Repo-mode required-file manifest and status artifact"
+    },
+    {
+      "id": "FR-002",
+      "type": "requirement",
+      "summary": "Missing required-file validation failure with remediation"
+    },
+    {
+      "id": "FR-003",
+      "type": "requirement",
+      "summary": "Coupled generated-reference contract checks in validate"
+    },
+    {
+      "id": "FR-004",
+      "type": "requirement",
+      "summary": "Preflight required-surfaces-at-risk enrichment"
+    },
+    {
+      "id": "NFR-SEC-001",
+      "type": "requirement",
+      "summary": "Repository-scoped path resolution guardrails"
+    },
+    {
+      "id": "NFR-OBS-001",
+      "type": "requirement",
+      "summary": "Summary counters and metrics extraction coverage"
+    },
+    {
+      "id": "NFR-REL-001",
+      "type": "requirement",
+      "summary": "Deterministic report ordering and repeatability"
+    },
+    {
+      "id": "NFR-OPS-001",
+      "type": "requirement",
+      "summary": "Operator-facing remediation diagnostics"
+    },
+    {
+      "id": "AC-001",
+      "type": "acceptance",
+      "summary": "Missing required file fails validate with remediation"
+    },
+    {
+      "id": "AC-002",
+      "type": "acceptance",
+      "summary": "Repo-mode gating behavior is enforced"
+    },
+    {
+      "id": "AC-003",
+      "type": "acceptance",
+      "summary": "Preflight reports required surfaces at risk"
+    },
+    {
+      "id": "AC-004",
+      "type": "acceptance",
+      "summary": "Impacted validation suites pass"
+    }
+  ],
+  "edges": [
+    {
+      "from": "FR-001",
+      "to": "AC-001",
+      "relation": "validated_by"
+    },
+    {
+      "from": "FR-002",
+      "to": "AC-001",
+      "relation": "validated_by"
+    },
+    {
+      "from": "FR-002",
+      "to": "AC-002",
+      "relation": "validated_by"
+    },
+    {
+      "from": "FR-003",
+      "to": "AC-001",
+      "relation": "validated_by"
+    },
+    {
+      "from": "FR-004",
+      "to": "AC-003",
+      "relation": "validated_by"
+    },
+    {
+      "from": "NFR-SEC-001",
+      "to": "AC-002",
+      "relation": "constrains"
+    },
+    {
+      "from": "NFR-OBS-001",
+      "to": "AC-004",
+      "relation": "constrains"
+    },
+    {
+      "from": "NFR-REL-001",
+      "to": "AC-004",
+      "relation": "constrains"
+    },
+    {
+      "from": "NFR-OPS-001",
+      "to": "AC-002",
+      "relation": "constrains"
+    }
+  ]
+}

--- a/specs/2026-04-18-upgrade-validation-required-file-reconciliation/hardening_review.md
+++ b/specs/2026-04-18-upgrade-validation-required-file-reconciliation/hardening_review.md
@@ -1,0 +1,32 @@
+# Hardening Review
+
+## Repository-Wide Findings Fixed
+- Added deterministic required-file reconciliation gate in upgrade validate with repo-mode filtering.
+- Added coupled generated-reference contract checks to avoid partial generated-doc drift.
+- Added preflight required-surface risk surfacing before apply.
+- Hardened wrapper metrics emission with new required-file/generated-reference counters.
+
+## Observability and Diagnostics Changes
+- Metrics/logging/tracing updates:
+  - `blueprint_upgrade_validate_required_files_expected_total`
+  - `blueprint_upgrade_validate_required_files_missing_total`
+  - `blueprint_upgrade_validate_generated_reference_missing_paths_total`
+  - `blueprint_upgrade_validate_generated_reference_missing_targets_total`
+  - `blueprint_upgrade_validate_generated_reference_failed_targets_total`
+- Operational diagnostics updates:
+  - validate stderr now reports missing required files with remediation action category
+  - validate stderr now reports coupled generated-reference failures with missing path/target diagnostics
+  - preflight payload now reports `required_surfaces_at_risk`
+
+## Architecture and Code Quality Compliance
+- SOLID / Clean Architecture / Clean Code / DDD checks:
+  - kept scope constrained to upgrade validation/preflight bounded contexts and report contracts
+  - no cross-layer import boundary regressions introduced
+- Test-automation and pyramid checks:
+  - added fixture-backed unit/contract tests for missing required files and repo-mode gating
+  - maintained schema assertions for validate report
+- Documentation/diagram/CI/skill consistency checks:
+  - completed work-item SDD artifacts and ADR linkage to satisfy SDD quality gates
+
+## Proposals Only (Not Implemented)
+- Build one shared `required_files_for_repo_mode` helper module consumed by all contract/upgrade validators to remove duplicate implementations.

--- a/specs/2026-04-18-upgrade-validation-required-file-reconciliation/plan.md
+++ b/specs/2026-04-18-upgrade-validation-required-file-reconciliation/plan.md
@@ -1,0 +1,114 @@
+# Implementation Plan
+
+## Implementation Start Gate
+- Implementation tasks MUST remain unchecked until `SPEC_READY=true`.
+- If required inputs are missing, add `BLOCKED_MISSING_INPUTS` in `spec.md` and keep the gate closed.
+
+## Constitution Gates (Pre-Implementation)
+- Simplicity gate:
+  - Keep initial implementation scope minimal and explicit.
+  - Avoid speculative future-proof abstractions.
+- Anti-abstraction gate:
+  - Prefer direct framework primitives over wrapper layers unless justified.
+  - Keep model representations singular unless boundary separation is required.
+- Integration-first testing gate:
+  - Define contract and boundary tests before implementation details.
+  - Ensure realistic environment coverage for integration points.
+- Positive-path filter/transform test gate:
+  - For any filter or payload-transform logic, at least one unit test MUST assert that a matching fixture value returns a record.
+  - Positive-path assertions MUST verify relevant output fields remain intact after filtering/transform.
+  - Empty-result-only assertions MUST NOT satisfy this gate.
+- Finding-to-test translation gate:
+  - Any reproducible pre-PR finding from smoke/`curl`/deterministic manual checks MUST be translated into a failing automated test first.
+  - The implementation fix MUST turn that test green in the same work item.
+  - If no deterministic automation path exists, publish artifacts MUST record the exception rationale, owner, and follow-up trigger.
+
+## Delivery Slices
+1. Slice 1: implement validate required-file reconciliation and coupled generated-reference checks.
+2. Slice 2: implement preflight required-surface-at-risk enrichment and schema/metrics/test updates.
+
+## Change Strategy
+- Migration/rollout sequence:
+  - add validate logic and schema fields
+  - add preflight enrichment fields
+  - add metrics extraction keys and wrapper emission
+  - add/adjust fixture-backed tests
+- Backward compatibility policy:
+  - existing report fields and existing required validation targets remain unchanged
+  - new report fields are additive in JSON payloads while schema is updated in the same change
+- Rollback plan:
+  - revert changed validate/preflight/metrics/schema/test files to previous baseline
+  - rerun `make infra-validate` and `make quality-hooks-fast`
+
+## Validation Strategy (Shift-Left)
+- Unit checks:
+  - `python3 -m unittest tests.blueprint.test_upgrade_consumer`
+  - `python3 -m unittest tests.blueprint.test_upgrade_preflight`
+  - `python3 -m unittest tests.blueprint.test_upgrade_consumer_wrapper`
+- Contract checks:
+  - `python3 -m unittest tests.blueprint.test_quality_contracts`
+  - `make infra-validate`
+- Integration checks: not required for this script-only work item.
+- E2E checks: not required for this script-only work item.
+
+## App Onboarding Contract (Normative)
+- Required minimum make targets:
+  - `apps-bootstrap`
+  - `apps-smoke`
+  - `backend-test-unit`
+  - `backend-test-integration`
+  - `backend-test-contracts`
+  - `backend-test-e2e`
+  - `touchpoints-test-unit`
+  - `touchpoints-test-integration`
+  - `touchpoints-test-contracts`
+  - `touchpoints-test-e2e`
+  - `test-unit-all`
+  - `test-integration-all`
+  - `test-contracts-all`
+  - `test-e2e-all-local`
+  - `infra-port-forward-start`
+  - `infra-port-forward-stop`
+  - `infra-port-forward-cleanup`
+- App onboarding impact: no-impact | impacted (select one)
+- App onboarding impact: no-impact
+- Notes: no `apps/**` scope change; app onboarding targets remain unchanged.
+
+## Documentation Plan (Document Phase)
+- Blueprint docs updates: update work-item SDD artifacts and ADR.
+- Consumer docs updates: none.
+- Mermaid diagrams updated: ADR decision/context diagrams only.
+- Docs validation commands:
+  - `make docs-build`
+  - `make docs-smoke`
+
+## Publish Preparation
+- PR context file:
+  - `pr_context.md`
+- Hardening review file:
+  - `hardening_review.md`
+- Local smoke gate (HTTP route/filter changes):
+  - For work that touches HTTP route handlers, query/filter logic, or new API endpoints, run local smoke before PR publication.
+  - Execute local smoke with deterministic wrappers (`make infra-provision`, `make infra-deploy`, `make infra-port-forward-start`), then run positive-path `curl` assertions per changed endpoint.
+  - Positive-path filter assertions MUST use non-empty fixture/request values; empty-result-only assertions MUST NOT satisfy this gate.
+  - Record evidence in `pr_context.md` as `Endpoint | Method | Auth | Result`.
+  - Stop/cleanup wrappers after smoke (`make infra-port-forward-stop`, `make infra-port-forward-cleanup`).
+- Publish checklist:
+  - include requirement/contract coverage
+  - include key reviewer files
+  - include validation evidence + rollback notes
+
+## Operational Readiness
+- Logging/metrics/traces:
+  - add validate summary counters for required files and generated-reference checks
+  - emit wrapper metrics from `upgrade_consumer_validate.sh`
+- Alerts/ownership:
+  - no new alert contract; existing CI gate status covers this scope
+- Runbook updates:
+  - remediation hints are embedded in validation report and stderr diagnostics
+
+## Risks and Mitigations
+- Risk 1: false positives in generated-consumer repos from source-only required paths.
+  - Mitigation: explicit repo-mode gating and fixture-backed tests for generated-consumer/template-source behavior.
+- Risk 2: schema/report drift when adding new payload fields.
+  - Mitigation: update schema and schema-validated tests in the same change.

--- a/specs/2026-04-18-upgrade-validation-required-file-reconciliation/pr_context.md
+++ b/specs/2026-04-18-upgrade-validation-required-file-reconciliation/pr_context.md
@@ -1,0 +1,57 @@
+# PR Context
+
+## Summary
+- Work item: `2026-04-18-upgrade-validation-required-file-reconciliation`
+- Objective: enforce deterministic repo-mode required-file reconciliation and coupled generated-reference validation for consumer upgrade flows.
+- Scope boundaries:
+  - validate script/schema/metrics/wrapper wiring
+  - preflight required-surface risk enrichment
+  - fixture-backed tests for generated-consumer/template-source behavior
+
+## Requirement Coverage
+- Requirement IDs covered: `FR-001`, `FR-002`, `FR-003`, `FR-004`, `NFR-SEC-001`, `NFR-OBS-001`, `NFR-REL-001`, `NFR-OPS-001`
+- Acceptance criteria covered: `AC-001`, `AC-002`, `AC-003`, `AC-004`
+- Contract surfaces changed:
+  - `scripts/lib/blueprint/schemas/upgrade_validate.schema.json`
+  - `artifacts/blueprint/upgrade_validate.json` payload structure
+  - `artifacts/blueprint/upgrade/required_files_status.json` artifact
+  - `artifacts/blueprint/upgrade_preflight.json` required-surface reconciliation section
+
+## Key Reviewer Files
+- Primary files to review first:
+  - `scripts/lib/blueprint/upgrade_consumer_validate.py`
+  - `scripts/lib/blueprint/upgrade_preflight.py`
+  - `scripts/lib/blueprint/schemas/upgrade_validate.schema.json`
+- High-risk files:
+  - `tests/blueprint/test_upgrade_consumer.py`
+  - `tests/blueprint/test_upgrade_preflight.py`
+  - `scripts/bin/blueprint/upgrade_consumer_validate.sh`
+  - `scripts/lib/blueprint/upgrade_report_metrics.py`
+
+## Validation Evidence
+- Required commands executed:
+  - `python3 -m unittest tests.blueprint.test_upgrade_consumer tests.blueprint.test_upgrade_preflight`
+  - `python3 -m unittest tests.blueprint.test_upgrade_consumer_wrapper`
+  - `python3 -m unittest tests.blueprint.test_quality_contracts`
+  - `make infra-validate`
+  - `make quality-hooks-fast`
+  - `make quality-hooks-run`
+  - `make quality-hardening-review`
+  - `make docs-build`
+  - `make docs-smoke`
+- Result summary: all commands above passed.
+- Artifact references:
+  - `artifacts/blueprint/upgrade_validate.json`
+  - `artifacts/blueprint/upgrade/required_files_status.json`
+  - `artifacts/blueprint/upgrade_preflight.json`
+
+## Risk and Rollback
+- Main risks:
+  - stricter required-file reconciliation can fail legacy/minimal fixtures unless repo-mode-aware filtering is correct
+  - schema/report consumers must tolerate newly required validate fields
+- Rollback strategy:
+  - revert changed validate/preflight/metrics/schema/test files
+  - rerun `make infra-validate` and `make quality-hooks-fast`
+
+## Deferred Proposals
+- Extract repo-mode required-file filtering into a shared helper used by `validate_contract`, `upgrade_consumer_validate`, and `upgrade_preflight`.

--- a/specs/2026-04-18-upgrade-validation-required-file-reconciliation/spec.md
+++ b/specs/2026-04-18-upgrade-validation-required-file-reconciliation/spec.md
@@ -1,0 +1,85 @@
+# Specification
+
+## Spec Readiness Gate (Blocking)
+- SPEC_READY: true
+- Open questions count: 0
+- Unresolved alternatives count: 0
+- Unresolved TODO markers count: 0
+- Pending assumptions count: 0
+- Open clarification markers count: 0
+- Product sign-off: approved
+- Architecture sign-off: approved
+- Security sign-off: approved
+- Operations sign-off: approved
+- Missing input blocker token: none
+- ADR path: docs/blueprint/architecture/decisions/ADR-20260418-upgrade-validation-required-file-reconciliation.md
+- ADR status: approved
+
+## Applicable Guardrail Controls (Normative)
+- Applicable control IDs: SDD-C-001, SDD-C-002, SDD-C-003, SDD-C-004, SDD-C-005, SDD-C-006, SDD-C-007, SDD-C-008, SDD-C-009, SDD-C-010, SDD-C-011, SDD-C-012, SDD-C-013, SDD-C-014, SDD-C-015, SDD-C-016, SDD-C-017, SDD-C-018, SDD-C-019, SDD-C-020, SDD-C-021
+- Control exception rationale: none
+
+## Implementation Stack Profile (Normative)
+- Backend stack profile: python_plus_fastapi_pydantic_v2
+- Frontend stack profile: vue_router_pinia_onyx
+- Test automation profile: pytest_vitest_playwright_pact
+- Agent execution model: specialized-subagents-isolated-worktrees
+- Managed service preference: stackit-managed-first
+- Managed service exception rationale: none
+- Runtime profile: local-first-docker-desktop-kubernetes
+- Local Kubernetes context policy: docker-desktop-preferred
+- Local provisioning stack: crossplane-plus-helm
+- Runtime identity baseline: eso-plus-argocd-plus-keycloak
+- Local-first exception rationale: none
+
+## Objective
+- Business outcome: post-upgrade validation and preflight MUST make missing required surfaces explicit and blocking, with deterministic remediation guidance.
+- Success metric: upgrades with missing required files or coupled generated-doc drift MUST fail in `blueprint-upgrade-consumer-validate` and be visible in structured artifacts before merge.
+
+## Normative Requirements
+
+### Functional Requirements (Normative)
+- FR-001 MUST derive required files from `blueprint/contract.yaml` using active `repo_mode` gating and write a machine-readable manifest to `artifacts/blueprint/upgrade/required_files_status.json`.
+- FR-002 MUST fail `upgrade_consumer_validate` when at least one required file for the active `repo_mode` is missing and MUST include path-specific remediation (`render`, `sync`, `restore`, `manual-review`).
+- FR-003 MUST evaluate `docs/reference/generated/core_targets.generated.md` and `docs/reference/generated/contract_metadata.generated.md` as one coupled generated-reference contract in validate output.
+- FR-004 MUST enrich preflight output with a required-surface reconciliation section and a deterministic `required_surfaces_at_risk` list when upgrade plan entries affect required files.
+
+### Non-Functional Requirements (Normative)
+- NFR-SEC-001 MUST keep all artifact/report paths repository-scoped and MUST reject path traversal via relative arguments.
+- NFR-OBS-001 MUST expose required-file and generated-reference summary counts so wrapper metrics can emit deterministic observability signals.
+- NFR-REL-001 MUST keep report entry ordering deterministic to preserve repeatable CI comparisons across runs.
+- NFR-OPS-001 MUST emit actionable stderr diagnostics for missing required files and generated-reference contract failures.
+
+## Normative Option Decision
+- Option A: keep implicit required-file assumptions and rely only on existing make-target failures.
+- Option B: add explicit repo-mode-aware required-file reconciliation and coupled generated-reference checks in validate/preflight artifacts.
+- Selected option: OPTION_B
+- Rationale: Option B provides deterministic failures and machine-readable diagnostics while preserving existing ownership boundaries.
+
+## Contract Changes (Normative)
+- Config/Env contract: `upgrade_consumer_validate.py` SHALL support `--required-files-status-path` (default `artifacts/blueprint/upgrade/required_files_status.json`).
+- API contract: `upgrade_validate.json` MUST include `required_file_reconciliation` and `generated_reference_contract_check` sections with schema-enforced summary keys.
+- Event contract:
+- Make/CLI contract: `upgrade_consumer_validate.sh` MUST emit metrics for required-file expected/missing counters and generated-reference missing/failed counters.
+- Docs contract: `upgrade_preflight.json` MUST include `required_surface_reconciliation` with `required_surfaces_at_risk`.
+
+## Blueprint Upstream Defect Escalation (Normative)
+- Upstream issue URL: none
+- Temporary workaround path: none
+- Replacement trigger: none
+- Workaround review date: none
+
+## Normative Acceptance Criteria
+- AC-001 MUST be objectively testable: generated-consumer validate fails when a required file is missing and report includes remediation action.
+- AC-002 MUST be objectively testable: repo-mode gating excludes source-only required files in generated-consumer mode and requires them in template-source mode.
+- AC-003 MUST be objectively testable: preflight report exposes `required_surface_delta_count` and `required_surface_at_risk_count` based on required-file plan impact.
+- AC-004 MUST be objectively testable: updated unit tests pass for validate/preflight/wrapper and schema assertions.
+
+## Informative Notes (Non-Normative)
+- Context: this slice closes Issue #129 and intentionally keeps ownership classes unchanged.
+- Tradeoffs: validate/preflight each keep local repo-mode filtering helper logic to avoid cross-script coupling in this iteration.
+- Clarifications: none.
+
+## Explicit Exclusions
+- No automatic file regeneration or auto-commit behavior is introduced.
+- No ownership path class changes are introduced.

--- a/specs/2026-04-18-upgrade-validation-required-file-reconciliation/tasks.md
+++ b/specs/2026-04-18-upgrade-validation-required-file-reconciliation/tasks.md
@@ -1,0 +1,40 @@
+# Tasks
+
+## Gate Checks (Required Before Implementation)
+- [x] G-001 Confirm `SPEC_READY=true` in `spec.md`
+- [x] G-002 Confirm open questions and unresolved alternatives are `0`
+- [x] G-003 Confirm required sign-offs are approved
+- [x] G-004 Confirm `Applicable Guardrail Controls` section includes `SDD-C-###` IDs
+- [x] G-005 Confirm `Implementation Stack Profile` section is fully populated
+
+## Implementation
+- [x] T-001 Update contract/governance surfaces
+- [x] T-002 Implement runtime/code changes
+- [x] T-003 Update blueprint docs/diagrams
+- [x] T-004 Update consumer-facing docs/diagrams when contracts/behavior change
+
+## Test Automation
+- [x] T-101 Add or update unit tests
+- [x] T-102 Add or update contract tests
+- [x] T-103 For any new or modified filter/payload-transform route, verify a positive-path unit test exists (matching fixture value returns record and output fields remain intact); capture evidence in `pr_context.md`
+- [x] T-104 Translate any reproducible pre-PR smoke/`curl`/deterministic-check finding into a failing automated test first, then turn it green with the fix in the same work item (or document deterministic exception in publish artifacts)
+- [x] T-105 Add boundary/integration tests where required
+
+## Validation and Release Readiness
+- [x] T-201 Run required Make validation bundles
+- [x] T-202 Attach evidence to traceability document
+- [x] T-203 Confirm no stale TODOs/dead code/drift
+- [x] T-204 Run documentation validation (`make docs-build` and `make docs-smoke`)
+- [x] T-205 Run hardening review validation bundle (`make quality-hardening-review`)
+
+## Publish
+- [x] P-001 Update `hardening_review.md` with repository-wide findings fixed and proposals-only section
+- [x] P-002 Update `pr_context.md` with requirement/contract coverage, key reviewer files, validation evidence, and rollback notes
+- [ ] P-003 Ensure PR description follows repository template headings and references `pr_context.md`
+
+## App Onboarding Minimum Targets (Normative)
+- [x] A-001 `apps-bootstrap` and `apps-smoke` are implemented and verified for the affected app scope (no-impact)
+- [x] A-002 Backend app lanes (`backend-test-unit`, `backend-test-integration`, `backend-test-contracts`, `backend-test-e2e`) are available (no-impact)
+- [x] A-003 Frontend app lanes (`touchpoints-test-unit`, `touchpoints-test-integration`, `touchpoints-test-contracts`, `touchpoints-test-e2e`) are available (no-impact)
+- [x] A-004 Aggregate gates (`test-unit-all`, `test-integration-all`, `test-contracts-all`, `test-e2e-all-local`) are available (no-impact)
+- [x] A-005 Port-forward operational wrappers (`infra-port-forward-start`, `infra-port-forward-stop`, `infra-port-forward-cleanup`) are available (no-impact)

--- a/specs/2026-04-18-upgrade-validation-required-file-reconciliation/traceability.md
+++ b/specs/2026-04-18-upgrade-validation-required-file-reconciliation/traceability.md
@@ -1,0 +1,61 @@
+# Traceability Matrix
+
+## Requirement-to-Delivery Mapping
+
+| Requirement ID | Control IDs | Design Element | Implementation Path(s) | Test Evidence | Documentation Evidence | Operational Evidence |
+|---|---|---|---|---|---|---|
+| FR-001 | SDD-C-005 | Repo-mode required-file reconciliation | scripts/lib/blueprint/upgrade_consumer_validate.py | tests.blueprint.test_upgrade_consumer.UpgradeConsumerValidateTests.test_validate_reports_success_and_runs_required_targets | specs/2026-04-18-upgrade-validation-required-file-reconciliation/spec.md | artifacts/blueprint/upgrade/required_files_status.json |
+| FR-002 | SDD-C-005 | Missing required-file hard-fail with remediation | scripts/lib/blueprint/upgrade_consumer_validate.py | tests.blueprint.test_upgrade_consumer.UpgradeConsumerValidateTests.test_validate_fails_when_required_file_is_missing | specs/2026-04-18-upgrade-validation-required-file-reconciliation/pr_context.md | stderr diagnostics + upgrade_validate summary counts |
+| FR-003 | SDD-C-005 | Coupled generated-reference contract checks | scripts/lib/blueprint/upgrade_consumer_validate.py; scripts/lib/blueprint/schemas/upgrade_validate.schema.json | tests.blueprint.test_upgrade_consumer.UpgradeConsumerValidateTests.test_validate_reports_success_and_runs_required_targets | specs/2026-04-18-upgrade-validation-required-file-reconciliation/spec.md | generated_reference_contract_check payload + wrapper metrics |
+| FR-004 | SDD-C-005 | Preflight required-surfaces-at-risk enrichment | scripts/lib/blueprint/upgrade_preflight.py | tests.blueprint.test_upgrade_preflight.UpgradePreflightTests.test_preflight_report_groups_actions_manual_steps_and_follow_up_commands | specs/2026-04-18-upgrade-validation-required-file-reconciliation/plan.md | artifacts/blueprint/upgrade_preflight.json required_surface_reconciliation |
+| NFR-SEC-001 | SDD-C-009 | Repo-scoped path resolution | scripts/lib/blueprint/upgrade_consumer_validate.py; scripts/lib/blueprint/upgrade_preflight.py | tests.blueprint.test_upgrade_consumer.UpgradeConsumerTests.test_rejects_plan_path_outside_repo_root; tests.blueprint.test_upgrade_preflight.UpgradePreflightTests.test_preflight_rejects_relative_paths_outside_repo_root | specs/2026-04-18-upgrade-validation-required-file-reconciliation/spec.md | path validation failures with deterministic error text |
+| NFR-OBS-001 | SDD-C-010 | Validate summary counters + metrics extraction | scripts/lib/blueprint/upgrade_report_metrics.py; scripts/bin/blueprint/upgrade_consumer_validate.sh | tests.blueprint.test_quality_contracts.QualityContractTests.test_upgrade_workflow_wrappers_emit_metrics_and_parse_reports | specs/2026-04-18-upgrade-validation-required-file-reconciliation/hardening_review.md | blueprint_upgrade_validate_* metrics for required-file/generated-reference counters |
+| NFR-REL-001 | SDD-C-011 | Deterministic ordering in artifacts | scripts/lib/blueprint/upgrade_consumer_validate.py; scripts/lib/blueprint/upgrade_preflight.py | tests.blueprint.test_upgrade_consumer.UpgradeConsumerTests.test_dry_run_is_deterministic_and_preserves_target_content | specs/2026-04-18-upgrade-validation-required-file-reconciliation/spec.md | sorted path lists in report payloads |
+| NFR-OPS-001 | SDD-C-018 | Actionable remediation + operator guidance | scripts/lib/blueprint/upgrade_consumer_validate.py; scripts/lib/blueprint/upgrade_preflight.py | tests.blueprint.test_upgrade_consumer.UpgradeConsumerValidateTests.test_validate_fails_when_required_file_is_missing | specs/2026-04-18-upgrade-validation-required-file-reconciliation/context_pack.md | required_surfaces_at_risk and stderr remediation actions |
+| AC-001 | SDD-C-012 | Missing required-file failure is enforced | scripts/lib/blueprint/upgrade_consumer_validate.py | tests.blueprint.test_upgrade_consumer.UpgradeConsumerValidateTests.test_validate_fails_when_required_file_is_missing | specs/2026-04-18-upgrade-validation-required-file-reconciliation/pr_context.md | upgrade_validate summary.required_files_missing_count |
+| AC-002 | SDD-C-012 | Repo-mode gating behavior is verified | scripts/lib/blueprint/upgrade_consumer_validate.py | tests.blueprint.test_upgrade_consumer.UpgradeConsumerValidateTests.test_validate_generated_consumer_repo_mode_excludes_source_only_required_paths; tests.blueprint.test_upgrade_consumer.UpgradeConsumerValidateTests.test_validate_template_source_repo_mode_requires_source_only_required_paths | specs/2026-04-18-upgrade-validation-required-file-reconciliation/spec.md | required_file_reconciliation.excluded_by_repo_mode |
+| AC-003 | SDD-C-012 | Preflight required-surface risk reporting is verified | scripts/lib/blueprint/upgrade_preflight.py | tests.blueprint.test_upgrade_preflight.UpgradePreflightTests.test_preflight_report_groups_actions_manual_steps_and_follow_up_commands | specs/2026-04-18-upgrade-validation-required-file-reconciliation/plan.md | summary.required_surface_at_risk_count |
+| AC-004 | SDD-C-012 | Validation bundle stays green for impacted scope | scripts/lib/blueprint/**; tests/blueprint/** | python3 -m unittest tests.blueprint.test_upgrade_consumer tests.blueprint.test_upgrade_preflight tests.blueprint.test_upgrade_consumer_wrapper tests.blueprint.test_quality_contracts | specs/2026-04-18-upgrade-validation-required-file-reconciliation/evidence_manifest.json | make infra-validate; make quality-hooks-fast |
+
+## Graph Linkage
+- Graph file: `graph.yaml`
+- Every `FR-###`, `NFR-*-###`, and `AC-###` listed in this file MUST have a corresponding node in `graph.yaml`.
+- Node IDs referenced:
+  - FR-001
+  - FR-002
+  - FR-003
+  - FR-004
+  - NFR-SEC-001
+  - NFR-OBS-001
+  - NFR-REL-001
+  - NFR-OPS-001
+  - AC-001
+  - AC-002
+  - AC-003
+  - AC-004
+
+## Validation Summary
+- Required bundles executed:
+  - `python3 -m unittest tests.blueprint.test_upgrade_consumer tests.blueprint.test_upgrade_preflight`
+  - `python3 -m unittest tests.blueprint.test_upgrade_consumer_wrapper`
+  - `python3 -m unittest tests.blueprint.test_quality_contracts`
+  - `make infra-validate`
+  - `make quality-hooks-fast`
+  - `make quality-hooks-run`
+  - `make quality-hardening-review`
+  - `make docs-build`
+  - `make docs-smoke`
+- Result summary:
+  - all listed commands passed after SDD artifact completion
+- Documentation validation:
+  - `make docs-build`
+  - `make docs-smoke`
+
+## Evidence Manifest
+- Manifest file: `evidence_manifest.json`
+- Context export: `context_pack.md`
+- PR context export: `pr_context.md`
+- Hardening review export: `hardening_review.md`
+
+## Open Risks and Follow-Ups
+- Follow-up 1: externalize shared repo-mode required-file helper into one library function to remove duplicate logic in validate/preflight.

--- a/tests/blueprint/test_upgrade_consumer.py
+++ b/tests/blueprint/test_upgrade_consumer.py
@@ -1246,6 +1246,7 @@ class UpgradeConsumerValidateTests(unittest.TestCase):
             self.assertEqual(summary.get("runtime_dependency_missing_count"), 0)
             self.assertEqual(summary.get("required_files_missing_count"), 0)
             self.assertEqual(summary.get("generated_reference_missing_path_count"), 0)
+            self.assertEqual(summary.get("contract_load_error_count"), 0)
             runtime_dependency_check = report.get("runtime_dependency_edge_check", {})
             self.assertIsInstance(runtime_dependency_check, dict)
             self.assertGreaterEqual(len(runtime_dependency_check.get("required_edges", [])), 1)
@@ -1282,6 +1283,7 @@ class UpgradeConsumerValidateTests(unittest.TestCase):
             summary = report.get("summary", {})
             self.assertEqual(summary.get("status"), "failure")
             self.assertGreater(summary.get("merge_markers_pre_count", 0), 0)
+            self.assertEqual(summary.get("contract_load_error_count"), 0)
             _assert_json_schema(report, VALIDATE_SCHEMA)
 
     def test_validate_fails_when_runtime_dependency_edge_is_missing(self) -> None:
@@ -1309,6 +1311,7 @@ class UpgradeConsumerValidateTests(unittest.TestCase):
             summary = report.get("summary", {})
             self.assertEqual(summary.get("status"), "failure")
             self.assertEqual(summary.get("runtime_dependency_missing_count"), 1)
+            self.assertEqual(summary.get("contract_load_error_count"), 0)
             runtime_dependency_check = report.get("runtime_dependency_edge_check", {})
             self.assertEqual(len(runtime_dependency_check.get("missing", [])), 1)
             missing = runtime_dependency_check.get("missing", [])[0]
@@ -1341,6 +1344,7 @@ class UpgradeConsumerValidateTests(unittest.TestCase):
             summary = report.get("summary", {})
             self.assertEqual(summary.get("status"), "failure")
             self.assertEqual(summary.get("required_files_missing_count"), 1)
+            self.assertEqual(summary.get("contract_load_error_count"), 0)
             required_reconciliation = report.get("required_file_reconciliation", {})
             self.assertEqual(required_reconciliation.get("missing_paths"), [missing_path])
             entries = required_reconciliation.get("entries", [])
@@ -1377,6 +1381,7 @@ class UpgradeConsumerValidateTests(unittest.TestCase):
             report = _load_json(repo / "artifacts/blueprint/upgrade_validate.json")
             required_reconciliation = report.get("required_file_reconciliation", {})
             self.assertEqual(required_reconciliation.get("missing_count"), 0)
+            self.assertEqual(report.get("summary", {}).get("contract_load_error_count"), 0)
             excluded = required_reconciliation.get("excluded_by_repo_mode", [])
             self.assertIn(source_only_required_path, excluded)
             _assert_json_schema(report, VALIDATE_SCHEMA)
@@ -1406,7 +1411,43 @@ class UpgradeConsumerValidateTests(unittest.TestCase):
             report = _load_json(repo / "artifacts/blueprint/upgrade_validate.json")
             required_reconciliation = report.get("required_file_reconciliation", {})
             self.assertEqual(required_reconciliation.get("missing_count"), 1)
+            self.assertEqual(report.get("summary", {}).get("contract_load_error_count"), 0)
             self.assertEqual(required_reconciliation.get("missing_paths"), [source_only_required_path])
+            _assert_json_schema(report, VALIDATE_SCHEMA)
+
+    def test_validate_writes_failure_artifacts_when_contract_cannot_be_loaded(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_root = Path(tmpdir)
+            repo = self._create_validation_repo(tmp_root)
+            _write(repo / "blueprint/contract.yaml", "<<<<<<< HEAD\n")
+
+            result = _run(
+                [
+                    sys.executable,
+                    str(VALIDATE_SCRIPT),
+                    "--repo-root",
+                    str(repo),
+                ],
+                cwd=REPO_ROOT,
+            )
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("unable to load blueprint contract for required-files reconciliation", result.stderr)
+
+            report = _load_json(repo / "artifacts/blueprint/upgrade_validate.json")
+            summary = report.get("summary", {})
+            self.assertEqual(summary.get("status"), "failure")
+            self.assertEqual(summary.get("commands_total"), 0)
+            self.assertEqual(summary.get("contract_load_error_count"), 1)
+            self.assertGreaterEqual(summary.get("generated_reference_missing_target_count"), 1)
+            self.assertGreater(summary.get("merge_markers_pre_count", 0), 0)
+            self.assertIsInstance(report.get("contract_load_error"), str)
+
+            required_files_status = _load_json(repo / "artifacts/blueprint/upgrade/required_files_status.json")
+            self.assertIsInstance(required_files_status.get("contract_load_error"), str)
+            self.assertEqual(
+                required_files_status.get("required_file_reconciliation", {}).get("repo_mode"),
+                "unknown",
+            )
             _assert_json_schema(report, VALIDATE_SCHEMA)
 
 

--- a/tests/blueprint/test_upgrade_consumer.py
+++ b/tests/blueprint/test_upgrade_consumer.py
@@ -56,15 +56,35 @@ def _commit_all(repo: Path, message: str) -> None:
     _require_success(_git(repo, "commit", "-m", message), f"git commit -m {message}")
 
 
-def _generated_contract_text(*, drop_paths: tuple[str, ...] = ()) -> str:
+def _contract_text_for_repo_mode(repo_mode: str, *, drop_paths: tuple[str, ...] = ()) -> str:
     content = (REPO_ROOT / "blueprint/contract.yaml").read_text(encoding="utf-8").replace(
         "repo_mode: template-source",
-        "repo_mode: generated-consumer",
+        f"repo_mode: {repo_mode}",
         1,
     )
-    for path in drop_paths:
-        content = content.replace(f"      - {path}\n", "")
-    return content
+    drop_set = set(drop_paths)
+    filtered_lines: list[str] = []
+    in_required_files = False
+    for line in content.splitlines(keepends=True):
+        if line.startswith("    required_files:"):
+            in_required_files = True
+            filtered_lines.append(line)
+            continue
+
+        if in_required_files and line.startswith("    ") and not line.startswith("      - "):
+            in_required_files = False
+
+        if in_required_files and line.startswith("      - "):
+            candidate = line.strip()[2:].strip()
+            if candidate in drop_set:
+                continue
+
+        filtered_lines.append(line)
+    return "".join(filtered_lines)
+
+
+def _generated_contract_text(*, drop_paths: tuple[str, ...] = ()) -> str:
+    return _contract_text_for_repo_mode("generated-consumer", drop_paths=drop_paths)
 
 
 def _template_version() -> str:
@@ -1142,7 +1162,15 @@ class UpgradeConsumerTests(unittest.TestCase):
 
 
 class UpgradeConsumerValidateTests(unittest.TestCase):
-    def _create_validation_repo(self, tmp_root: Path, *, include_marker: bool = False) -> Path:
+    def _create_validation_repo(
+        self,
+        tmp_root: Path,
+        *,
+        include_marker: bool = False,
+        repo_mode: str = "generated-consumer",
+        missing_required_paths: tuple[str, ...] = (),
+        include_source_only_required_path: str | None = None,
+    ) -> Path:
         repo = tmp_root / "validate"
         _init_git_repo(repo)
 
@@ -1159,7 +1187,34 @@ class UpgradeConsumerValidateTests(unittest.TestCase):
             lines.append(f"{target}:")
             lines.append("\t@mkdir -p artifacts/blueprint")
             lines.append(f"\t@echo {target} >> artifacts/blueprint/validate_targets.log")
-        _write(repo / "Makefile", "\n".join(lines) + "\n")
+
+        contract = load_blueprint_contract(REPO_ROOT / "blueprint/contract.yaml")
+        keep_required_paths = {
+            "Makefile",
+            "blueprint/contract.yaml",
+            "docs/reference/generated/core_targets.generated.md",
+            "docs/reference/generated/contract_metadata.generated.md",
+        }
+        if include_source_only_required_path:
+            keep_required_paths.add(include_source_only_required_path)
+        drop_required_paths = tuple(
+            path for path in contract.repository.required_files if path not in keep_required_paths
+        )
+        _write(
+            repo / "blueprint/contract.yaml",
+            _contract_text_for_repo_mode(repo_mode, drop_paths=drop_required_paths),
+        )
+
+        for required_path in sorted(keep_required_paths):
+            if required_path == "blueprint/contract.yaml":
+                continue
+            if required_path in missing_required_paths:
+                continue
+            if required_path == "Makefile":
+                _write(repo / "Makefile", "\n".join(lines) + "\n")
+                continue
+            _write(repo / required_path, f"{required_path}\n")
+
         if include_marker:
             _write(repo / "marker.txt", "<<<<<<< HEAD\n")
 
@@ -1189,10 +1244,17 @@ class UpgradeConsumerValidateTests(unittest.TestCase):
             self.assertEqual(summary.get("merge_markers_pre_count"), 0)
             self.assertEqual(summary.get("merge_markers_post_count"), 0)
             self.assertEqual(summary.get("runtime_dependency_missing_count"), 0)
+            self.assertEqual(summary.get("required_files_missing_count"), 0)
+            self.assertEqual(summary.get("generated_reference_missing_path_count"), 0)
             runtime_dependency_check = report.get("runtime_dependency_edge_check", {})
             self.assertIsInstance(runtime_dependency_check, dict)
             self.assertGreaterEqual(len(runtime_dependency_check.get("required_edges", [])), 1)
             self.assertEqual(runtime_dependency_check.get("missing", []), [])
+            required_files_report = _load_json(repo / "artifacts/blueprint/upgrade/required_files_status.json")
+            self.assertEqual(
+                required_files_report.get("required_file_reconciliation", {}).get("missing_count"),
+                0,
+            )
             _assert_json_schema(report, VALIDATE_SCHEMA)
 
             command_results = report.get("command_results", [])
@@ -1255,6 +1317,96 @@ class UpgradeConsumerValidateTests(unittest.TestCase):
                 missing.get("dependency_path"),
                 "scripts/bin/platform/auth/reconcile_runtime_identity.sh",
             )
+            _assert_json_schema(report, VALIDATE_SCHEMA)
+
+    def test_validate_fails_when_required_file_is_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_root = Path(tmpdir)
+            missing_path = "docs/reference/generated/core_targets.generated.md"
+            repo = self._create_validation_repo(tmp_root, missing_required_paths=(missing_path,))
+
+            result = _run(
+                [
+                    sys.executable,
+                    str(VALIDATE_SCRIPT),
+                    "--repo-root",
+                    str(repo),
+                ],
+                cwd=REPO_ROOT,
+            )
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("missing required files for active repo_mode", result.stderr)
+
+            report = _load_json(repo / "artifacts/blueprint/upgrade_validate.json")
+            summary = report.get("summary", {})
+            self.assertEqual(summary.get("status"), "failure")
+            self.assertEqual(summary.get("required_files_missing_count"), 1)
+            required_reconciliation = report.get("required_file_reconciliation", {})
+            self.assertEqual(required_reconciliation.get("missing_paths"), [missing_path])
+            entries = required_reconciliation.get("entries", [])
+            self.assertIsInstance(entries, list)
+            missing_entries = [entry for entry in entries if isinstance(entry, dict) and entry.get("status") == "missing"]
+            self.assertEqual(len(missing_entries), 1)
+            self.assertEqual(missing_entries[0].get("path"), missing_path)
+            remediation = missing_entries[0].get("remediation", {})
+            self.assertEqual(remediation.get("action"), "render")
+            _assert_json_schema(report, VALIDATE_SCHEMA)
+
+    def test_validate_generated_consumer_repo_mode_excludes_source_only_required_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_root = Path(tmpdir)
+            source_only_required_path = "tests/blueprint/contract_refactor_governance_structure_cases.py"
+            repo = self._create_validation_repo(
+                tmp_root,
+                repo_mode="generated-consumer",
+                include_source_only_required_path=source_only_required_path,
+                missing_required_paths=(source_only_required_path,),
+            )
+
+            result = _run(
+                [
+                    sys.executable,
+                    str(VALIDATE_SCRIPT),
+                    "--repo-root",
+                    str(repo),
+                ],
+                cwd=REPO_ROOT,
+            )
+            self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+
+            report = _load_json(repo / "artifacts/blueprint/upgrade_validate.json")
+            required_reconciliation = report.get("required_file_reconciliation", {})
+            self.assertEqual(required_reconciliation.get("missing_count"), 0)
+            excluded = required_reconciliation.get("excluded_by_repo_mode", [])
+            self.assertIn(source_only_required_path, excluded)
+            _assert_json_schema(report, VALIDATE_SCHEMA)
+
+    def test_validate_template_source_repo_mode_requires_source_only_required_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_root = Path(tmpdir)
+            source_only_required_path = "tests/blueprint/contract_refactor_governance_structure_cases.py"
+            repo = self._create_validation_repo(
+                tmp_root,
+                repo_mode="template-source",
+                include_source_only_required_path=source_only_required_path,
+                missing_required_paths=(source_only_required_path,),
+            )
+
+            result = _run(
+                [
+                    sys.executable,
+                    str(VALIDATE_SCRIPT),
+                    "--repo-root",
+                    str(repo),
+                ],
+                cwd=REPO_ROOT,
+            )
+            self.assertEqual(result.returncode, 1)
+
+            report = _load_json(repo / "artifacts/blueprint/upgrade_validate.json")
+            required_reconciliation = report.get("required_file_reconciliation", {})
+            self.assertEqual(required_reconciliation.get("missing_count"), 1)
+            self.assertEqual(required_reconciliation.get("missing_paths"), [source_only_required_path])
             _assert_json_schema(report, VALIDATE_SCHEMA)
 
 

--- a/tests/blueprint/test_upgrade_consumer_wrapper.py
+++ b/tests/blueprint/test_upgrade_consumer_wrapper.py
@@ -63,6 +63,7 @@ class UpgradeConsumerWrapperTests(unittest.TestCase):
             tmp_root = Path(tmpdir)
             consumer_repo = tmp_root / "consumer"
             consumer_repo.mkdir(parents=True, exist_ok=True)
+            _write(consumer_repo / "Makefile", ".PHONY: noop\nnoop:\n\t@:\n")
 
             _copy_file(UPGRADE_WRAPPER_REL, consumer_repo)
             _copy_file(CONTRACT_RUNTIME_REL, consumer_repo)

--- a/tests/blueprint/test_upgrade_preflight.py
+++ b/tests/blueprint/test_upgrade_preflight.py
@@ -170,6 +170,63 @@ class UpgradePreflightTests(unittest.TestCase):
                 ],
             )
 
+    def test_preflight_excludes_benign_skip_and_keeps_missing_target_skip_as_risk(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_root = Path(tmpdir)
+            artifacts_dir = repo_root / "artifacts/blueprint"
+            artifacts_dir.mkdir(parents=True, exist_ok=True)
+            contract = load_blueprint_contract(REPO_ROOT / "blueprint/contract.yaml")
+            keep_required_paths = {"README.md"}
+            drop_required_paths = tuple(path for path in contract.repository.required_files if path not in keep_required_paths)
+            (repo_root / "blueprint").mkdir(parents=True, exist_ok=True)
+            (repo_root / "blueprint/contract.yaml").write_text(
+                _contract_text_for_repo_mode("generated-consumer", drop_paths=drop_required_paths),
+                encoding="utf-8",
+            )
+
+            plan_payload = {
+                "entries": [
+                    {
+                        "path": "README.md",
+                        "action": "skip",
+                        "reason": "path already matches upgrade source content",
+                        "source_exists": True,
+                        "target_exists": True,
+                    },
+                    {
+                        "path": "README.md",
+                        "action": "skip",
+                        "reason": "path is consumer-owned and excluded from blueprint upgrade apply",
+                        "source_exists": True,
+                        "target_exists": False,
+                    },
+                ],
+                "required_manual_actions": [],
+            }
+            apply_payload = {"results": []}
+            (artifacts_dir / "upgrade_plan.json").write_text(json.dumps(plan_payload), encoding="utf-8")
+            (artifacts_dir / "upgrade_apply.json").write_text(json.dumps(apply_payload), encoding="utf-8")
+
+            report_path = artifacts_dir / "upgrade_preflight.json"
+            result = self._run_preflight(repo_root)
+
+            self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+            report = json.loads(report_path.read_text(encoding="utf-8"))
+            summary = report["summary"]
+            self.assertEqual(summary["required_surface_delta_count"], 2)
+            self.assertEqual(summary["required_surface_at_risk_count"], 1)
+            required_surfaces = report["required_surface_reconciliation"]
+            self.assertEqual(
+                required_surfaces["required_surfaces_at_risk"],
+                [
+                    {
+                        "action": "skip",
+                        "path": "README.md",
+                        "risk_reasons": ["plan-action:skip-missing-target"],
+                    }
+                ],
+            )
+
     def test_preflight_fails_when_apply_report_is_missing(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             repo_root = Path(tmpdir)

--- a/tests/blueprint/test_upgrade_preflight.py
+++ b/tests/blueprint/test_upgrade_preflight.py
@@ -6,12 +6,40 @@ import sys
 import tempfile
 import unittest
 
+from scripts.lib.blueprint.contract_schema import load_blueprint_contract
 from tests._shared.exec import DEFAULT_TEST_COMMAND_TIMEOUT_SECONDS, run_command
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 UPGRADE_PREFLIGHT_SCRIPT = REPO_ROOT / "scripts/lib/blueprint/upgrade_preflight.py"
 UPGRADE_PREFLIGHT_WRAPPER = REPO_ROOT / "scripts/bin/blueprint/upgrade_consumer_preflight.sh"
+
+
+def _contract_text_for_repo_mode(repo_mode: str, *, drop_paths: tuple[str, ...] = ()) -> str:
+    content = (REPO_ROOT / "blueprint/contract.yaml").read_text(encoding="utf-8").replace(
+        "repo_mode: template-source",
+        f"repo_mode: {repo_mode}",
+        1,
+    )
+    drop_set = set(drop_paths)
+    filtered_lines: list[str] = []
+    in_required_files = False
+    for line in content.splitlines(keepends=True):
+        if line.startswith("    required_files:"):
+            in_required_files = True
+            filtered_lines.append(line)
+            continue
+
+        if in_required_files and line.startswith("    ") and not line.startswith("      - "):
+            in_required_files = False
+
+        if in_required_files and line.startswith("      - "):
+            candidate = line.strip()[2:].strip()
+            if candidate in drop_set:
+                continue
+
+        filtered_lines.append(line)
+    return "".join(filtered_lines)
 
 
 class UpgradePreflightTests(unittest.TestCase):
@@ -33,13 +61,26 @@ class UpgradePreflightTests(unittest.TestCase):
             repo_root = Path(tmpdir)
             artifacts_dir = repo_root / "artifacts/blueprint"
             artifacts_dir.mkdir(parents=True, exist_ok=True)
+            contract = load_blueprint_contract(REPO_ROOT / "blueprint/contract.yaml")
+            keep_required_paths = {
+                "README.md",
+                "docs/reference/generated/contract_metadata.generated.md",
+            }
+            drop_required_paths = tuple(
+                path for path in contract.repository.required_files if path not in keep_required_paths
+            )
+            (repo_root / "blueprint").mkdir(parents=True, exist_ok=True)
+            (repo_root / "blueprint/contract.yaml").write_text(
+                _contract_text_for_repo_mode("generated-consumer", drop_paths=drop_required_paths),
+                encoding="utf-8",
+            )
 
             plan_payload = {
                 "entries": [
                     {"path": "README.md", "action": "create"},
                     {"path": "scripts/bin/blueprint/upgrade_consumer.sh", "action": "update"},
                     {"path": "docs/platform/consumer/quickstart.md", "action": "merge-required"},
-                    {"path": "blueprint/contract.yaml", "action": "conflict"},
+                    {"path": "docs/reference/generated/contract_metadata.generated.md", "action": "conflict"},
                     {"path": "docs/legacy.md", "action": "skip"},
                 ],
                 "required_manual_actions": [
@@ -92,6 +133,9 @@ class UpgradePreflightTests(unittest.TestCase):
             self.assertEqual(summary["required_manual_action_count"], 2)
             self.assertEqual(summary["required_follow_up_command_count"], 3)
             self.assertEqual(summary["blocking_path_count"], 4)
+            self.assertEqual(summary["required_surface_delta_count"], 2)
+            self.assertEqual(summary["required_surface_auto_apply_count"], 1)
+            self.assertEqual(summary["required_surface_at_risk_count"], 1)
             self.assertEqual(
                 report["required_follow_up_commands"],
                 [
@@ -103,10 +147,26 @@ class UpgradePreflightTests(unittest.TestCase):
             self.assertEqual(
                 report["blocking_paths"],
                 [
-                    "blueprint/contract.yaml",
                     "blueprint/runtime_identity_contract.yaml",
                     "docs/platform/consumer/quickstart.md",
                     "docs/platform/consumer/runtime_credentials_eso.md",
+                    "docs/reference/generated/contract_metadata.generated.md",
+                ],
+            )
+            required_surfaces = report["required_surface_reconciliation"]
+            self.assertTrue(required_surfaces["contract_available"])
+            self.assertEqual(required_surfaces["repo_mode"], "generated-consumer")
+            self.assertEqual(required_surfaces["required_files_expected_count"], 2)
+            self.assertEqual(len(required_surfaces["required_surface_deltas"]), 2)
+            self.assertEqual(required_surfaces["required_surfaces_auto_apply"], ["README.md"])
+            self.assertEqual(
+                required_surfaces["required_surfaces_at_risk"],
+                [
+                    {
+                        "action": "conflict",
+                        "path": "docs/reference/generated/contract_metadata.generated.md",
+                        "risk_reasons": ["plan-action:conflict"],
+                    }
                 ],
             )
 


### PR DESCRIPTION
## Summary
- Enforce deterministic post-upgrade required-file reconciliation in `blueprint-upgrade-consumer-validate` using active `repo_mode` semantics.
- Add coupled generated-reference contract validation for `core_targets.generated.md` + `contract_metadata.generated.md`.
- Add preflight required-surface risk reporting (`required_surface_reconciliation` / `required_surfaces_at_risk`).
- Work-item folder: `specs/2026-04-18-upgrade-validation-required-file-reconciliation/`
- Closes #129

## Requirement and Contract Coverage
- Requirement IDs covered: `FR-001`, `FR-002`, `FR-003`, `FR-004`, `NFR-SEC-001`, `NFR-OBS-001`, `NFR-REL-001`, `NFR-OPS-001`
- Acceptance criteria covered: `AC-001`, `AC-002`, `AC-003`, `AC-004`
- Contract surfaces changed:
  - [ ] `blueprint/contract.yaml` changed
  - [x] docs/templates/tests were synchronized
  - [x] generated consumer behavior changed

## Key Reviewer Files
- Primary files to review first:
  - `scripts/lib/blueprint/upgrade_consumer_validate.py`
  - `scripts/lib/blueprint/upgrade_preflight.py`
  - `scripts/lib/blueprint/schemas/upgrade_validate.schema.json`
- High-risk files:
  - `tests/blueprint/test_upgrade_consumer.py`
  - `tests/blueprint/test_upgrade_preflight.py`
  - `scripts/bin/blueprint/upgrade_consumer_validate.sh`
  - `scripts/lib/blueprint/upgrade_report_metrics.py`

## Validation Evidence
- `python3 -m unittest tests.blueprint.test_upgrade_consumer tests.blueprint.test_upgrade_preflight`
- `python3 -m unittest tests.blueprint.test_upgrade_consumer_wrapper`
- `python3 -m unittest tests.blueprint.test_quality_contracts`
- `make infra-validate`
- `make quality-hooks-fast`
- `make quality-hooks-run`
- `make quality-hardening-review`
- `make docs-build`
- `make docs-smoke`
- Result: all commands passed.
- Relevant artifacts:
  - `artifacts/blueprint/upgrade_validate.json`
  - `artifacts/blueprint/upgrade/required_files_status.json`
  - `artifacts/blueprint/upgrade_preflight.json`

## Risk and Rollback
- Main risk(s):
  - stricter required-file gating can fail legacy/minimal fixtures without correct repo-mode filtering
  - consumers of validate reports must tolerate newly required schema fields
- Rollback strategy:
  - revert validate/preflight/metrics/schema/test + SDD artifact changes from this PR
  - rerun `make infra-validate` and `make quality-hooks-fast`

## Deferred Proposals (Not Implemented)
- Extract repo-mode required-file filtering into one shared helper used by `validate_contract`, `upgrade_consumer_validate`, and `upgrade_preflight`.

## Follow-Up
- Next backlog item already captured: docs ownership boundary so generated-consumer repos do not mirror consumer-owned `docs/platform/**` back into template docs.