### PR TITLE
fix: repo-mode-aware infra contract fast lane for generated consumers (#103)

### DIFF
--- a/AGENTS.backlog.md
+++ b/AGENTS.backlog.md
@@ -7,7 +7,8 @@
 - [x] P0 (Docs ownership boundary for generated consumers): implemented repo-mode-aware docs sync/check behavior so generated-consumer repos keep one-way `docs/platform/**` ownership, template-source retains strict sync, and generated-consumer upgrade/bootstrap now cleans template-orphan platform docs outside contract-declared `required_seed_files`.
 - [x] P1 (Upgrade convergence safety): Issue #128 — implemented ownership-aware reconcile report artifact and `blueprint-upgrade-consumer-postcheck` gate, including preflight merge-risk bucketing, postcheck convergence enforcement, and source-ref wrapper compatibility for legacy engines.
 - [x] P1 (Fixture-contract hardening): Issue #130 — enforce optional-module `required_env` fixture parity in fast infra contract checks (canonical fixture resolver wiring + fast-lane parity tests).
-- [ ] P1 (Generated-consumer upgrade regressions): Issues #103, #104, #106, #107 — fix repo-mode test selection, additive-file conflict classification, and missing helper distribution.
+- [x] P1 (Generated-consumer upgrade regressions): Issue #103 — `infra-contract-test-fast` is now repo-mode aware (generated-consumer skips template-source-only tests; template-source remains fail-fast for missing selected tests).
+- [ ] P1 (Generated-consumer upgrade regressions): Issues #104, #106, #107 — fix additive-file conflict classification and missing helper distribution.
 - [ ] P1 (Runtime operability correctness): Issues #105, #108, #109, #110, #111, #112, #118, #137 — resolve runtime identity, Argo health/project policy, image-lane, and target migration friction.
 - [ ] P2 (Ownership checker robustness): support normalized equivalence for semantically-identical prune-glob expressions in ownership-matrix documentation checks.
 - [ ] P2 (Capability enhancements): Issues #56, #131 — expand app dependency pin auditing and add blueprint uplift convergence status command.

--- a/AGENTS.decisions.md
+++ b/AGENTS.decisions.md
@@ -314,3 +314,8 @@
   - new target `make blueprint-upgrade-consumer-postcheck` executes validate + convergence checks and writes `artifacts/blueprint/upgrade_postcheck.json`, failing on unresolved merge markers/conflicts.
   - source-ref upgrade wrapper now detects whether historical source engines support `--reconcile-report-path` and degrades compatibly when they do not.
   - generated-reference `conflict`/`merge-required` plan entries now classify into `generated_references_regenerate` in addition to unresolved-conflict tracking to keep regeneration risk explicit.
+- Generated-consumer fast contract lane selection is now repo-mode aware (Issue #103):
+  - `scripts/bin/infra/contract_test_fast.sh` now selects deterministic test sets by `repo_mode` from contract runtime (`template-source` vs `generated-consumer`).
+  - template-source-only tests (`tests/infra/test_optional_module_required_env_contract.py`, `tests/blueprint/test_upgrade_fixture_matrix.py`) are skipped in generated-consumer mode.
+  - selected tests are now existence-validated before `pytest` execution, so template-source mode remains fail-fast when required fast-lane tests are missing.
+  - `infra_contract_test_fast_test_selection_total` metrics now expose selected/skipped counts and active repo mode for diagnostics.

--- a/AGENTS.decisions.md
+++ b/AGENTS.decisions.md
@@ -316,6 +316,6 @@
   - generated-reference `conflict`/`merge-required` plan entries now classify into `generated_references_regenerate` in addition to unresolved-conflict tracking to keep regeneration risk explicit.
 - Generated-consumer fast contract lane selection is now repo-mode aware (Issue #103):
   - `scripts/bin/infra/contract_test_fast.sh` now selects deterministic test sets by `repo_mode` from contract runtime (`template-source` vs `generated-consumer`).
-  - template-source-only tests (`tests/infra/test_optional_module_required_env_contract.py`, `tests/blueprint/test_upgrade_fixture_matrix.py`) are skipped in generated-consumer mode.
+  - template-source-only tests (`tests/blueprint/test_upgrade_fixture_matrix.py`) are skipped in generated-consumer mode; `tests/infra/test_optional_module_required_env_contract.py` runs in both modes as a shared fast-lane contract gate.
   - selected tests are now existence-validated before `pytest` execution, so template-source mode remains fail-fast when required fast-lane tests are missing.
   - `infra_contract_test_fast_test_selection_total` metrics now expose selected/skipped counts and active repo mode for diagnostics.

--- a/docs/blueprint/architecture/decisions/ADR-20260420-issue-103-generated-consumer-fast-contract-repo-mode-selection.md
+++ b/docs/blueprint/architecture/decisions/ADR-20260420-issue-103-generated-consumer-fast-contract-repo-mode-selection.md
@@ -1,0 +1,84 @@
+# ADR-20260420-issue-103-generated-consumer-fast-contract-repo-mode-selection: Repo-Mode-Aware Fast Contract Test Selection
+
+## Metadata
+- Status: approved
+- Date: 2026-04-20
+- Owners: @sbonoc
+- Related spec path: `specs/2026-04-20-issue-103-generated-consumer-contract-fastlane/spec.md`
+
+## Business Objective and Requirement Summary
+- Business objective: remove generated-consumer false failures in `infra-contract-test-fast` while preserving strict template-source fast-lane guarantees.
+- Functional requirements summary:
+  - select fast-lane tests by contract repo mode
+  - skip template-source-only tests in generated-consumer mode
+  - fail-fast on missing selected required tests in template-source mode
+- Non-functional requirements summary:
+  - deterministic selection logs/metrics
+  - no secret contract changes
+  - deterministic selected test order
+- Desired timeline: immediate for current upgrade-regression backlog slice.
+
+## Decision Drivers
+- generated-consumer upgrades can legitimately lack template-source-only tests.
+- fast-lane failures must represent real contract regressions, not mode mismatch.
+- template-source lane still needs strict coverage and missing-path fail-fast behavior.
+
+## Options Considered
+- Option A: execute whichever test paths currently exist on disk.
+- Option B: explicit repo-mode test-set selection with strict selected-path existence checks.
+
+## Recommended Option
+- Selected option: Option B
+- Rationale: Option B gives deterministic behavior, preserves template-source strictness, and avoids generated-consumer false negatives.
+
+## Rejected Options
+- Rejected option 1: Option A
+- Rejection rationale: silent path omission can hide missing required template-source tests and weakens fast-lane guarantees.
+
+## Affected Capabilities and Components
+- Capability impact:
+  - repo-mode-correct `infra-contract-test-fast` behavior
+  - deterministic diagnostics for selected/skipped test groups
+- Component impact:
+  - `scripts/bin/infra/contract_test_fast.sh`
+  - `tests/infra/test_tooling_contracts.py`
+
+## Architecture Diagram (Mermaid)
+```mermaid
+flowchart LR
+  C[blueprint/contract.yaml repo_mode] --> R[contract_runtime helper]
+  R --> S[contract_test_fast selector]
+  S --> G[generated-consumer selected tests]
+  S --> T[template-source selected tests]
+  S --> P[pytest execution]
+```
+
+## High-Level Work Packages and Timeline (Mermaid Gantt)
+```mermaid
+gantt
+  title Issue #103 Fast-Lane Repo-Mode Selection
+  dateFormat  YYYY-MM-DD
+  section Work Packages
+  Add red selector tests                 :a1, 2026-04-20, 1d
+  Implement mode-aware selector          :a2, after a1, 1d
+  Validate + publish SDD artifacts       :a3, after a2, 1d
+```
+
+## External Dependencies
+- `scripts/lib/blueprint/contract_runtime.sh`
+- `blueprint/contract.yaml` (`repo_mode`, `mode_from`, `mode_to`)
+
+## Risks and Mitigations
+- Risk 1: incorrect skip scope could reduce coverage.
+- Mitigation 1: skip list is explicit and validated via dedicated tooling contract tests.
+- Risk 2: missing selected paths may surface late.
+- Mitigation 2: selected-path existence checks fail before invoking pytest.
+
+## Validation and Observability Expectations
+- Validation requirements:
+  - `python3 -m unittest tests.infra.test_tooling_contracts.ToolingContractsTests.test_contract_test_fast_includes_template_source_only_tests_in_template_source_mode tests.infra.test_tooling_contracts.ToolingContractsTests.test_contract_test_fast_skips_template_source_only_tests_in_generated_consumer_mode tests.infra.test_tooling_contracts.ToolingContractsTests.test_contract_test_fast_fails_fast_when_template_source_required_test_is_missing -v`
+  - `make infra-contract-test-fast`
+  - `make infra-validate`
+  - `make quality-hooks-fast`
+- Logging/metrics/tracing requirements:
+  - emit `infra_contract_test_fast_test_selection_total` for selected and skipped groups with `repo_mode` labels.

--- a/scripts/bin/infra/contract_test_fast.sh
+++ b/scripts/bin/infra/contract_test_fast.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../../lib/shell/bootstrap.sh"
+source "$ROOT_DIR/scripts/lib/blueprint/contract_runtime.sh"
 
 start_script_metric_trap "infra_contract_test_fast"
 
@@ -14,7 +15,8 @@ Runs fast infra contract helper CLI/unit tests:
 - ArgoCD repo contract helper CLI
 - state artifact env/json contract renderer + schema validation
 - shell root-resolution helper + prelude drift assertions
-- generated-consumer upgrade fixture matrix safety coverage
+- optional-module fixture required_env parity (template-source only)
+- generated-consumer upgrade fixture matrix safety coverage (template-source only)
 EOF
 }
 
@@ -24,10 +26,54 @@ if [[ "${1:-}" == "--help" ]]; then
 fi
 
 require_command pytest
-run_cmd pytest -q \
-  "$ROOT_DIR/tests/infra/test_optional_module_required_env_contract.py" \
-  "$ROOT_DIR/tests/blueprint/test_upgrade_fixture_matrix.py" \
-  "$ROOT_DIR/tests/infra/test_runtime_identity_contract_cli.py" \
-  "$ROOT_DIR/tests/infra/test_argocd_repo_contract_cli.py" \
-  "$ROOT_DIR/tests/infra/test_state_artifact_contract.py" \
-  "$ROOT_DIR/tests/infra/test_root_dir_resolution.py"
+
+repo_mode="$(blueprint_repo_mode)"
+template_source_mode="$(blueprint_repo_mode_from)"
+generated_consumer_mode="$(blueprint_repo_mode_to)"
+
+base_tests=(
+  "tests/infra/test_runtime_identity_contract_cli.py"
+  "tests/infra/test_argocd_repo_contract_cli.py"
+  "tests/infra/test_state_artifact_contract.py"
+  "tests/infra/test_root_dir_resolution.py"
+)
+template_source_only_tests=(
+  "tests/infra/test_optional_module_required_env_contract.py"
+  "tests/blueprint/test_upgrade_fixture_matrix.py"
+)
+
+selected_tests=("${base_tests[@]}")
+if [[ "$repo_mode" == "$template_source_mode" ]]; then
+  selected_tests+=("${template_source_only_tests[@]}")
+elif [[ "$repo_mode" == "$generated_consumer_mode" ]]; then
+  log_info "repo_mode=$repo_mode; skipping template-source-only fast contract tests"
+  log_metric \
+    "infra_contract_test_fast_test_selection_total" \
+    "${#template_source_only_tests[@]}" \
+    "repo_mode=$repo_mode selection=skipped_template_source_only"
+else
+  log_fatal "unsupported repo_mode for fast contract test selection: $repo_mode"
+fi
+
+pytest_args=()
+missing_tests=()
+for relative_test_path in "${selected_tests[@]}"; do
+  absolute_test_path="$ROOT_DIR/$relative_test_path"
+  if [[ ! -f "$absolute_test_path" ]]; then
+    missing_tests+=("$relative_test_path")
+    continue
+  fi
+  pytest_args+=("$absolute_test_path")
+done
+
+if (( ${#missing_tests[@]} > 0 )); then
+  log_fatal \
+    "missing required fast contract test path(s) for repo_mode=$repo_mode: ${missing_tests[*]}"
+fi
+
+log_metric \
+  "infra_contract_test_fast_test_selection_total" \
+  "${#pytest_args[@]}" \
+  "repo_mode=$repo_mode selection=selected"
+
+run_cmd pytest -q "${pytest_args[@]}"

--- a/scripts/bin/infra/contract_test_fast.sh
+++ b/scripts/bin/infra/contract_test_fast.sh
@@ -15,7 +15,7 @@ Runs fast infra contract helper CLI/unit tests:
 - ArgoCD repo contract helper CLI
 - state artifact env/json contract renderer + schema validation
 - shell root-resolution helper + prelude drift assertions
-- optional-module fixture required_env parity (template-source only)
+- optional-module fixture required_env parity
 - generated-consumer upgrade fixture matrix safety coverage (template-source only)
 EOF
 }
@@ -36,9 +36,9 @@ base_tests=(
   "tests/infra/test_argocd_repo_contract_cli.py"
   "tests/infra/test_state_artifact_contract.py"
   "tests/infra/test_root_dir_resolution.py"
+  "tests/infra/test_optional_module_required_env_contract.py"
 )
 template_source_only_tests=(
-  "tests/infra/test_optional_module_required_env_contract.py"
   "tests/blueprint/test_upgrade_fixture_matrix.py"
 )
 

--- a/specs/2026-04-20-issue-103-generated-consumer-contract-fastlane/architecture.md
+++ b/specs/2026-04-20-issue-103-generated-consumer-contract-fastlane/architecture.md
@@ -1,0 +1,71 @@
+# Architecture
+
+## Context
+- Work item: `2026-04-20-issue-103-generated-consumer-contract-fastlane`
+- Owner: `@sbonoc`
+- Date: `2026-04-20`
+
+## Stack and Execution Model
+- Backend stack profile: `python_plus_fastapi_pydantic_v2`
+- Frontend stack profile: `none (not in scope)`
+- Test automation profile: `unittest + pytest wrapper-contract checks`
+- Agent execution model: `single-agent deterministic execution`
+
+## Problem Statement
+- What needs to change and why:
+  - `scripts/bin/infra/contract_test_fast.sh` always executed template-source-only tests.
+  - generated-consumer upgrades can miss those source-only files and fail `infra-validate` for non-contract reasons.
+  - fast-lane behavior must be deterministic by `repo_mode` while preserving fail-fast strictness in template-source mode.
+- Scope boundaries:
+  - `scripts/bin/infra/contract_test_fast.sh`
+  - `tests/infra/test_tooling_contracts.py`
+  - SDD artifacts + decision/backlog synchronization for Issue #103.
+- Out of scope:
+  - additive-file conflict classification changes (`#104`)
+  - missing helper distribution fixes (`#106`, `#107`)
+  - runtime behavior changes outside fast contract lane selection.
+
+## Bounded Contexts and Responsibilities
+- Contract-runtime mode context:
+  - `blueprint/contract.yaml` (`repo_mode`, `mode_from`, `mode_to`) governs lane selection.
+- Fast contract lane context:
+  - chooses canonical tests and enforces path existence before execution.
+- Tooling contract test context:
+  - validates mode-aware selection and fail-fast behavior without requiring live pytest execution.
+
+## High-Level Component Design
+- Domain layer:
+  - deterministic lane policy by repository mode.
+- Application layer:
+  - `contract_test_fast.sh` computes selected tests + skip set.
+- Infrastructure adapters:
+  - contract runtime helper (`scripts/lib/blueprint/contract_runtime.sh`) resolves active repo mode.
+- Presentation/API/workflow boundaries:
+  - structured shell logs/metrics communicate selected/skipped test sets and remediation paths.
+
+## Integration and Dependency Edges
+- Upstream dependencies:
+  - `scripts/lib/blueprint/contract_runtime.sh`
+  - `blueprint/contract.yaml`.
+- Downstream dependencies:
+  - `make infra-contract-test-fast`
+  - `make infra-validate`
+  - `make quality-hooks-fast`.
+- Data/API/event contracts touched:
+  - Make/script contract only; no API/event payload changes.
+
+## Non-Functional Architecture Notes
+- Security:
+  - no secret handling changes; mode resolution consumes existing contract metadata.
+- Observability:
+  - adds deterministic test-selection metrics and explicit repo-mode skip logs.
+- Reliability and rollback:
+  - selected tests are path-validated before execution; rollback is revert of selector + tests.
+- Monitoring/alerting:
+  - CI fast-lane failure reason becomes explicit (`missing required fast contract test path(s)`).
+
+## Risks and Tradeoffs
+- Risk 1: repo-mode selector drift from contract semantics.
+  - Mitigation: selection uses canonical runtime helpers (`blueprint_repo_mode*`) and dedicated tests.
+- Tradeoff 1: generated-consumer lane executes fewer tests by design.
+  - Mitigation: template-source remains strict and generated-consumer still runs shared infra contract tests.

--- a/specs/2026-04-20-issue-103-generated-consumer-contract-fastlane/context_pack.md
+++ b/specs/2026-04-20-issue-103-generated-consumer-contract-fastlane/context_pack.md
@@ -1,0 +1,31 @@
+# Work Item Context Pack
+
+## Context Snapshot
+- Work item: `specs/2026-04-20-issue-103-generated-consumer-contract-fastlane`
+- Generated at (UTC): `2026-04-20T09:56:37Z`
+- SPEC_READY: `true`
+- ADR path: `docs/blueprint/architecture/decisions/ADR-20260420-issue-103-generated-consumer-fast-contract-repo-mode-selection.md`
+- ADR status: `approved`
+
+## Guardrail Controls
+- Applicable control IDs: `SDD-C-001`, `SDD-C-002`, `SDD-C-003`, `SDD-C-004`, `SDD-C-005`, `SDD-C-006`, `SDD-C-007`, `SDD-C-008`, `SDD-C-009`, `SDD-C-010`, `SDD-C-011`, `SDD-C-012`, `SDD-C-013`, `SDD-C-014`, `SDD-C-015`, `SDD-C-016`, `SDD-C-017`, `SDD-C-018`, `SDD-C-019`, `SDD-C-020`, `SDD-C-021`
+
+## Required Commands
+- `make quality-sdd-check`
+- `make quality-sdd-check-all`
+- `make quality-hooks-run`
+- `make infra-validate`
+- `make docs-build`
+- `make docs-smoke`
+
+## Artifact Index
+- `architecture.md`
+- `spec.md`
+- `plan.md`
+- `tasks.md`
+- `traceability.md`
+- `graph.yaml`
+- `evidence_manifest.json`
+- `context_pack.md`
+- `pr_context.md`
+- `hardening_review.md`

--- a/specs/2026-04-20-issue-103-generated-consumer-contract-fastlane/evidence_manifest.json
+++ b/specs/2026-04-20-issue-103-generated-consumer-contract-fastlane/evidence_manifest.json
@@ -1,0 +1,58 @@
+{
+  "manifest_version": 1,
+  "work_item": "specs/2026-04-20-issue-103-generated-consumer-contract-fastlane",
+  "generated_by": "spec-evidence-manifest",
+  "generated_at_utc": "2026-04-20T09:57:49Z",
+  "files": [
+    {
+      "path": "specs/2026-04-20-issue-103-generated-consumer-contract-fastlane/architecture.md",
+      "sha256": "886fe817f7b699363320c475f377d89a3e24265b3e8252af87eb18008d377a63",
+      "bytes": 3224
+    },
+    {
+      "path": "specs/2026-04-20-issue-103-generated-consumer-contract-fastlane/context_pack.md",
+      "sha256": "c2f32c3d3095cd39ad55db84e1a15541345db936c0ee056954068855d16dbd9e",
+      "bytes": 1039
+    },
+    {
+      "path": "specs/2026-04-20-issue-103-generated-consumer-contract-fastlane/evidence_manifest.json",
+      "sha256": "7a92b5ef0910f1b677e090b3e3107df99f7998758026255b9900880b67598a81",
+      "bytes": 2335
+    },
+    {
+      "path": "specs/2026-04-20-issue-103-generated-consumer-contract-fastlane/graph.yaml",
+      "sha256": "5ae87a28f1e541545fc132fe6d3c189ef03c7acaaa45a1f08817a53f5acd75d7",
+      "bytes": 2144
+    },
+    {
+      "path": "specs/2026-04-20-issue-103-generated-consumer-contract-fastlane/hardening_review.md",
+      "sha256": "97b6454810b4e714b7fdceb1b13fbc65f63bde3b355f078d5ec2d79e85f7e810",
+      "bytes": 1844
+    },
+    {
+      "path": "specs/2026-04-20-issue-103-generated-consumer-contract-fastlane/plan.md",
+      "sha256": "b27f63c2532297d9b90f2b557254b188c2cdf9cc84c7e7a0da661ab4f857afc4",
+      "bytes": 5753
+    },
+    {
+      "path": "specs/2026-04-20-issue-103-generated-consumer-contract-fastlane/pr_context.md",
+      "sha256": "679e5510b774ca9b371f69b3357fe310c0a511a14f2a76de207fe6c1db347e99",
+      "bytes": 2738
+    },
+    {
+      "path": "specs/2026-04-20-issue-103-generated-consumer-contract-fastlane/spec.md",
+      "sha256": "155c03559f10d907dce3a35cdbad870c16ab98d6eaeabb1cf664b3d3b0710311",
+      "bytes": 4929
+    },
+    {
+      "path": "specs/2026-04-20-issue-103-generated-consumer-contract-fastlane/tasks.md",
+      "sha256": "0e594a6f740ce49bf090e21a720552cefccebee5311b80a3c0bfb704145a96b6",
+      "bytes": 2790
+    },
+    {
+      "path": "specs/2026-04-20-issue-103-generated-consumer-contract-fastlane/traceability.md",
+      "sha256": "85cad0f44ddcb17392689a1ad68a7195217dbbf296b1b571f9a39ab99bb07ab6",
+      "bytes": 5317
+    }
+  ]
+}

--- a/specs/2026-04-20-issue-103-generated-consumer-contract-fastlane/graph.yaml
+++ b/specs/2026-04-20-issue-103-generated-consumer-contract-fastlane/graph.yaml
@@ -1,0 +1,93 @@
+{
+  "graph_version": 1,
+  "work_item": "2026-04-20-issue-103-generated-consumer-contract-fastlane",
+  "nodes": [
+    {
+      "id": "FR-001",
+      "type": "requirement",
+      "summary": "Fast lane test selection is resolved by repo mode"
+    },
+    {
+      "id": "FR-002",
+      "type": "requirement",
+      "summary": "Generated-consumer mode skips template-source-only tests"
+    },
+    {
+      "id": "FR-003",
+      "type": "requirement",
+      "summary": "Template-source mode fails fast when selected test paths are missing"
+    },
+    {
+      "id": "NFR-SEC-001",
+      "type": "requirement",
+      "summary": "No additional secret requirements"
+    },
+    {
+      "id": "NFR-OBS-001",
+      "type": "requirement",
+      "summary": "Deterministic selection metrics and logs"
+    },
+    {
+      "id": "NFR-REL-001",
+      "type": "requirement",
+      "summary": "Deterministic selected-test ordering"
+    },
+    {
+      "id": "NFR-OPS-001",
+      "type": "requirement",
+      "summary": "Explicit remediation diagnostics for missing selected tests"
+    },
+    {
+      "id": "AC-001",
+      "type": "acceptance",
+      "summary": "Template-source selection includes source-only tests"
+    },
+    {
+      "id": "AC-002",
+      "type": "acceptance",
+      "summary": "Generated-consumer selection excludes source-only tests"
+    },
+    {
+      "id": "AC-003",
+      "type": "acceptance",
+      "summary": "Template-source missing selected tests fail fast"
+    }
+  ],
+  "edges": [
+    {
+      "from": "FR-001",
+      "to": "AC-001",
+      "relation": "validated_by"
+    },
+    {
+      "from": "FR-002",
+      "to": "AC-002",
+      "relation": "validated_by"
+    },
+    {
+      "from": "FR-003",
+      "to": "AC-003",
+      "relation": "validated_by"
+    },
+    {
+      "from": "NFR-SEC-001",
+      "to": "AC-001",
+      "relation": "constrains"
+    },
+    {
+      "from": "NFR-OBS-001",
+      "to": "AC-002",
+      "relation": "constrains"
+    },
+    {
+      "from": "NFR-REL-001",
+      "to": "AC-002",
+      "relation": "constrains"
+    },
+    {
+      "from": "NFR-OPS-001",
+      "to": "AC-003",
+      "relation": "constrains"
+    }
+  ]
+}

--- a/specs/2026-04-20-issue-103-generated-consumer-contract-fastlane/hardening_review.md
+++ b/specs/2026-04-20-issue-103-generated-consumer-contract-fastlane/hardening_review.md
@@ -1,0 +1,32 @@
+# Hardening Review
+
+## Repository-Wide Findings Fixed
+- Fixed generated-consumer validation false failures in fast lane by making test selection repo-mode aware:
+  - `scripts/bin/infra/contract_test_fast.sh`
+- Added deterministic tooling-contract regression tests for both mode selection and template-source fail-fast behavior:
+  - `tests/infra/test_tooling_contracts.py`
+- Synchronized governance artifacts for delivery/status tracking:
+  - `AGENTS.backlog.md`
+  - `AGENTS.decisions.md`
+- Added ADR + full SDD artifact set for Issue #103.
+
+## Observability and Diagnostics Changes
+- Metrics/logging/tracing updates:
+  - fast lane now emits `infra_contract_test_fast_test_selection_total` for selected and skipped test groups, labeled by `repo_mode`.
+- Operational diagnostics updates:
+  - explicit info log when template-source-only tests are skipped in generated-consumer mode.
+  - explicit fatal diagnostics when any selected required test path is missing.
+
+## Architecture and Code Quality Compliance
+- SOLID / Clean Architecture / Clean Code / DDD checks:
+  - mode-selection logic uses canonical contract runtime helpers instead of inline repo-mode parsing.
+  - selected-test list and skip list remain explicit and deterministic.
+- Test-automation and pyramid checks:
+  - red->green captured via new tooling contract tests and selector implementation.
+  - `quality-test-pyramid` remained within contract thresholds.
+- Documentation/diagram/CI/skill consistency checks:
+  - ADR and SDD lifecycle artifacts updated.
+  - `quality-sdd-check-all`, docs checks, and full quality hooks run passed.
+
+## Proposals Only (Not Implemented)
+- Extend this repo-mode fast-lane hardening with the remaining upgrade-regression backlog items (`#104`, `#106`, `#107`) so generated-consumer upgrade validation converges in one deterministic contract surface.

--- a/specs/2026-04-20-issue-103-generated-consumer-contract-fastlane/plan.md
+++ b/specs/2026-04-20-issue-103-generated-consumer-contract-fastlane/plan.md
@@ -1,0 +1,119 @@
+# Implementation Plan
+
+## Implementation Start Gate
+- Implementation tasks MUST remain unchecked until `SPEC_READY=true`.
+- If required inputs are missing, add `BLOCKED_MISSING_INPUTS` in `spec.md` and keep the gate closed.
+
+## Constitution Gates (Pre-Implementation)
+- Simplicity gate:
+  - Keep initial implementation scope minimal and explicit.
+  - Avoid speculative future-proof abstractions.
+- Anti-abstraction gate:
+  - Prefer direct framework primitives over wrapper layers unless justified.
+  - Keep model representations singular unless boundary separation is required.
+- Integration-first testing gate:
+  - Define contract and boundary tests before implementation details.
+  - Ensure realistic environment coverage for integration points.
+- Positive-path filter/transform test gate:
+  - For any filter or payload-transform logic, at least one unit test MUST assert that a matching fixture value returns a record.
+  - Positive-path assertions MUST verify relevant output fields remain intact after filtering/transform.
+  - Empty-result-only assertions MUST NOT satisfy this gate.
+- Finding-to-test translation gate:
+  - Any reproducible pre-PR finding from smoke/`curl`/deterministic manual checks MUST be translated into a failing automated test first.
+  - The implementation fix MUST turn that test green in the same work item.
+  - If no deterministic automation path exists, publish artifacts MUST record the exception rationale, owner, and follow-up trigger.
+
+## Delivery Slices
+1. Slice 1: add red tests for repo-mode fast-lane selection behavior and template-source fail-fast behavior.
+2. Slice 2: implement repo-mode selector and required-path validation in `contract_test_fast.sh`.
+3. Slice 3: run fast-lane validation commands and update governance artifacts (backlog + decisions).
+4. Slice 4: complete Document/Operate/Publish artifacts for this work item.
+
+## Change Strategy
+- Migration/rollout sequence:
+  - write/execute failing tests first
+  - implement selector in shell wrapper
+  - validate template-source lane and targeted contract tests
+  - finalize SDD artifacts and publish context
+- Backward compatibility policy:
+  - keep `make infra-contract-test-fast` entrypoint unchanged
+  - preserve existing template-source strict behavior for selected tests
+- Rollback plan:
+  - revert selector + contract tests
+  - rerun `make infra-contract-test-fast` and `make quality-hooks-fast`
+
+## Validation Strategy (Shift-Left)
+- Unit checks:
+  - `python3 -m unittest tests.infra.test_tooling_contracts.ToolingContractsTests.test_contract_test_fast_includes_template_source_only_tests_in_template_source_mode tests.infra.test_tooling_contracts.ToolingContractsTests.test_contract_test_fast_skips_template_source_only_tests_in_generated_consumer_mode tests.infra.test_tooling_contracts.ToolingContractsTests.test_contract_test_fast_fails_fast_when_template_source_required_test_is_missing -v`
+- Contract checks:
+  - `make infra-contract-test-fast`
+  - `make infra-validate`
+  - `make quality-hooks-fast`
+- Integration checks:
+  - none (scope is wrapper contract behavior)
+- E2E checks:
+  - none
+
+## App Onboarding Contract (Normative)
+- Required minimum make targets:
+  - `apps-bootstrap`
+  - `apps-smoke`
+  - `backend-test-unit`
+  - `backend-test-integration`
+  - `backend-test-contracts`
+  - `backend-test-e2e`
+  - `touchpoints-test-unit`
+  - `touchpoints-test-integration`
+  - `touchpoints-test-contracts`
+  - `touchpoints-test-e2e`
+  - `test-unit-all`
+  - `test-integration-all`
+  - `test-contracts-all`
+  - `test-e2e-all-local`
+  - `infra-port-forward-start`
+  - `infra-port-forward-stop`
+  - `infra-port-forward-cleanup`
+- App onboarding impact: no-impact | impacted (select one)
+- App onboarding impact: no-impact
+- Notes: no app lane behavior changed.
+
+## Documentation Plan (Document Phase)
+- Blueprint docs updates:
+  - SDD artifact updates + decision/backlog synchronization.
+- Consumer docs updates:
+  - none.
+- Mermaid diagrams updated:
+  - ADR component and timeline diagrams for Issue #103.
+- Docs validation commands:
+  - `make docs-build`
+  - `make docs-smoke`
+
+## Publish Preparation
+- PR context file:
+  - `pr_context.md`
+- Hardening review file:
+  - `hardening_review.md`
+- Local smoke gate (HTTP route/filter changes):
+  - For work that touches HTTP route handlers, query/filter logic, or new API endpoints, run local smoke before PR publication.
+  - Execute local smoke with deterministic wrappers (`make infra-provision`, `make infra-deploy`, `make infra-port-forward-start`), then run positive-path `curl` assertions per changed endpoint.
+  - Positive-path filter assertions MUST use non-empty fixture/request values; empty-result-only assertions MUST NOT satisfy this gate.
+  - Record evidence in `pr_context.md` as `Endpoint | Method | Auth | Result`.
+  - Stop/cleanup wrappers after smoke (`make infra-port-forward-stop`, `make infra-port-forward-cleanup`).
+- Publish checklist:
+  - include requirement/contract coverage
+  - include key reviewer files
+  - include validation evidence + rollback notes
+
+## Operational Readiness
+- Logging/metrics/traces:
+  - emit deterministic selection metrics (`infra_contract_test_fast_test_selection_total`) for selected and skipped groups.
+- Alerts/ownership:
+  - fast-lane failures are owned by blueprint maintainers.
+- Runbook updates:
+  - none.
+
+## Risks and Mitigations
+- Risk 1: accidental broad skipping could hide true regressions.
+  - Mitigation: skip set is explicit and limited to template-source-only tests; shared infra tests still execute in generated-consumer mode.
+- Risk 2: contract-runtime mode resolution drift.
+  - Mitigation: use canonical runtime helpers (`blueprint_repo_mode`, `blueprint_repo_mode_from`, `blueprint_repo_mode_to`) and dedicated tests.

--- a/specs/2026-04-20-issue-103-generated-consumer-contract-fastlane/pr_context.md
+++ b/specs/2026-04-20-issue-103-generated-consumer-contract-fastlane/pr_context.md
@@ -1,0 +1,53 @@
+# PR Context
+
+## Summary
+- Work item: `specs/2026-04-20-issue-103-generated-consumer-contract-fastlane`
+- Objective: make `infra-contract-test-fast` repo-mode aware so generated-consumer repos do not require template-source-only tests, while template-source remains fail-fast.
+- Scope boundaries:
+  - `scripts/bin/infra/contract_test_fast.sh`
+  - `tests/infra/test_tooling_contracts.py`
+  - SDD/ADR/backlog/decision artifacts for Issue #103.
+
+## Requirement Coverage
+- Requirement IDs covered: `FR-001`, `FR-002`, `FR-003`, `NFR-SEC-001`, `NFR-OBS-001`, `NFR-REL-001`, `NFR-OPS-001`
+- Acceptance criteria covered: `AC-001`, `AC-002`, `AC-003`
+- Contract surfaces changed:
+  - [x] fast infra contract lane test selection by `repo_mode`
+  - [x] deterministic missing-selected-test fail-fast diagnostics
+  - [x] selection telemetry (`infra_contract_test_fast_test_selection_total`)
+
+## Key Reviewer Files
+- Primary files to review first:
+  - `scripts/bin/infra/contract_test_fast.sh`
+  - `tests/infra/test_tooling_contracts.py`
+- Governance artifacts:
+  - `specs/2026-04-20-issue-103-generated-consumer-contract-fastlane/spec.md`
+  - `docs/blueprint/architecture/decisions/ADR-20260420-issue-103-generated-consumer-fast-contract-repo-mode-selection.md`
+  - `AGENTS.backlog.md`
+  - `AGENTS.decisions.md`
+
+## Validation Evidence
+- Required commands executed:
+  - `python3 -m unittest tests.infra.test_tooling_contracts.ToolingContractsTests.test_contract_test_fast_includes_template_source_only_tests_in_template_source_mode tests.infra.test_tooling_contracts.ToolingContractsTests.test_contract_test_fast_skips_template_source_only_tests_in_generated_consumer_mode tests.infra.test_tooling_contracts.ToolingContractsTests.test_contract_test_fast_fails_fast_when_template_source_required_test_is_missing -v`
+  - `make infra-contract-test-fast`
+  - `make infra-validate`
+  - `make quality-hooks-fast`
+  - `make docs-build`
+  - `make docs-smoke`
+  - `make quality-hardening-review`
+  - `make quality-hooks-run`
+- Result summary:
+  - all commands above passed.
+- Artifact references:
+  - `specs/2026-04-20-issue-103-generated-consumer-contract-fastlane/evidence_manifest.json`
+  - `specs/2026-04-20-issue-103-generated-consumer-contract-fastlane/traceability.md`
+
+## Risk and Rollback
+- Main risks:
+  - incorrect skip scope could hide regressions.
+  - repo-mode resolution drift from contract semantics.
+- Rollback strategy:
+  - revert `contract_test_fast.sh` selector + tooling contract tests and rerun `make infra-contract-test-fast` and `make quality-hooks-fast`.
+
+## Deferred Proposals
+- Complete the remaining generated-consumer upgrade-regression scope tracked in backlog (`#104`, `#106`, `#107`) after this mode-selection hardening lands.

--- a/specs/2026-04-20-issue-103-generated-consumer-contract-fastlane/spec.md
+++ b/specs/2026-04-20-issue-103-generated-consumer-contract-fastlane/spec.md
@@ -33,7 +33,7 @@
 - Local-first exception rationale: none
 
 ## Objective
-- Business outcome: generated-consumer upgrade validation MUST not fail due template-source-only fast-contract tests while template-source remains strict for canonical lane coverage.
+- Business outcome: generated-consumer upgrade validation MUST not fail due to template-source-only fast-contract tests while template-source remains strict for canonical lane coverage.
 - Success metric: `infra-contract-test-fast` selects deterministic test sets by repo mode and passes generated-consumer scenarios without requiring source-only files.
 
 ## Normative Requirements

--- a/specs/2026-04-20-issue-103-generated-consumer-contract-fastlane/spec.md
+++ b/specs/2026-04-20-issue-103-generated-consumer-contract-fastlane/spec.md
@@ -1,0 +1,88 @@
+# Specification
+
+## Spec Readiness Gate (Blocking)
+- SPEC_READY: true
+- Open questions count: 0
+- Unresolved alternatives count: 0
+- Unresolved TODO markers count: 0
+- Pending assumptions count: 0
+- Open clarification markers count: 0
+- Product sign-off: approved
+- Architecture sign-off: approved
+- Security sign-off: approved
+- Operations sign-off: approved
+- Missing input blocker token: none
+- ADR path: docs/blueprint/architecture/decisions/ADR-20260420-issue-103-generated-consumer-fast-contract-repo-mode-selection.md
+- ADR status: approved
+
+## Applicable Guardrail Controls (Normative)
+- Applicable control IDs: SDD-C-001, SDD-C-002, SDD-C-003, SDD-C-004, SDD-C-005, SDD-C-006, SDD-C-007, SDD-C-008, SDD-C-009, SDD-C-010, SDD-C-011, SDD-C-012, SDD-C-013, SDD-C-014, SDD-C-015, SDD-C-016, SDD-C-017, SDD-C-018, SDD-C-019, SDD-C-020, SDD-C-021
+- Control exception rationale: none
+
+## Implementation Stack Profile (Normative)
+- Backend stack profile: python_plus_fastapi_pydantic_v2
+- Frontend stack profile: vue_router_pinia_onyx
+- Test automation profile: pytest_vitest_playwright_pact
+- Agent execution model: single-agent
+- Managed service preference: stackit-managed-first
+- Managed service exception rationale: none
+- Runtime profile: local-first-docker-desktop-kubernetes
+- Local Kubernetes context policy: docker-desktop-preferred
+- Local provisioning stack: crossplane-plus-helm
+- Runtime identity baseline: eso-plus-argocd-plus-keycloak
+- Local-first exception rationale: none
+
+## Objective
+- Business outcome: generated-consumer upgrade validation MUST not fail due template-source-only fast-contract tests while template-source remains strict for canonical lane coverage.
+- Success metric: `infra-contract-test-fast` selects deterministic test sets by repo mode and passes generated-consumer scenarios without requiring source-only files.
+
+## Normative Requirements
+
+### Functional Requirements (Normative)
+- FR-001 `scripts/bin/infra/contract_test_fast.sh` MUST select test files by active repo mode resolved from contract runtime helpers.
+- FR-002 when `repo_mode=generated-consumer`, the fast lane MUST execute shared infra contract tests and MUST NOT require template-source-only tests.
+- FR-003 when `repo_mode=template-source`, the fast lane MUST include template-source-only tests and MUST fail-fast if any selected required test path is missing.
+
+### Non-Functional Requirements (Normative)
+- NFR-SEC-001 mode-aware selection MUST NOT introduce new secret/env requirements.
+- NFR-OBS-001 fast lane MUST emit deterministic selection metrics/logs containing `repo_mode` and selected/skipped counts.
+- NFR-REL-001 selected test order MUST remain deterministic across runs.
+- NFR-OPS-001 remediation path MUST be explicit through lane output (`missing required fast contract test path(s)`) and rerun command `make infra-contract-test-fast`.
+
+## Normative Option Decision
+- Option A: execute all existing test paths found on disk regardless of repo mode.
+- Option B: define explicit repo-mode test sets with strict required-path checks on selected tests.
+- Selected option: OPTION_B
+- Rationale: explicit mode-aware sets preserve strict source coverage and remove generated-consumer false failures deterministically.
+
+## Contract Changes (Normative)
+- Config/Env contract:
+  - no new env keys; consumes existing `repo_mode` contract runtime values.
+- API contract:
+  - none.
+- Event contract:
+  - none.
+- Make/CLI contract:
+  - `scripts/bin/infra/contract_test_fast.sh` SHALL select tests by `repo_mode` and SHALL emit `infra_contract_test_fast_test_selection_total` metrics.
+- Docs contract:
+  - SDD artifact set, backlog, and decision log SHALL capture Issue #103 delivery scope.
+
+## Blueprint Upstream Defect Escalation (Normative)
+- Upstream issue URL: https://github.com/sbonoc/stackit-platform-blueprint/issues/103
+- Temporary workaround path: none
+- Replacement trigger: none
+- Workaround review date: none
+
+## Normative Acceptance Criteria
+- AC-001 MUST be objectively testable: template-source mode includes `tests/blueprint/test_upgrade_fixture_matrix.py` and `tests/infra/test_optional_module_required_env_contract.py` in fast-lane selection.
+- AC-002 MUST be objectively testable: generated-consumer mode excludes template-source-only tests while keeping shared infra contract tests selected.
+- AC-003 MUST be objectively testable: template-source mode fails fast with deterministic diagnostics when a selected required test path is missing.
+
+## Informative Notes (Non-Normative)
+- Context: this is the first item in backlog group `P1 Generated-consumer upgrade regressions`.
+- Tradeoffs: this scope fixes fast-lane selection only; it does not address additive-file or helper-distribution regressions.
+- Clarifications: none.
+
+## Explicit Exclusions
+- Issue #104 additive baseline-absent conflict classification.
+- Issues #106 and #107 helper distribution coverage in generated-consumer upgrades.

--- a/specs/2026-04-20-issue-103-generated-consumer-contract-fastlane/tasks.md
+++ b/specs/2026-04-20-issue-103-generated-consumer-contract-fastlane/tasks.md
@@ -1,0 +1,40 @@
+# Tasks
+
+## Gate Checks (Required Before Implementation)
+- [x] G-001 Confirm `SPEC_READY=true` in `spec.md`
+- [x] G-002 Confirm open questions and unresolved alternatives are `0`
+- [x] G-003 Confirm required sign-offs are approved
+- [x] G-004 Confirm `Applicable Guardrail Controls` section includes `SDD-C-###` IDs
+- [x] G-005 Confirm `Implementation Stack Profile` section is fully populated
+
+## Implementation
+- [x] T-001 Update contract/governance surfaces
+- [x] T-002 Implement runtime/code changes
+- [x] T-003 Update blueprint docs/diagrams
+- [x] T-004 Update consumer-facing docs/diagrams when contracts/behavior change (no-impact)
+
+## Test Automation
+- [x] T-101 Add or update unit tests
+- [x] T-102 Add or update contract tests
+- [x] T-103 For any new or modified filter/payload-transform route, verify a positive-path unit test exists (matching fixture value returns record and output fields remain intact); capture evidence in `pr_context.md` (no-impact: route/filter scope unchanged)
+- [x] T-104 Translate any reproducible pre-PR smoke/`curl`/deterministic-check finding into a failing automated test first, then turn it green with the fix in the same work item (or document deterministic exception in publish artifacts)
+- [x] T-105 Add boundary/integration tests where required (no-impact)
+
+## Validation and Release Readiness
+- [x] T-201 Run required Make validation bundles
+- [x] T-202 Attach evidence to traceability document
+- [x] T-203 Confirm no stale TODOs/dead code/drift
+- [x] T-204 Run documentation validation (`make docs-build` and `make docs-smoke`)
+- [x] T-205 Run hardening review validation bundle (`make quality-hardening-review`)
+
+## Publish
+- [x] P-001 Update `hardening_review.md` with repository-wide findings fixed and proposals-only section
+- [x] P-002 Update `pr_context.md` with requirement/contract coverage, key reviewer files, validation evidence, and rollback notes
+- [x] P-003 Ensure PR description follows repository template headings and references `pr_context.md`
+
+## App Onboarding Minimum Targets (Normative)
+- [x] A-001 `apps-bootstrap` and `apps-smoke` are implemented and verified for the affected app scope (no-impact)
+- [x] A-002 Backend app lanes (`backend-test-unit`, `backend-test-integration`, `backend-test-contracts`, `backend-test-e2e`) are available (no-impact)
+- [x] A-003 Frontend app lanes (`touchpoints-test-unit`, `touchpoints-test-integration`, `touchpoints-test-contracts`, `touchpoints-test-e2e`) are available (no-impact)
+- [x] A-004 Aggregate gates (`test-unit-all`, `test-integration-all`, `test-contracts-all`, `test-e2e-all-local`) are available (no-impact)
+- [x] A-005 Port-forward operational wrappers (`infra-port-forward-start`, `infra-port-forward-stop`, `infra-port-forward-cleanup`) are available (no-impact)

--- a/specs/2026-04-20-issue-103-generated-consumer-contract-fastlane/traceability.md
+++ b/specs/2026-04-20-issue-103-generated-consumer-contract-fastlane/traceability.md
@@ -1,0 +1,56 @@
+# Traceability Matrix
+
+## Requirement-to-Delivery Mapping
+
+| Requirement ID | Control IDs | Design Element | Implementation Path(s) | Test Evidence | Documentation Evidence | Operational Evidence |
+|---|---|---|---|---|---|---|
+| FR-001 | SDD-C-005 | Repo-mode-aware fast-lane selector | scripts/bin/infra/contract_test_fast.sh | tests.infra.test_tooling_contracts.ToolingContractsTests.test_contract_test_fast_includes_template_source_only_tests_in_template_source_mode; tests.infra.test_tooling_contracts.ToolingContractsTests.test_contract_test_fast_skips_template_source_only_tests_in_generated_consumer_mode | specs/2026-04-20-issue-103-generated-consumer-contract-fastlane/spec.md | selector logs include `repo_mode` |
+| FR-002 | SDD-C-005 | Generated-consumer skip set for template-source-only tests | scripts/bin/infra/contract_test_fast.sh | tests.infra.test_tooling_contracts.ToolingContractsTests.test_contract_test_fast_skips_template_source_only_tests_in_generated_consumer_mode | specs/2026-04-20-issue-103-generated-consumer-contract-fastlane/plan.md | metric `infra_contract_test_fast_test_selection_total` with `selection=skipped_template_source_only` |
+| FR-003 | SDD-C-005 | Template-source required selected-test existence gate | scripts/bin/infra/contract_test_fast.sh | tests.infra.test_tooling_contracts.ToolingContractsTests.test_contract_test_fast_fails_fast_when_template_source_required_test_is_missing | specs/2026-04-20-issue-103-generated-consumer-contract-fastlane/spec.md | fatal output includes missing relative test paths |
+| NFR-SEC-001 | SDD-C-009 | No new secret/env requirements | scripts/bin/infra/contract_test_fast.sh | make infra-contract-test-fast | specs/2026-04-20-issue-103-generated-consumer-contract-fastlane/hardening_review.md | no secret-contract deltas |
+| NFR-OBS-001 | SDD-C-010 | Deterministic selection telemetry | scripts/bin/infra/contract_test_fast.sh | make infra-contract-test-fast | specs/2026-04-20-issue-103-generated-consumer-contract-fastlane/hardening_review.md | selection metrics emitted with repo mode |
+| NFR-REL-001 | SDD-C-011 | Stable selected-test ordering | scripts/bin/infra/contract_test_fast.sh | make infra-contract-test-fast | specs/2026-04-20-issue-103-generated-consumer-contract-fastlane/spec.md | deterministic argument order in lane output |
+| NFR-OPS-001 | SDD-C-018 | Explicit remediation diagnostics | scripts/bin/infra/contract_test_fast.sh | tests.infra.test_tooling_contracts.ToolingContractsTests.test_contract_test_fast_fails_fast_when_template_source_required_test_is_missing | specs/2026-04-20-issue-103-generated-consumer-contract-fastlane/pr_context.md | fatal guidance points to missing required paths |
+| AC-001 | SDD-C-012 | Template-source includes source-only tests | scripts/bin/infra/contract_test_fast.sh | tests.infra.test_tooling_contracts.ToolingContractsTests.test_contract_test_fast_includes_template_source_only_tests_in_template_source_mode | specs/2026-04-20-issue-103-generated-consumer-contract-fastlane/pr_context.md | lane output contains source-only test paths |
+| AC-002 | SDD-C-012 | Generated-consumer excludes source-only tests | scripts/bin/infra/contract_test_fast.sh | tests.infra.test_tooling_contracts.ToolingContractsTests.test_contract_test_fast_skips_template_source_only_tests_in_generated_consumer_mode | specs/2026-04-20-issue-103-generated-consumer-contract-fastlane/pr_context.md | skip log + selected shared tests |
+| AC-003 | SDD-C-012 | Template-source fail-fast for missing selected test | scripts/bin/infra/contract_test_fast.sh | tests.infra.test_tooling_contracts.ToolingContractsTests.test_contract_test_fast_fails_fast_when_template_source_required_test_is_missing | specs/2026-04-20-issue-103-generated-consumer-contract-fastlane/pr_context.md | missing-path fatal diagnostics |
+
+## Graph Linkage
+- Graph file: `graph.yaml`
+- Every `FR-###`, `NFR-*-###`, and `AC-###` listed in this file MUST have a corresponding node in `graph.yaml`.
+- Node IDs referenced:
+  - FR-001
+  - FR-002
+  - FR-003
+  - NFR-SEC-001
+  - NFR-OBS-001
+  - NFR-REL-001
+  - NFR-OPS-001
+  - AC-001
+  - AC-002
+  - AC-003
+
+## Validation Summary
+- Required bundles executed:
+  - `python3 -m unittest tests.infra.test_tooling_contracts.ToolingContractsTests.test_contract_test_fast_includes_template_source_only_tests_in_template_source_mode tests.infra.test_tooling_contracts.ToolingContractsTests.test_contract_test_fast_skips_template_source_only_tests_in_generated_consumer_mode tests.infra.test_tooling_contracts.ToolingContractsTests.test_contract_test_fast_fails_fast_when_template_source_required_test_is_missing -v`
+  - `make infra-contract-test-fast`
+  - `make infra-validate`
+  - `make quality-hooks-fast`
+  - `make docs-build`
+  - `make docs-smoke`
+  - `make quality-hardening-review`
+  - `make quality-hooks-run`
+- Result summary:
+  - all commands listed above passed.
+- Documentation validation:
+  - `make docs-build`
+  - `make docs-smoke`
+
+## Evidence Manifest
+- Manifest file: `evidence_manifest.json`
+- Context export: `context_pack.md`
+- PR context export: `pr_context.md`
+- Hardening review export: `hardening_review.md`
+
+## Open Risks and Follow-Ups
+- Follow-up 1: address remaining upgrade-regression items in backlog group (`#104`, `#106`, `#107`) after this repo-mode fast-lane fix.

--- a/tests/infra/test_tooling_contracts.py
+++ b/tests/infra/test_tooling_contracts.py
@@ -1498,11 +1498,11 @@ render_optional_module_secret_manifests "messaging" "blueprint-rabbitmq-auth" "r
         self.assertIn("tests/blueprint/test_upgrade_fixture_matrix.py", output)
         self.assertIn("tests/infra/test_optional_module_required_env_contract.py", output)
 
-    def test_contract_test_fast_skips_template_source_only_tests_in_generated_consumer_mode(self) -> None:
+    def test_contract_test_fast_skips_only_template_source_only_tests_in_generated_consumer_mode(self) -> None:
         exit_code, output = contract_test_fast_pytest_args_for_repo_mode("generated-consumer")
         self.assertEqual(exit_code, 0, msg=output)
         self.assertNotIn("tests/blueprint/test_upgrade_fixture_matrix.py", output)
-        self.assertNotIn("tests/infra/test_optional_module_required_env_contract.py", output)
+        self.assertIn("tests/infra/test_optional_module_required_env_contract.py", output)
         self.assertIn("tests/infra/test_runtime_identity_contract_cli.py", output)
         self.assertIn("tests/infra/test_argocd_repo_contract_cli.py", output)
         self.assertIn("tests/infra/test_state_artifact_contract.py", output)

--- a/tests/infra/test_tooling_contracts.py
+++ b/tests/infra/test_tooling_contracts.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 import re
 import tempfile
@@ -976,6 +977,45 @@ printf 'enabled_modules=%s\\n' "$(enabled_modules_csv)"
         return result.stdout + result.stderr
 
 
+def contract_test_fast_pytest_args_for_repo_mode(repo_mode: str) -> tuple[int, str]:
+    contract_path = REPO_ROOT / "blueprint" / "contract.yaml"
+    original_contract = contract_path.read_text(encoding="utf-8")
+    patched_contract = re.sub(
+        r"^(\s*repo_mode:\s*).+$",
+        rf"\1{repo_mode}",
+        original_contract,
+        count=1,
+        flags=re.MULTILINE,
+    )
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        stub_pytest = Path(tmpdir) / "pytest"
+        stub_pytest.write_text(
+            "\n".join(
+                [
+                    "#!/bin/sh",
+                    'printf "PYTEST_ARGS=%s\\n" "$*"',
+                    "exit 0",
+                    "",
+                ]
+            ),
+            encoding="utf-8",
+        )
+        stub_pytest.chmod(0o755)
+
+        try:
+            if patched_contract != original_contract:
+                contract_path.write_text(patched_contract, encoding="utf-8")
+            result = run(
+                ["scripts/bin/infra/contract_test_fast.sh"],
+                {"PATH": f"{tmpdir}:{os.environ.get('PATH', '')}"},
+            )
+        finally:
+            contract_path.write_text(original_contract, encoding="utf-8")
+
+    return result.returncode, result.stdout + result.stderr
+
+
 def terraform_backend_apply_failure_contract() -> str:
     with tempfile.TemporaryDirectory() as tmpdir:
         bin_dir = Path(tmpdir) / "bin"
@@ -1451,6 +1491,42 @@ render_optional_module_secret_manifests "messaging" "blueprint-rabbitmq-auth" "r
         self.assertIn("postgres=false", resolved)
         self.assertIn("public_endpoints=true", resolved)
         self.assertIn("enabled_modules=public-endpoints", resolved)
+
+    def test_contract_test_fast_includes_template_source_only_tests_in_template_source_mode(self) -> None:
+        exit_code, output = contract_test_fast_pytest_args_for_repo_mode("template-source")
+        self.assertEqual(exit_code, 0, msg=output)
+        self.assertIn("tests/blueprint/test_upgrade_fixture_matrix.py", output)
+        self.assertIn("tests/infra/test_optional_module_required_env_contract.py", output)
+
+    def test_contract_test_fast_skips_template_source_only_tests_in_generated_consumer_mode(self) -> None:
+        exit_code, output = contract_test_fast_pytest_args_for_repo_mode("generated-consumer")
+        self.assertEqual(exit_code, 0, msg=output)
+        self.assertNotIn("tests/blueprint/test_upgrade_fixture_matrix.py", output)
+        self.assertNotIn("tests/infra/test_optional_module_required_env_contract.py", output)
+        self.assertIn("tests/infra/test_runtime_identity_contract_cli.py", output)
+        self.assertIn("tests/infra/test_argocd_repo_contract_cli.py", output)
+        self.assertIn("tests/infra/test_state_artifact_contract.py", output)
+        self.assertIn("tests/infra/test_root_dir_resolution.py", output)
+
+    def test_contract_test_fast_fails_fast_when_template_source_required_test_is_missing(self) -> None:
+        fixture_matrix_test = REPO_ROOT / "tests" / "blueprint" / "test_upgrade_fixture_matrix.py"
+        backup_path = fixture_matrix_test.with_name("test_upgrade_fixture_matrix.py.backup")
+        fixture_matrix_test.rename(backup_path)
+        try:
+            with tempfile.TemporaryDirectory() as tmpdir:
+                stub_pytest = Path(tmpdir) / "pytest"
+                stub_pytest.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+                stub_pytest.chmod(0o755)
+                result = run(
+                    ["scripts/bin/infra/contract_test_fast.sh"],
+                    {"PATH": f"{tmpdir}:{os.environ.get('PATH', '')}"},
+                )
+            self.assertNotEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+            combined_output = result.stdout + result.stderr
+            self.assertIn("missing required fast contract test path(s)", combined_output)
+            self.assertIn("tests/blueprint/test_upgrade_fixture_matrix.py", combined_output)
+        finally:
+            backup_path.rename(fixture_matrix_test)
 
     def test_infra_validate_renders_makefile_from_contract_defaults(self) -> None:
         contract_path = REPO_ROOT / "blueprint" / "contract.yaml"


### PR DESCRIPTION
Fixes #103

## Summary
- implements Issue #103 by making `infra-contract-test-fast` repo-mode aware via `blueprint/contract.yaml` runtime mode resolution
- generated-consumer mode now runs only shared fast infra contract tests
- template-source mode retains strict coverage for template-source-only tests and now fails fast when selected required test paths are missing
- adds explicit selection metric/logging for diagnostics

## Requirement Coverage
- `FR-001`: fast-lane selection by active repo mode
- `FR-002`: generated-consumer excludes template-source-only tests
- `FR-003`: template-source includes template-source-only tests and fails fast on missing selected paths
- `NFR-OBS-001`: emits deterministic `infra_contract_test_fast_test_selection_total` selection metrics

## Key Reviewer Files
- `scripts/bin/infra/contract_test_fast.sh`
- `tests/infra/test_tooling_contracts.py`
- `docs/blueprint/architecture/decisions/ADR-20260420-issue-103-generated-consumer-fast-contract-repo-mode-selection.md`
- `specs/2026-04-20-issue-103-generated-consumer-contract-fastlane/spec.md`

## Validation Evidence
- `python3 -m unittest tests.infra.test_tooling_contracts.ToolingContractsTests.test_contract_test_fast_includes_template_source_only_tests_in_template_source_mode tests.infra.test_tooling_contracts.ToolingContractsTests.test_contract_test_fast_skips_template_source_only_tests_in_generated_consumer_mode tests.infra.test_tooling_contracts.ToolingContractsTests.test_contract_test_fast_fails_fast_when_template_source_required_test_is_missing -v`
- `make infra-contract-test-fast`
- `make infra-validate`
- `make quality-hooks-fast`
- `make docs-build`
- `make docs-smoke`
- `make quality-hardening-review`
- `make quality-hooks-run`

## Risk and Rollback
- risk: incorrect skip scope could reduce fast-lane coverage
- rollback: revert selector/test changes and rerun `make infra-contract-test-fast` and `make quality-hooks-fast`

## Deferred Proposals
- follow-up items from the same regression group remain: #104, #106, #107