### PR TITLE
test: enforce optional-module required_env fixture parity in fast lane

### DIFF
--- a/AGENTS.backlog.md
+++ b/AGENTS.backlog.md
@@ -6,7 +6,7 @@
 - [x] P0 (Upgrade validation determinism): Issue #129 — add repo-mode-aware required-file reconciliation checks and deterministic remediation hints.
 - [x] P0 (Docs ownership boundary for generated consumers): implemented repo-mode-aware docs sync/check behavior so generated-consumer repos keep one-way `docs/platform/**` ownership, template-source retains strict sync, and generated-consumer upgrade/bootstrap now cleans template-orphan platform docs outside contract-declared `required_seed_files`.
 - [x] P1 (Upgrade convergence safety): Issue #128 — implemented ownership-aware reconcile report artifact and `blueprint-upgrade-consumer-postcheck` gate, including preflight merge-risk bucketing, postcheck convergence enforcement, and source-ref wrapper compatibility for legacy engines.
-- [ ] P1 (Fixture-contract hardening): Issue #130 — enforce optional-module `required_env` fixture parity in fast infra contract checks.
+- [x] P1 (Fixture-contract hardening): Issue #130 — enforce optional-module `required_env` fixture parity in fast infra contract checks (canonical fixture resolver wiring + fast-lane parity tests).
 - [ ] P1 (Generated-consumer upgrade regressions): Issues #103, #104, #106, #107 — fix repo-mode test selection, additive-file conflict classification, and missing helper distribution.
 - [ ] P1 (Runtime operability correctness): Issues #105, #108, #109, #110, #111, #112, #118, #137 — resolve runtime identity, Argo health/project policy, image-lane, and target migration friction.
 - [ ] P2 (Ownership checker robustness): support normalized equivalence for semantically-identical prune-glob expressions in ownership-matrix documentation checks.

--- a/AGENTS.decisions.md
+++ b/AGENTS.decisions.md
@@ -195,6 +195,11 @@
   - `make infra-contract-test-fast` runs focused infra contract helper CLI tests.
   - `make quality-docs-sync-all` provides one deterministic docs sync aggregator target for all generated docs/summaries.
   - `quality-hooks-fast` now includes `infra-contract-test-fast` to keep helper-contract drift visible in the default lane.
+- Optional-module required-env fixture parity is now a fast-lane contract:
+  - `tests/infra/test_optional_module_required_env_contract.py` enforces parity between optional-module `required_env` declarations and test fixture hydration output.
+  - `tests/_shared/helpers.py::module_flags_env` now resolves enabled-module required env defaults via canonical `enabled_module_required_env_specs` instead of ad-hoc per-module branches.
+  - `scripts/bin/infra/contract_test_fast.sh` includes the parity test as a default fast contract gate.
+  - canonical module required-env defaults now include `STACKIT_PROJECT_ID` and `STACKIT_REGION` so workflows fixture parity remains deterministic.
 - Infra validation now enforces a lightweight import-boundary rule for `scripts/lib/**/*.py`:
   - `scripts/lib` modules may not import `scripts/bin` modules.
   - blueprint-managed `scripts/lib/blueprint/**` may not import platform-owned `scripts/lib/platform/**`.

--- a/docs/blueprint/architecture/decisions/ADR-20260419-issue-130-optional-module-required-env-fixture-parity.md
+++ b/docs/blueprint/architecture/decisions/ADR-20260419-issue-130-optional-module-required-env-fixture-parity.md
@@ -1,0 +1,84 @@
+# ADR-20260419-issue-130-optional-module-required-env-fixture-parity: Optional-Module Required Env Fixture Parity In Fast Contract Lane
+
+## Metadata
+- Status: approved
+- Date: 2026-04-19
+- Owners: @sbonoc
+- Related spec path: `specs/2026-04-19-issue-130-required-env-fixture-parity/spec.md`
+
+## Business Objective and Requirement Summary
+- Business objective: enforce deterministic parity between optional-module `required_env` contracts and test fixture defaults to eliminate late CI regressions.
+- Functional requirements summary:
+  - hydrate required env defaults for enabled optional modules through canonical resolver logic
+  - add deterministic parity tests for module contract required env coverage
+  - execute parity test in `infra-contract-test-fast`
+- Non-functional requirements summary:
+  - deterministic sorted diagnostics
+  - no real secret dependence
+  - fail-fast CI lane integration
+- Desired timeline: immediate in current fast contract lane.
+
+## Decision Drivers
+- Optional-module contracts evolve frequently and fixture helpers can drift.
+- Drift detection is most valuable in fast, deterministic lanes before broader optional-module flows.
+- One canonical default source reduces duplicated per-module fixture logic.
+
+## Options Considered
+- Option A: keep manual helper branches and rely on existing optional-module behavior tests.
+- Option B: centralize fixture hydration on canonical required-env resolver and add explicit parity tests in fast lane.
+
+## Recommended Option
+- Selected option: Option B
+- Rationale: Option B detects drift earlier, removes duplicated helper branches, and keeps remediation explicit.
+
+## Rejected Options
+- Rejected option 1: Option A
+- Rejection rationale: Option A allows contract/default drift to survive until slower behavior tests.
+
+## Affected Capabilities and Components
+- Capability impact:
+  - fast infra contract drift detection
+  - optional-module fixture determinism in tests
+- Component impact:
+  - `tests/_shared/helpers.py`
+  - `tests/infra/test_optional_module_required_env_contract.py` (new)
+  - `scripts/bin/infra/contract_test_fast.sh`
+
+## Architecture Diagram (Mermaid)
+```mermaid
+flowchart LR
+  C[blueprint/modules/*/module.contract.yaml] --> R[enabled_module_required_env_specs]
+  R --> H[module_flags_env]
+  H --> T[test_optional_module_required_env_contract.py]
+  T --> F[infra-contract-test-fast]
+```
+
+## High-Level Work Packages and Timeline (Mermaid Gantt)
+```mermaid
+gantt
+  title Issue #130 Fixture Contract Hardening
+  dateFormat  YYYY-MM-DD
+  section Work Packages
+  Add parity tests (red)                    :a1, 2026-04-19, 1d
+  Refactor fixture hydration (green)        :a2, after a1, 1d
+  Wire fast-lane execution + evidence       :a3, after a2, 1d
+```
+
+## External Dependencies
+- `scripts/lib/blueprint/init_repo_env.py` default required-env catalog.
+- `scripts/lib/blueprint/init_repo_contract.py` optional-module metadata.
+
+## Risks and Mitigations
+- Risk 1: newly added module flags diverge from helper parameter mapping.
+- Mitigation 1: parity test enforces module-to-parameter coverage.
+- Risk 2: default map entries become empty for new `required_env` keys.
+- Mitigation 2: parity test asserts non-empty values for each required env.
+
+## Validation and Observability Expectations
+- Validation requirements:
+  - `pytest -q tests/infra/test_optional_module_required_env_contract.py`
+  - `make infra-contract-test-fast`
+  - `make quality-hooks-fast`
+- Logging/metrics/tracing requirements:
+  - deterministic parity diagnostics in pytest failure output
+  - no new runtime metrics required for this scope

--- a/scripts/bin/infra/contract_test_fast.sh
+++ b/scripts/bin/infra/contract_test_fast.sh
@@ -25,6 +25,7 @@ fi
 
 require_command pytest
 run_cmd pytest -q \
+  "$ROOT_DIR/tests/infra/test_optional_module_required_env_contract.py" \
   "$ROOT_DIR/tests/blueprint/test_upgrade_fixture_matrix.py" \
   "$ROOT_DIR/tests/infra/test_runtime_identity_contract_cli.py" \
   "$ROOT_DIR/tests/infra/test_argocd_repo_contract_cli.py" \

--- a/scripts/lib/blueprint/init_repo_env.py
+++ b/scripts/lib/blueprint/init_repo_env.py
@@ -59,6 +59,8 @@ MODULE_REQUIRED_ENV_DEFAULTS = {
     "PUBLIC_ENDPOINTS_BASE_DOMAIN": "apps.local",
     "RABBITMQ_INSTANCE_NAME": "marketplace-rabbitmq",
     "SECRETS_MANAGER_INSTANCE_NAME": "marketplace-secrets",
+    "STACKIT_PROJECT_ID": "project-001",
+    "STACKIT_REGION": "eu01",
     "STACKIT_WORKFLOWS_DAGS_REPO_URL": "https://github.com/example-org/example-repo.git",
     "STACKIT_WORKFLOWS_DAGS_REPO_BRANCH": "main",
     "STACKIT_WORKFLOWS_DAGS_REPO_USERNAME": "workflows-user",

--- a/scripts/lib/quality/test_pyramid_contract.json
+++ b/scripts/lib/quality/test_pyramid_contract.json
@@ -30,6 +30,7 @@
         "tests/docs/test_docs_lint.py",
         "tests/docs/test_orchestrate_sync.py",
         "tests/infra/test_runtime_credentials_eso.py",
+        "tests/infra/test_optional_module_required_env_contract.py",
         "tests/infra/test_runtime_identity_contract_cli.py",
         "tests/infra/test_argocd_repo_contract_cli.py",
         "tests/infra/test_state_artifact_contract.py",

--- a/specs/2026-04-19-issue-130-required-env-fixture-parity/architecture.md
+++ b/specs/2026-04-19-issue-130-required-env-fixture-parity/architecture.md
@@ -1,0 +1,73 @@
+# Architecture
+
+## Context
+- Work item: `2026-04-19-issue-130-required-env-fixture-parity`
+- Owner: `@sbonoc`
+- Date: `2026-04-19`
+
+## Stack and Execution Model
+- Backend stack profile: `python_plus_fastapi_pydantic_v2` (contract parsing and fixture-hydration utilities)
+- Frontend stack profile: `none (not in scope)`
+- Test automation profile: `pytest + unittest contract assertions`
+- Agent execution model: `single-agent deterministic execution`
+
+## Problem Statement
+- What needs to change and why:
+  - optional-module `required_env` contracts evolve over time while test fixture helper defaults can drift.
+  - drift currently surfaces late in heavier optional-module tests after bootstrap/preflight steps.
+  - fast infra contract checks need explicit parity coverage between contract-required env vars and fixture defaults.
+- Scope boundaries:
+  - `tests/_shared/helpers.py`
+  - new fast parity test file under `tests/infra/`
+  - `scripts/bin/infra/contract_test_fast.sh`
+  - SDD artifacts + backlog/decision synchronization
+- Out of scope:
+  - runtime optional-module provisioning behavior
+  - module contract schema changes
+  - app/runtime docs feature behavior updates
+
+## Bounded Contexts and Responsibilities
+- Module contract context:
+  - source of truth for optional-module `required_env` entries (`blueprint/modules/*/module.contract.yaml`)
+- Fixture hydration context:
+  - deterministic env assembly for tests (`module_flags_env`)
+- Fast validation context:
+  - fail-fast parity guard in `infra-contract-test-fast`
+
+## High-Level Component Design
+- Domain layer:
+  - canonical required-env contract per optional module
+- Application layer:
+  - `module_flags_env` derives enabled modules and resolves required env defaults via shared init-repo env resolver
+- Infrastructure adapters:
+  - contract loaders from `scripts/lib/blueprint/init_repo_contract.py` and module env resolver from `scripts/lib/blueprint/init_repo_env.py`
+- Presentation/API/workflow boundaries:
+  - deterministic contract test output in pytest failures and fast-lane script execution output
+
+## Integration and Dependency Edges
+- Upstream dependencies:
+  - `blueprint/contract.yaml` optional module catalog
+  - `blueprint/modules/*/module.contract.yaml` required env declarations
+  - `scripts/lib/blueprint/init_repo_env.py` default catalog and resolver
+- Downstream dependencies:
+  - `tests/infra/test_optional_modules.py` and other tests that call `module_flags_env`
+  - `make quality-hooks-fast` via `infra-contract-test-fast`
+- Data/API/event contracts touched:
+  - env contract only (test-fixture scope); no API/event payload changes
+
+## Non-Functional Architecture Notes
+- Security:
+  - no live secret acquisition; test defaults remain deterministic placeholders or local overrides
+- Observability:
+  - deterministic sorted drift diagnostics in parity test assertions
+- Reliability and rollback:
+  - single-source resolver removes duplicated helper branches and reduces drift risk
+  - rollback is revert of helper + parity test + fast-lane script changes
+- Monitoring/alerting:
+  - CI fast lane acts as contract-drift alert surface
+
+## Risks and Tradeoffs
+- Risk 1: helper hydration may still pass with empty defaults if resolver map regresses.
+  - Mitigation: parity test asserts non-empty required values for enabled modules.
+- Tradeoff 1: helper now loads contract metadata during test env assembly.
+  - Mitigation: keep logic cached/deterministic and limited to test processes.

--- a/specs/2026-04-19-issue-130-required-env-fixture-parity/context_pack.md
+++ b/specs/2026-04-19-issue-130-required-env-fixture-parity/context_pack.md
@@ -1,0 +1,32 @@
+# Work Item Context Pack
+
+## Context Snapshot
+- Work item: `2026-04-19-issue-130-required-env-fixture-parity`
+- Track: blueprint
+- SPEC_READY: true
+- ADR path: `docs/blueprint/architecture/decisions/ADR-20260419-issue-130-optional-module-required-env-fixture-parity.md`
+- ADR status: approved
+
+## Guardrail Controls
+- Applicable control IDs: SDD-C-001, SDD-C-002, SDD-C-003, SDD-C-004, SDD-C-005, SDD-C-006, SDD-C-007, SDD-C-008, SDD-C-009, SDD-C-010, SDD-C-011, SDD-C-012, SDD-C-013, SDD-C-014, SDD-C-015, SDD-C-016, SDD-C-017, SDD-C-018, SDD-C-019, SDD-C-020, SDD-C-021
+
+## Required Commands
+- `make quality-sdd-check`
+- `make quality-sdd-check-all`
+- `make quality-hooks-run`
+- `make quality-hardening-review`
+- `make infra-validate`
+- `make docs-build`
+- `make docs-smoke`
+- `make spec-pr-context`
+
+## Artifact Index
+- `architecture.md`
+- `spec.md`
+- `plan.md`
+- `tasks.md`
+- `traceability.md`
+- `graph.yaml`
+- `evidence_manifest.json`
+- `pr_context.md`
+- `hardening_review.md`

--- a/specs/2026-04-19-issue-130-required-env-fixture-parity/evidence_manifest.json
+++ b/specs/2026-04-19-issue-130-required-env-fixture-parity/evidence_manifest.json
@@ -1,0 +1,58 @@
+{
+  "manifest_version": 1,
+  "work_item": "specs/2026-04-19-issue-130-required-env-fixture-parity",
+  "generated_by": "spec-evidence-manifest",
+  "generated_at_utc": "2026-04-19T06:41:00Z",
+  "files": [
+    {
+      "path": "specs/2026-04-19-issue-130-required-env-fixture-parity/architecture.md",
+      "sha256": "5169a2d3199db8439cfb442f865de25ebda5067df5a243ffe02bf4af947c816c",
+      "bytes": 3473
+    },
+    {
+      "path": "specs/2026-04-19-issue-130-required-env-fixture-parity/context_pack.md",
+      "sha256": "6422f648b3da880d0663854fb9dff5c36de6ab04effcf812a2b2905e83a8868d",
+      "bytes": 982
+    },
+    {
+      "path": "specs/2026-04-19-issue-130-required-env-fixture-parity/evidence_manifest.json",
+      "sha256": "7275a71fcf249ab51c1e53ef8e89bf0496489b7acd5ad111e4feaeeefa830bc6",
+      "bytes": 2237
+    },
+    {
+      "path": "specs/2026-04-19-issue-130-required-env-fixture-parity/graph.yaml",
+      "sha256": "a06c684b69a9232da91fcebfd471b0080231fce8b93d314d1ccae4821e16b45b",
+      "bytes": 2151
+    },
+    {
+      "path": "specs/2026-04-19-issue-130-required-env-fixture-parity/hardening_review.md",
+      "sha256": "8ed1bfeb1116410643760981adc6fde3597b0184075ba46e5a276d46e6b8f97a",
+      "bytes": 2225
+    },
+    {
+      "path": "specs/2026-04-19-issue-130-required-env-fixture-parity/plan.md",
+      "sha256": "184e43b1c15d95ce164eccc3c1fe695cf5636ee949aa8c29a3e08a9ac9245a42",
+      "bytes": 5610
+    },
+    {
+      "path": "specs/2026-04-19-issue-130-required-env-fixture-parity/pr_context.md",
+      "sha256": "603a4c0887819550c2a3ab4df0a2fcfe0f62bd3f8d9a56e0663c78e92a4ebcb9",
+      "bytes": 3021
+    },
+    {
+      "path": "specs/2026-04-19-issue-130-required-env-fixture-parity/spec.md",
+      "sha256": "0f330c3d3d2eb265bcf7a75df39f30f6df3a52a687114b4474cfb3aacab6c615",
+      "bytes": 5301
+    },
+    {
+      "path": "specs/2026-04-19-issue-130-required-env-fixture-parity/tasks.md",
+      "sha256": "99ac2118af19ae6fe8c76abb47b7694170fce6d53b1ce8e28f6724a69cc728ac",
+      "bytes": 2778
+    },
+    {
+      "path": "specs/2026-04-19-issue-130-required-env-fixture-parity/traceability.md",
+      "sha256": "63db9ad8dfb9c009eb57add9698c471ffe3de166a05378aa1f0faf60e63a4e41",
+      "bytes": 5113
+    }
+  ]
+}

--- a/specs/2026-04-19-issue-130-required-env-fixture-parity/graph.yaml
+++ b/specs/2026-04-19-issue-130-required-env-fixture-parity/graph.yaml
@@ -1,0 +1,93 @@
+{
+  "graph_version": 1,
+  "work_item": "2026-04-19-issue-130-required-env-fixture-parity",
+  "nodes": [
+    {
+      "id": "FR-001",
+      "type": "requirement",
+      "summary": "Fixture helper hydrates required env for enabled optional modules via canonical resolver"
+    },
+    {
+      "id": "FR-002",
+      "type": "requirement",
+      "summary": "Parity test fails deterministically when required_env coverage drifts"
+    },
+    {
+      "id": "FR-003",
+      "type": "requirement",
+      "summary": "Fast infra contract lane executes parity coverage checks"
+    },
+    {
+      "id": "NFR-SEC-001",
+      "type": "requirement",
+      "summary": "No live-secret dependence for parity checks"
+    },
+    {
+      "id": "NFR-OBS-001",
+      "type": "requirement",
+      "summary": "Deterministic, sorted parity diagnostics"
+    },
+    {
+      "id": "NFR-REL-001",
+      "type": "requirement",
+      "summary": "Deterministic parity behavior across runs"
+    },
+    {
+      "id": "NFR-OPS-001",
+      "type": "requirement",
+      "summary": "Explicit remediation path through fast lane"
+    },
+    {
+      "id": "AC-001",
+      "type": "acceptance",
+      "summary": "Enabled-module fixture env contains all required vars"
+    },
+    {
+      "id": "AC-002",
+      "type": "acceptance",
+      "summary": "Parity drift detection test fails deterministically"
+    },
+    {
+      "id": "AC-003",
+      "type": "acceptance",
+      "summary": "Fast lane runs parity checks"
+    }
+  ],
+  "edges": [
+    {
+      "from": "FR-001",
+      "to": "AC-001",
+      "relation": "validated_by"
+    },
+    {
+      "from": "FR-002",
+      "to": "AC-002",
+      "relation": "validated_by"
+    },
+    {
+      "from": "FR-003",
+      "to": "AC-003",
+      "relation": "validated_by"
+    },
+    {
+      "from": "NFR-SEC-001",
+      "to": "AC-001",
+      "relation": "constrains"
+    },
+    {
+      "from": "NFR-OBS-001",
+      "to": "AC-002",
+      "relation": "constrains"
+    },
+    {
+      "from": "NFR-REL-001",
+      "to": "AC-002",
+      "relation": "constrains"
+    },
+    {
+      "from": "NFR-OPS-001",
+      "to": "AC-003",
+      "relation": "constrains"
+    }
+  ]
+}

--- a/specs/2026-04-19-issue-130-required-env-fixture-parity/hardening_review.md
+++ b/specs/2026-04-19-issue-130-required-env-fixture-parity/hardening_review.md
@@ -1,0 +1,35 @@
+# Hardening Review
+
+## Repository-Wide Findings Fixed
+- Added deterministic parity contract tests to block optional-module `required_env` drift in fixtures:
+  - `tests/infra/test_optional_module_required_env_contract.py`
+- Removed duplicated per-module fixture branching in `module_flags_env` and switched to canonical required-env resolver wiring:
+  - `tests/_shared/helpers.py`
+- Added missing canonical required defaults for workflows contract-required fields:
+  - `STACKIT_PROJECT_ID`
+  - `STACKIT_REGION`
+  - source: `scripts/lib/blueprint/init_repo_env.py`
+- Wired parity checks into fast infra contract lane:
+  - `scripts/bin/infra/contract_test_fast.sh`
+- Classified the new parity test in the unit scope to keep test-pyramid governance deterministic:
+  - `scripts/lib/quality/test_pyramid_contract.json`
+
+## Observability and Diagnostics Changes
+- Metrics/logging/tracing updates:
+  - no runtime telemetry changes; scope is test-fixture and fast-lane contract enforcement.
+- Operational diagnostics updates:
+  - parity tests emit deterministic and sorted missing diagnostics as `module_id:ENV_NAME` and grouped `module=[env,...]` outputs.
+
+## Architecture and Code Quality Compliance
+- SOLID / Clean Architecture / Clean Code / DDD checks:
+  - fixture hydration now depends on one canonical required-env resolver (`enabled_module_required_env_specs`) instead of multiple ad-hoc branches.
+  - contract traversal remains explicit (`optional_modules` -> module contract -> `required_env`).
+- Test-automation and pyramid checks:
+  - red-to-green flow captured (`pytest -q tests/infra/test_optional_module_required_env_contract.py` initially failed, then passed after helper/default updates).
+  - `infra-contract-test-fast`, `quality-hooks-fast`, and `quality-hooks-run` passed with parity test included.
+- Documentation/diagram/CI/skill consistency checks:
+  - SDD work-item artifacts and ADR completed.
+  - no user-facing docs/skill behavior changed.
+
+## Proposals Only (Not Implemented)
+- Extract a typed shared helper from `init_repo_env` that returns required-env defaults plus explicit missing-default diagnostics, so test helpers and init flows consume one stable API surface without touching internal structures.

--- a/specs/2026-04-19-issue-130-required-env-fixture-parity/plan.md
+++ b/specs/2026-04-19-issue-130-required-env-fixture-parity/plan.md
@@ -1,0 +1,120 @@
+# Implementation Plan
+
+## Implementation Start Gate
+- Implementation tasks MUST remain unchecked until `SPEC_READY=true`.
+- If required inputs are missing, add `BLOCKED_MISSING_INPUTS` in `spec.md` and keep the gate closed.
+
+## Constitution Gates (Pre-Implementation)
+- Simplicity gate:
+  - Keep initial implementation scope minimal and explicit.
+  - Avoid speculative future-proof abstractions.
+- Anti-abstraction gate:
+  - Prefer direct framework primitives over wrapper layers unless justified.
+  - Keep model representations singular unless boundary separation is required.
+- Integration-first testing gate:
+  - Define contract and boundary tests before implementation details.
+  - Ensure realistic environment coverage for integration points.
+- Positive-path filter/transform test gate:
+  - For any filter or payload-transform logic, at least one unit test MUST assert that a matching fixture value returns a record.
+  - Positive-path assertions MUST verify relevant output fields remain intact after filtering/transform.
+  - Empty-result-only assertions MUST NOT satisfy this gate.
+- Finding-to-test translation gate:
+  - Any reproducible pre-PR finding from smoke/`curl`/deterministic manual checks MUST be translated into a failing automated test first.
+  - The implementation fix MUST turn that test green in the same work item.
+  - If no deterministic automation path exists, publish artifacts MUST record the exception rationale, owner, and follow-up trigger.
+
+## Delivery Slices
+1. Slice 1: add fast parity tests that assert optional-module contract `required_env` coverage by fixture helper output.
+2. Slice 2: refactor `module_flags_env` to derive required env defaults for enabled modules through canonical resolver logic.
+3. Slice 3: include parity tests in `infra-contract-test-fast` and run fast quality bundles.
+4. Slice 4: finalize docs-phase operational/publish artifacts and backlog/decision synchronization.
+
+## Change Strategy
+- Migration/rollout sequence:
+  - write failing parity test assertions
+  - update helper hydration logic to satisfy parity
+  - wire fast lane execution path
+  - run required validation commands and update SDD artifacts
+- Backward compatibility policy:
+  - maintain existing `module_flags_env` call signature and existing env flag keys
+  - preserve explicit caller overrides (`env.setdefault`) semantics
+- Rollback plan:
+  - revert helper + parity-test + fast-lane script edits
+  - rerun `make infra-contract-test-fast` and `make quality-hooks-fast`
+
+## Validation Strategy (Shift-Left)
+- Unit checks:
+  - `python3 -m unittest tests.blueprint.test_init_repo_env -v`
+- Contract checks:
+  - `pytest -q tests/infra/test_optional_module_required_env_contract.py`
+  - `make infra-contract-test-fast`
+  - `make quality-hooks-fast`
+  - `make infra-validate`
+- Integration checks:
+  - `pytest -q tests/infra/test_optional_modules.py -k "test_postgres_module_flow or test_workflows_module_flow"`
+- E2E checks:
+  - not required (fixture + contract-test scope)
+
+## App Onboarding Contract (Normative)
+- Required minimum make targets:
+  - `apps-bootstrap`
+  - `apps-smoke`
+  - `backend-test-unit`
+  - `backend-test-integration`
+  - `backend-test-contracts`
+  - `backend-test-e2e`
+  - `touchpoints-test-unit`
+  - `touchpoints-test-integration`
+  - `touchpoints-test-contracts`
+  - `touchpoints-test-e2e`
+  - `test-unit-all`
+  - `test-integration-all`
+  - `test-contracts-all`
+  - `test-e2e-all-local`
+  - `infra-port-forward-start`
+  - `infra-port-forward-stop`
+  - `infra-port-forward-cleanup`
+- App onboarding impact: no-impact | impacted (select one)
+- App onboarding impact: no-impact
+- Notes: no `apps/**` or app lane contract behavior changed.
+
+## Documentation Plan (Document Phase)
+- Blueprint docs updates:
+  - SDD artifact updates only; no user-facing docs behavior changes.
+- Consumer docs updates:
+  - none.
+- Mermaid diagrams updated:
+  - ADR decision and timeline diagrams for Issue #130 scope.
+- Docs validation commands:
+  - `make docs-build`
+  - `make docs-smoke`
+
+## Publish Preparation
+- PR context file:
+  - `pr_context.md`
+- Hardening review file:
+  - `hardening_review.md`
+- Local smoke gate (HTTP route/filter changes):
+  - For work that touches HTTP route handlers, query/filter logic, or new API endpoints, run local smoke before PR publication.
+  - Execute local smoke with deterministic wrappers (`make infra-provision`, `make infra-deploy`, `make infra-port-forward-start`), then run positive-path `curl` assertions per changed endpoint.
+  - Positive-path filter assertions MUST use non-empty fixture/request values; empty-result-only assertions MUST NOT satisfy this gate.
+  - Record evidence in `pr_context.md` as `Endpoint | Method | Auth | Result`.
+  - Stop/cleanup wrappers after smoke (`make infra-port-forward-stop`, `make infra-port-forward-cleanup`).
+- Publish checklist:
+  - include requirement/contract coverage
+  - include key reviewer files
+  - include validation evidence + rollback notes
+
+## Operational Readiness
+- Logging/metrics/traces:
+  - no new runtime metrics; contract parity diagnostics provided by deterministic test failure output.
+- Alerts/ownership:
+  - CI fast-lane failures on parity drift owned by blueprint maintainers.
+- Runbook updates:
+  - no operator runbook changes required.
+
+## Risks and Mitigations
+- Risk 1: new optional module added without helper signature alignment.
+  - Mitigation: parity test asserts module-to-helper-flag mapping presence.
+- Risk 2: required env defaults become empty in canonical resolver map.
+  - Mitigation: parity test asserts non-empty values for every required env variable.

--- a/specs/2026-04-19-issue-130-required-env-fixture-parity/pr_context.md
+++ b/specs/2026-04-19-issue-130-required-env-fixture-parity/pr_context.md
@@ -1,0 +1,62 @@
+# PR Context
+
+## Summary
+- Work item: `specs/2026-04-19-issue-130-required-env-fixture-parity/`
+- Objective: enforce deterministic parity between optional-module `required_env` contracts and test fixture defaults in fast validation lanes.
+- Scope boundaries:
+  - `tests/_shared/helpers.py`
+  - `tests/infra/test_optional_module_required_env_contract.py` (new)
+  - `scripts/bin/infra/contract_test_fast.sh`
+  - `scripts/lib/blueprint/init_repo_env.py`
+  - `scripts/lib/quality/test_pyramid_contract.json`
+  - SDD artifacts + ADR + governance backlog/decision updates
+
+## Requirement Coverage
+- Requirement IDs covered:
+  - `FR-001`, `FR-002`, `FR-003`, `NFR-SEC-001`, `NFR-OBS-001`, `NFR-REL-001`, `NFR-OPS-001`
+- Acceptance criteria covered:
+  - `AC-001`, `AC-002`, `AC-003`
+- Contract surfaces changed:
+  - fast lane command surface (`infra-contract-test-fast`) now includes required-env parity check
+  - canonical module required-env default map includes workflows `STACKIT_PROJECT_ID` + `STACKIT_REGION`
+
+## Key Reviewer Files
+- Primary files to review first:
+  - `tests/infra/test_optional_module_required_env_contract.py`
+  - `tests/_shared/helpers.py`
+  - `scripts/lib/blueprint/init_repo_env.py`
+  - `scripts/bin/infra/contract_test_fast.sh`
+- High-risk files:
+  - `tests/_shared/helpers.py`
+  - `scripts/lib/blueprint/init_repo_env.py`
+
+## Validation Evidence
+- Required commands executed:
+  - `pytest -q tests/infra/test_optional_module_required_env_contract.py`
+  - `python3 -m unittest tests.blueprint.test_init_repo_env -v`
+  - `make infra-contract-test-fast`
+  - `make quality-hooks-fast`
+  - `make docs-build`
+  - `make docs-smoke`
+  - `make quality-hardening-review`
+  - `make quality-hooks-run`
+- Result summary:
+  - all commands above passed after parity/test-pyramid fixes.
+  - one additional targeted integration spot-check (`pytest -q tests/infra/test_optional_modules.py -k "test_postgres_module_flow or test_workflows_module_flow"`) reported an unrelated sandbox permission failure when writing kubeconfig (`~/.kube/stackit-stackit-dev.yaml: Operation not permitted`).
+- Artifact references:
+  - `specs/2026-04-19-issue-130-required-env-fixture-parity/spec.md`
+  - `specs/2026-04-19-issue-130-required-env-fixture-parity/traceability.md`
+  - `specs/2026-04-19-issue-130-required-env-fixture-parity/hardening_review.md`
+  - `artifacts/docs/docs_build.env`
+  - `artifacts/docs/docs_smoke.env`
+
+## Risk and Rollback
+- Main risks:
+  - fixture helper now depends on contract loading; regressions would affect tests that call `module_flags_env`.
+  - future `required_env` additions without default entries will intentionally fail fast.
+- Rollback strategy:
+  - revert helper/parity-test/fast-lane/default-map changes in this work item.
+  - rerun `make infra-contract-test-fast` and `make quality-hooks-fast`.
+
+## Deferred Proposals
+- Extract a typed shared API in `init_repo_env` for required-env defaults + missing-default diagnostics so all fixture and init consumers use one explicit contract surface.

--- a/specs/2026-04-19-issue-130-required-env-fixture-parity/spec.md
+++ b/specs/2026-04-19-issue-130-required-env-fixture-parity/spec.md
@@ -1,0 +1,88 @@
+# Specification
+
+## Spec Readiness Gate (Blocking)
+- SPEC_READY: true
+- Open questions count: 0
+- Unresolved alternatives count: 0
+- Unresolved TODO markers count: 0
+- Pending assumptions count: 0
+- Open clarification markers count: 0
+- Product sign-off: approved
+- Architecture sign-off: approved
+- Security sign-off: approved
+- Operations sign-off: approved
+- Missing input blocker token: none
+- ADR path: docs/blueprint/architecture/decisions/ADR-20260419-issue-130-optional-module-required-env-fixture-parity.md
+- ADR status: approved
+
+## Applicable Guardrail Controls (Normative)
+- Applicable control IDs: SDD-C-001, SDD-C-002, SDD-C-003, SDD-C-004, SDD-C-005, SDD-C-006, SDD-C-007, SDD-C-008, SDD-C-009, SDD-C-010, SDD-C-011, SDD-C-012, SDD-C-013, SDD-C-014, SDD-C-015, SDD-C-016, SDD-C-017, SDD-C-018, SDD-C-019, SDD-C-020, SDD-C-021
+- Control exception rationale: none
+
+## Implementation Stack Profile (Normative)
+- Backend stack profile: python_plus_fastapi_pydantic_v2
+- Frontend stack profile: vue_router_pinia_onyx
+- Test automation profile: pytest_vitest_playwright_pact
+- Agent execution model: specialized-subagents-isolated-worktrees
+- Managed service preference: stackit-managed-first
+- Managed service exception rationale: none
+- Runtime profile: local-first-docker-desktop-kubernetes
+- Local Kubernetes context policy: docker-desktop-preferred
+- Local provisioning stack: crossplane-plus-helm
+- Runtime identity baseline: eso-plus-argocd-plus-keycloak
+- Local-first exception rationale: none
+
+## Objective
+- Business outcome: optional-module test fixtures MUST stay contract-aligned so generated-consumer upgrades fail fast on true behavior regressions, not missing test input plumbing.
+- Success metric: fast infra contract lane fails deterministically whenever any optional-module `required_env` contract variable is missing from fixture defaults, and passes when parity is complete.
+
+## Normative Requirements
+
+### Functional Requirements (Normative)
+- FR-001 fixture helper `tests/_shared/helpers.py::module_flags_env` MUST hydrate required environment inputs for every enabled optional module by reusing the canonical module required-env default resolver, not ad-hoc per-module branches.
+- FR-002 a dedicated automated parity test MUST compare optional-module `required_env` contracts against fixture default hydration output and MUST fail with deterministic missing-variable diagnostics.
+- FR-003 `infra-contract-test-fast` MUST execute the optional-module required-env parity test so drift is detected in fast quality lanes before broader infra/module tests.
+
+### Non-Functional Requirements (Normative)
+- NFR-SEC-001 parity checks MUST NOT require real credentials and MUST rely only on deterministic placeholder-safe defaults or explicit test env overrides.
+- NFR-OBS-001 parity check failures MUST emit deterministic, sorted missing-variable diagnostics that identify module IDs and env names.
+- NFR-REL-001 parity detection MUST be deterministic across runs and independent of file traversal order.
+- NFR-OPS-001 remediation path MUST be explicit: update canonical default catalog and rerun `make infra-contract-test-fast`.
+
+## Normative Option Decision
+- Option A: keep manual per-module fixture defaults in `module_flags_env` and rely on slower optional-module behavior tests for drift detection.
+- Option B: centralize fixture hydration on canonical required-env defaults and add fast contract parity tests executed by `infra-contract-test-fast`.
+- Selected option: OPTION_B
+- Rationale: Option B removes duplicated fixture logic and fails fast when contract-required inputs evolve.
+
+## Contract Changes (Normative)
+- Config/Env contract:
+  - no runtime contract keys added; change is limited to test-fixture hydration and contract-test coverage.
+- API contract:
+  - none.
+- Event contract:
+  - none.
+- Make/CLI contract:
+  - `scripts/bin/infra/contract_test_fast.sh` SHALL include the new optional-module required-env parity test file.
+- Docs contract:
+  - SDD artifacts and backlog/decision logs SHALL record Issue #130 completion scope.
+
+## Blueprint Upstream Defect Escalation (Normative)
+- Upstream issue URL: https://github.com/sbonoc/stackit-platform-blueprint/issues/130
+- Temporary workaround path: none
+- Replacement trigger: none
+- Workaround review date: none
+
+## Normative Acceptance Criteria
+- AC-001 MUST be objectively testable: enabling any optional module through `module_flags_env` yields non-empty values for all contract-required env vars of enabled modules.
+- AC-002 MUST be objectively testable: a fast parity test fails deterministically when any optional-module `required_env` entry is absent from fixture hydration output.
+- AC-003 MUST be objectively testable: `make infra-contract-test-fast` executes the parity test and surfaces contract-drift failures before optional-module behavior suites.
+
+## Informative Notes (Non-Normative)
+- Context: this work item implements backlog priority `P1 (Fixture-contract hardening): Issue #130`.
+- Tradeoffs: this scope hardens fixture plumbing only; it does not modify runtime module provisioning behavior.
+- Clarifications: none.
+
+## Explicit Exclusions
+- No changes to module runtime scripts under `scripts/bin/infra/*` for module behavior.
+- No changes to optional-module contract schema structure.

--- a/specs/2026-04-19-issue-130-required-env-fixture-parity/tasks.md
+++ b/specs/2026-04-19-issue-130-required-env-fixture-parity/tasks.md
@@ -1,0 +1,40 @@
+# Tasks
+
+## Gate Checks (Required Before Implementation)
+- [x] G-001 Confirm `SPEC_READY=true` in `spec.md`
+- [x] G-002 Confirm open questions and unresolved alternatives are `0`
+- [x] G-003 Confirm required sign-offs are approved
+- [x] G-004 Confirm `Applicable Guardrail Controls` section includes `SDD-C-###` IDs
+- [x] G-005 Confirm `Implementation Stack Profile` section is fully populated
+
+## Implementation
+- [x] T-001 Update contract/governance surfaces
+- [x] T-002 Implement runtime/code changes
+- [x] T-003 Update blueprint docs/diagrams
+- [x] T-004 Update consumer-facing docs/diagrams when contracts/behavior change (no-impact)
+
+## Test Automation
+- [x] T-101 Add or update unit tests
+- [x] T-102 Add or update contract tests
+- [x] T-103 For any new or modified filter/payload-transform route, verify a positive-path unit test exists (matching fixture value returns record and output fields remain intact); capture evidence in `pr_context.md` (no-impact: route/filter scope unchanged)
+- [x] T-104 Translate any reproducible pre-PR smoke/`curl`/deterministic-check finding into a failing automated test first, then turn it green with the fix in the same work item (or document deterministic exception in publish artifacts)
+- [x] T-105 Add boundary/integration tests where required
+
+## Validation and Release Readiness
+- [x] T-201 Run required Make validation bundles
+- [x] T-202 Attach evidence to traceability document
+- [x] T-203 Confirm no stale TODOs/dead code/drift
+- [x] T-204 Run documentation validation (`make docs-build` and `make docs-smoke`)
+- [x] T-205 Run hardening review validation bundle (`make quality-hardening-review`)
+
+## Publish
+- [x] P-001 Update `hardening_review.md` with repository-wide findings fixed and proposals-only section
+- [x] P-002 Update `pr_context.md` with requirement/contract coverage, key reviewer files, validation evidence, and rollback notes
+- [x] P-003 Ensure PR description follows repository template headings and references `pr_context.md`
+
+## App Onboarding Minimum Targets (Normative)
+- [x] A-001 `apps-bootstrap` and `apps-smoke` are implemented and verified for the affected app scope (no-impact)
+- [x] A-002 Backend app lanes (`backend-test-unit`, `backend-test-integration`, `backend-test-contracts`, `backend-test-e2e`) are available (no-impact)
+- [x] A-003 Frontend app lanes (`touchpoints-test-unit`, `touchpoints-test-integration`, `touchpoints-test-contracts`, `touchpoints-test-e2e`) are available (no-impact)
+- [x] A-004 Aggregate gates (`test-unit-all`, `test-integration-all`, `test-contracts-all`, `test-e2e-all-local`) are available (no-impact)
+- [x] A-005 Port-forward operational wrappers (`infra-port-forward-start`, `infra-port-forward-stop`, `infra-port-forward-cleanup`) are available (no-impact)

--- a/specs/2026-04-19-issue-130-required-env-fixture-parity/traceability.md
+++ b/specs/2026-04-19-issue-130-required-env-fixture-parity/traceability.md
@@ -1,0 +1,57 @@
+# Traceability Matrix
+
+## Requirement-to-Delivery Mapping
+
+| Requirement ID | Control IDs | Design Element | Implementation Path(s) | Test Evidence | Documentation Evidence | Operational Evidence |
+|---|---|---|---|---|---|---|
+| FR-001 | SDD-C-005 | Canonical required-env fixture hydration | tests/_shared/helpers.py | tests.infra.test_optional_module_required_env_contract.ModuleRequiredEnvFixtureContractTests.test_module_flags_env_populates_required_env_for_all_enabled_modules | specs/2026-04-19-issue-130-required-env-fixture-parity/spec.md | fast-lane contract diagnostics |
+| FR-002 | SDD-C-005 | Contract parity detector for required env defaults | tests/infra/test_optional_module_required_env_contract.py | tests.infra.test_optional_module_required_env_contract.ModuleRequiredEnvFixtureContractTests.test_module_flags_env_has_parameter_for_every_optional_module_toggle; tests.infra.test_optional_module_required_env_contract.ModuleRequiredEnvFixtureContractTests.test_required_env_contract_parity_reports_no_missing_defaults | specs/2026-04-19-issue-130-required-env-fixture-parity/plan.md | deterministic missing list in pytest output |
+| FR-003 | SDD-C-005 | Fast lane inclusion of parity test | scripts/bin/infra/contract_test_fast.sh | make infra-contract-test-fast | docs/reference/generated/core_targets.generated.md | quality-hooks-fast / infra-contract-test-fast output |
+| NFR-SEC-001 | SDD-C-009 | Placeholder-safe deterministic defaults for required env | scripts/lib/blueprint/init_repo_env.py; tests/_shared/helpers.py | tests.blueprint.test_init_repo_env.InitRepoEnvTests.test_enabled_module_required_inputs_split_by_sensitivity | specs/2026-04-19-issue-130-required-env-fixture-parity/spec.md | no live secret requirements in fast lane |
+| NFR-OBS-001 | SDD-C-010 | Sorted, deterministic parity diagnostics | tests/infra/test_optional_module_required_env_contract.py | pytest -q tests/infra/test_optional_module_required_env_contract.py | specs/2026-04-19-issue-130-required-env-fixture-parity/hardening_review.md | sorted missing diagnostics |
+| NFR-REL-001 | SDD-C-011 | Deterministic contract traversal and union coverage | tests/infra/test_optional_module_required_env_contract.py | pytest -q tests/infra/test_optional_module_required_env_contract.py | specs/2026-04-19-issue-130-required-env-fixture-parity/spec.md | stable pass/fail across runs |
+| NFR-OPS-001 | SDD-C-018 | Explicit remediation path in fast lane | scripts/bin/infra/contract_test_fast.sh; tests/infra/test_optional_module_required_env_contract.py | make quality-hooks-fast | specs/2026-04-19-issue-130-required-env-fixture-parity/pr_context.md | command-level remediation (`make infra-contract-test-fast`) |
+| AC-001 | SDD-C-012 | Enabled-module required env hydration | tests/_shared/helpers.py | tests.infra.test_optional_module_required_env_contract.ModuleRequiredEnvFixtureContractTests.test_module_flags_env_populates_required_env_for_all_enabled_modules | specs/2026-04-19-issue-130-required-env-fixture-parity/pr_context.md | fixture env payload contains required keys |
+| AC-002 | SDD-C-012 | Missing-required-env fail-fast check | tests/infra/test_optional_module_required_env_contract.py | tests.infra.test_optional_module_required_env_contract.ModuleRequiredEnvFixtureContractTests.test_required_env_contract_parity_reports_no_missing_defaults | specs/2026-04-19-issue-130-required-env-fixture-parity/pr_context.md | deterministic parity failure output |
+| AC-003 | SDD-C-012 | Fast lane wiring | scripts/bin/infra/contract_test_fast.sh | make infra-contract-test-fast; make quality-hooks-fast | specs/2026-04-19-issue-130-required-env-fixture-parity/pr_context.md | fast lane includes parity test file |
+
+## Graph Linkage
+- Graph file: `graph.yaml`
+- Every `FR-###`, `NFR-*-###`, and `AC-###` listed in this file MUST have a corresponding node in `graph.yaml`.
+- Node IDs referenced:
+  - FR-001
+  - FR-002
+  - FR-003
+  - NFR-SEC-001
+  - NFR-OBS-001
+  - NFR-REL-001
+  - NFR-OPS-001
+  - AC-001
+  - AC-002
+  - AC-003
+
+## Validation Summary
+- Required bundles executed:
+  - `pytest -q tests/infra/test_optional_module_required_env_contract.py`
+  - `python3 -m unittest tests.blueprint.test_init_repo_env -v`
+  - `make infra-contract-test-fast`
+  - `make quality-hooks-fast`
+  - `make docs-build`
+  - `make docs-smoke`
+  - `make quality-hardening-review`
+  - `make quality-hooks-run`
+- Result summary:
+  - all commands above passed.
+  - targeted optional-module integration spot-check (`pytest -q tests/infra/test_optional_modules.py -k "test_postgres_module_flow or test_workflows_module_flow"`) failed due sandbox-only kubeconfig write permission, not fixture parity logic.
+- Documentation validation:
+  - `make docs-build`
+  - `make docs-smoke`
+
+## Evidence Manifest
+- Manifest file: `evidence_manifest.json`
+- Context export: `context_pack.md`
+- PR context export: `pr_context.md`
+- Hardening review export: `hardening_review.md`
+
+## Open Risks and Follow-Ups
+- Follow-up 1: optionally expose a reusable helper to materialize required-env defaults for tests and init flows from one typed API surface.

--- a/tests/_shared/helpers.py
+++ b/tests/_shared/helpers.py
@@ -8,7 +8,10 @@ from pathlib import Path
 import shutil
 import subprocess
 
-from scripts.lib.blueprint.init_repo_contract import load_blueprint_contract_for_init
+from scripts.lib.blueprint.init_repo_contract import (
+    load_blueprint_contract_for_init,
+    normalize_bool,
+)
 from scripts.lib.blueprint.init_repo_env import enabled_module_required_env_specs
 from tests._shared.exec import DEFAULT_TEST_COMMAND_TIMEOUT_SECONDS, run_command
 
@@ -24,6 +27,14 @@ def _optional_module_enable_flags() -> dict[str, str]:
         module.module_id: module.enable_flag
         for module in contract.optional_modules.modules.values()
     }
+
+
+def _is_enabled(value: str | bool | None) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return False
+    return normalize_bool(str(value))
 
 
 def module_flags_env(
@@ -42,6 +53,7 @@ def module_flags_env(
     secrets_manager: str = "false",
     kms: str = "false",
     identity_aware_proxy: str = "false",
+    hydrate_module_required_env: str | bool = "true",
 ) -> dict[str, str]:
     env = {
         "BLUEPRINT_PROFILE": profile,
@@ -60,13 +72,14 @@ def module_flags_env(
         "IDENTITY_AWARE_PROXY_ENABLED": identity_aware_proxy,
     }
 
-    module_enablement = {
-        module_id: env.get(enable_flag, "false").strip().lower() == "true"
-        for module_id, enable_flag in _optional_module_enable_flags().items()
-    }
-    for env_name, env_value in enabled_module_required_env_specs(REPO_ROOT, module_enablement):
-        if env_value:
-            env.setdefault(env_name, env_value)
+    if _is_enabled(hydrate_module_required_env):
+        module_enablement = {
+            module_id: _is_enabled(env.get(enable_flag, "false"))
+            for module_id, enable_flag in _optional_module_enable_flags().items()
+        }
+        for env_name, env_value in enabled_module_required_env_specs(REPO_ROOT, module_enablement):
+            if env_value:
+                env.setdefault(env_name, env_value)
 
     return env
 

--- a/tests/_shared/helpers.py
+++ b/tests/_shared/helpers.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from functools import lru_cache
 import hashlib
 import json
 import os
@@ -7,11 +8,22 @@ from pathlib import Path
 import shutil
 import subprocess
 
+from scripts.lib.blueprint.init_repo_contract import load_blueprint_contract_for_init
+from scripts.lib.blueprint.init_repo_env import enabled_module_required_env_specs
 from tests._shared.exec import DEFAULT_TEST_COMMAND_TIMEOUT_SECONDS, run_command
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 FIXTURE_CACHE_DIR = REPO_ROOT / "artifacts" / "tests" / "fixture-cache"
+
+
+@lru_cache(maxsize=1)
+def _optional_module_enable_flags() -> dict[str, str]:
+    contract = load_blueprint_contract_for_init(REPO_ROOT)
+    return {
+        module.module_id: module.enable_flag
+        for module in contract.optional_modules.modules.values()
+    }
 
 
 def module_flags_env(
@@ -48,18 +60,13 @@ def module_flags_env(
         "IDENTITY_AWARE_PROXY_ENABLED": identity_aware_proxy,
     }
 
-    # Tests that enable provider-backed Postgres need stable contract inputs so
-    # `infra-bootstrap` can render the local/STACKIT scaffolding deterministically.
-    if postgres == "true":
-        env.setdefault("POSTGRES_INSTANCE_NAME", "blueprint-postgres")
-        env.setdefault("POSTGRES_DB_NAME", "platform")
-        env.setdefault("POSTGRES_USER", "platform")
-        env.setdefault("POSTGRES_PASSWORD", "platform-password")
-
-    if opensearch == "true":
-        env.setdefault("OPENSEARCH_INSTANCE_NAME", "marketplace-opensearch")
-        env.setdefault("OPENSEARCH_VERSION", "2.17")
-        env.setdefault("OPENSEARCH_PLAN_NAME", "stackit-opensearch-single")
+    module_enablement = {
+        module_id: env.get(enable_flag, "false").strip().lower() == "true"
+        for module_id, enable_flag in _optional_module_enable_flags().items()
+    }
+    for env_name, env_value in enabled_module_required_env_specs(REPO_ROOT, module_enablement):
+        if env_value:
+            env.setdefault(env_name, env_value)
 
     return env
 

--- a/tests/infra/test_optional_module_required_env_contract.py
+++ b/tests/infra/test_optional_module_required_env_contract.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import inspect
+import unittest
+
+from scripts.lib.blueprint.contract_schema import load_module_contract
+from scripts.lib.blueprint.init_repo_contract import load_blueprint_contract_for_init
+from tests._shared.helpers import REPO_ROOT, module_flags_env
+
+
+class ModuleRequiredEnvFixtureContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.contract = load_blueprint_contract_for_init(REPO_ROOT)
+
+    def _required_env_pairs(self) -> list[tuple[str, str]]:
+        pairs: list[tuple[str, str]] = []
+        for module in self.contract.optional_modules.modules.values():
+            module_contract = load_module_contract(REPO_ROOT / module.paths["contract_path"], REPO_ROOT)
+            for env_name in module_contract.required_env:
+                pairs.append((module.module_id, env_name))
+        return sorted(set(pairs), key=lambda item: (item[0], item[1]))
+
+    def test_module_flags_env_has_parameter_for_every_optional_module_toggle(self) -> None:
+        signature = inspect.signature(module_flags_env)
+        missing: list[str] = []
+        for module in self.contract.optional_modules.modules.values():
+            expected_param = module.module_id.replace("-", "_")
+            if expected_param not in signature.parameters:
+                missing.append(f"{module.module_id}->{expected_param}")
+
+        self.assertEqual(
+            missing,
+            [],
+            msg=(
+                "module_flags_env missing module toggle parameter(s): "
+                + ", ".join(missing)
+                + ". Add matching kwargs so fixture enablement remains contract-aligned."
+            ),
+        )
+
+    def test_module_flags_env_populates_required_env_for_all_enabled_modules(self) -> None:
+        all_enabled_kwargs = {
+            module.module_id.replace("-", "_"): "true"
+            for module in self.contract.optional_modules.modules.values()
+        }
+        env = module_flags_env(profile="stackit-dev", **all_enabled_kwargs)
+
+        missing: list[str] = []
+        for module_id, env_name in self._required_env_pairs():
+            value = str(env.get(env_name, "")).strip()
+            if not value:
+                missing.append(f"{module_id}:{env_name}")
+
+        self.assertEqual(
+            missing,
+            [],
+            msg=(
+                "missing required optional-module fixture env defaults: "
+                + ", ".join(missing)
+                + ". Update canonical module required-env defaults and fixture hydration wiring."
+            ),
+        )
+
+    def test_required_env_contract_parity_reports_no_missing_defaults(self) -> None:
+        all_enabled_kwargs = {
+            module.module_id.replace("-", "_"): "true"
+            for module in self.contract.optional_modules.modules.values()
+        }
+        env = module_flags_env(profile="stackit-dev", **all_enabled_kwargs)
+
+        missing_by_module: dict[str, list[str]] = {}
+        for module in self.contract.optional_modules.modules.values():
+            module_contract = load_module_contract(REPO_ROOT / module.paths["contract_path"], REPO_ROOT)
+            required_missing = [
+                env_name
+                for env_name in module_contract.required_env
+                if not str(env.get(env_name, "")).strip()
+            ]
+            if required_missing:
+                missing_by_module[module.module_id] = sorted(required_missing)
+
+        self.assertEqual(
+            missing_by_module,
+            {},
+            msg=(
+                "optional-module required_env parity drift detected: "
+                + "; ".join(
+                    f"{module_id}=[{','.join(names)}]"
+                    for module_id, names in sorted(missing_by_module.items())
+                )
+            ),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/infra/test_optional_module_required_env_contract.py
+++ b/tests/infra/test_optional_module_required_env_contract.py
@@ -44,7 +44,11 @@ class ModuleRequiredEnvFixtureContractTests(unittest.TestCase):
             module.module_id.replace("-", "_"): "true"
             for module in self.contract.optional_modules.modules.values()
         }
-        env = module_flags_env(profile="stackit-dev", **all_enabled_kwargs)
+        env = module_flags_env(
+            profile="stackit-dev",
+            hydrate_module_required_env="true",
+            **all_enabled_kwargs,
+        )
 
         missing: list[str] = []
         for module_id, env_name in self._required_env_pairs():
@@ -67,7 +71,11 @@ class ModuleRequiredEnvFixtureContractTests(unittest.TestCase):
             module.module_id.replace("-", "_"): "true"
             for module in self.contract.optional_modules.modules.values()
         }
-        env = module_flags_env(profile="stackit-dev", **all_enabled_kwargs)
+        env = module_flags_env(
+            profile="stackit-dev",
+            hydrate_module_required_env="true",
+            **all_enabled_kwargs,
+        )
 
         missing_by_module: dict[str, list[str]] = {}
         for module in self.contract.optional_modules.modules.values():

--- a/tests/infra/test_optional_modules.py
+++ b/tests/infra/test_optional_modules.py
@@ -686,7 +686,7 @@ class OptionalModulesTests(unittest.TestCase):
         self.assertEqual(destroy.returncode, 0, msg=destroy.stdout + destroy.stderr)
 
     def test_identity_aware_proxy_requires_keycloak_oidc_configuration(self) -> None:
-        env = module_flags_env(identity_aware_proxy="true")
+        env = module_flags_env(identity_aware_proxy="true", hydrate_module_required_env="false")
         bootstrap = run_render_and_infra_bootstrap(env)
         self.assertEqual(bootstrap.returncode, 0, msg=bootstrap.stdout + bootstrap.stderr)
 


### PR DESCRIPTION
## Summary
- Harden optional-module fixture contract parity for generated-consumer upgrade/test flows (Issue #130).
- Add deterministic fast-lane parity checks between module `required_env` contracts and fixture hydration defaults.
- Refactor `module_flags_env` to hydrate enabled-module required inputs via canonical resolver logic instead of ad-hoc module branches.
- Work item: `specs/2026-04-19-issue-130-required-env-fixture-parity/`.
- Full SDD publish context: `specs/2026-04-19-issue-130-required-env-fixture-parity/pr_context.md`.

## Requirement and Contract Coverage
- Requirement IDs covered: `FR-001`, `FR-002`, `FR-003`, `NFR-SEC-001`, `NFR-OBS-001`, `NFR-REL-001`, `NFR-OPS-001`.
- Acceptance criteria covered: `AC-001`, `AC-002`, `AC-003`.
- Contract surfaces changed:
  - [x] `infra-contract-test-fast` now includes required-env parity checks.
  - [x] canonical module required-env defaults extended (`STACKIT_PROJECT_ID`, `STACKIT_REGION`).
  - [x] test-pyramid classification updated for new unit contract test.

## Key Reviewer Files
- Primary files to review first:
  - `tests/infra/test_optional_module_required_env_contract.py`
  - `tests/_shared/helpers.py`
  - `scripts/lib/blueprint/init_repo_env.py`
  - `scripts/bin/infra/contract_test_fast.sh`
- Additional governance artifacts:
  - `docs/blueprint/architecture/decisions/ADR-20260419-issue-130-optional-module-required-env-fixture-parity.md`
  - `specs/2026-04-19-issue-130-required-env-fixture-parity/spec.md`

## Validation Evidence
- Commands executed:
  - `pytest -q tests/infra/test_optional_module_required_env_contract.py`
  - `python3 -m unittest tests.blueprint.test_init_repo_env -v`
  - `make infra-contract-test-fast`
  - `make quality-hooks-fast`
  - `make docs-build`
  - `make docs-smoke`
  - `make quality-hardening-review`
  - `make quality-hooks-run`
- Result: all commands above passed.
- Note: one targeted optional-module spot-check (`pytest -q tests/infra/test_optional_modules.py -k "test_postgres_module_flow or test_workflows_module_flow"`) hit sandbox-only kubeconfig write permission (`~/.kube/stackit-stackit-dev.yaml: Operation not permitted`) and is not part of required lane evidence for this scope.

## Risk and Rollback
- Main risks:
  - fixture helper now loads optional-module contract metadata in test setup paths.
  - future `required_env` additions without defaults will fail fast (intentional behavior).
- Rollback strategy:
  - revert this PR branch and rerun `make infra-contract-test-fast` + `make quality-hooks-fast`.

## Deferred Proposals (Not Implemented)
- Extract a typed shared API in `init_repo_env` for required-env defaults + missing-default diagnostics so all fixture/init consumers use one explicit contract surface.
