### PR TITLE
fix(infra): add external-secrets destination to ArgoCD AppProject overlays

### DIFF
--- a/AGENTS.backlog.md
+++ b/AGENTS.backlog.md
@@ -9,7 +9,8 @@
 - [x] P1 (Fixture-contract hardening): Issue #130 — enforce optional-module `required_env` fixture parity in fast infra contract checks (canonical fixture resolver wiring + fast-lane parity tests).
 - [x] P1 (Generated-consumer upgrade regressions): Issue #103 — `infra-contract-test-fast` is now repo-mode aware (generated-consumer skips template-source-only tests; template-source remains fail-fast for missing selected tests).
 - [x] P1 (Generated-consumer upgrade regressions): Issues #104, #106, #107 — fix additive-file conflict classification and missing helper distribution. **Done**: `specs/2026-04-22-issue-104-106-107-upgrade-additive-file-helper-gaps/`
-- [ ] P1 (Runtime operability correctness): Issues #105, #108, #109, #110, #111, #112, #118, #137 — resolve runtime identity, Argo health/project policy, image-lane, and target migration friction.
+- [x] P1 (ArgoCD AppProject namespace policy gap): Issues #108, #109 — `external-secrets` destination added to all overlay AppProject files; guard test added in `infra-contract-test-fast`; Issue #109 cause #2 (ESO NotReady for unneeded optional modules) deferred to #137. **Done**: `specs/2026-04-22-issue-108-109-argocd-appproject-namespace-policy/`
+- [ ] P1 (Runtime operability correctness): Issues #105, #110, #111, #112, #118, #137 — resolve runtime identity, image-lane, and target migration friction.
 - [ ] P2 (Ownership checker robustness): support normalized equivalence for semantically-identical prune-glob expressions in ownership-matrix documentation checks.
 - [ ] P2 (Capability enhancements): Issues #56, #131 — expand app dependency pin auditing and add blueprint uplift convergence status command.
 - [ ] Add an automated bundled-skill contract verifier to enforce parity across `.agents/skills/**`, consumer-template fallbacks, install make targets, and docs references.

--- a/AGENTS.decisions.md
+++ b/AGENTS.decisions.md
@@ -327,3 +327,10 @@
   - template-source-only tests (`tests/blueprint/test_upgrade_fixture_matrix.py`) are skipped in generated-consumer mode; `tests/infra/test_optional_module_required_env_contract.py` runs in both modes as a shared fast-lane contract gate.
   - selected tests are now existence-validated before `pytest` execution, so template-source mode remains fail-fast when required fast-lane tests are missing.
   - `infra_contract_test_fast_test_selection_total` metrics now expose selected/skipped counts and active repo mode for diagnostics.
+- ArgoCD AppProject namespace policy gap fixed (Issues #108, #109):
+  - All four ArgoCD AppProject overlay files (`local`, `dev`, `stage`, `prod`) and the bootstrap template copy were missing `external-secrets` in `spec.destinations`, blocking ArgoCD from syncing RBAC resources that the External Secrets Operator creates in the `external-secrets` namespace.
+  - `external-secrets` destination entry added to all five AppProject files.
+  - `tests/infra/test_tooling_contracts.py::AppProjectNamespacePolicyTests` added to guard against regression; test verifies all overlay files and the bootstrap template contain the required destination.
+  - `tests/infra/test_tooling_contracts.py` added to `base_tests` in `scripts/bin/infra/contract_test_fast.sh` so the guard runs in both `template-source` and `generated-consumer` fast-lane modes.
+  - Test isolation fix: `profile_module_enablement_contract` now passes `ROOT_DIR` pointing to the temp repo root so `profile.sh` resolves the patched contract from the temp dir when run inside the `make infra-contract-test-fast` process environment.
+  - Issue #109 cause #2 (optional-module ESOs NotReady when modules are not seeded) is tracked separately in Issue #137.

--- a/docs/blueprint/architecture/decisions/ADR-20260422-issue-108-109-argocd-appproject-namespace-policy.md
+++ b/docs/blueprint/architecture/decisions/ADR-20260422-issue-108-109-argocd-appproject-namespace-policy.md
@@ -1,0 +1,38 @@
+# ADR-20260422-issue-108-109-argocd-appproject-namespace-policy: ArgoCD AppProject Namespace Policy Gap
+
+## Metadata
+- Status: approved
+- Date: 2026-04-22
+- Owners: @sbonoc
+- Related spec path: `specs/2026-04-22-issue-108-109-argocd-appproject-namespace-policy/spec.md`
+
+## Business Objective and Requirement Summary
+- Business objective: ArgoCD AppProject `platform-local` (and all environment variants) MUST permit the `external-secrets` namespace as a deployment destination so platform and consumer-extended manifests targeting that namespace sync without policy errors.
+- Functional requirements summary:
+  - ALL AppProject overlays (local, dev, stage, prod) and the bootstrap template copy MUST include `external-secrets` under `spec.destinations`
+  - `infra-contract-test-fast` MUST include a guard that fails when any AppProject file is missing that entry
+- Non-functional requirements summary:
+  - no new resource kinds added to `namespaceResourceWhitelist` or `clusterResourceWhitelist`
+  - guard failure message identifies the offending file and missing namespace
+- Desired timeline: immediate; unblocks ArgoCD sync for any resource targeting `external-secrets`.
+
+## Decision Drivers
+- ESO-managed namespaced RBAC resources (Role/RoleBinding for TokenRequest) are created in the `external-secrets` namespace. ArgoCD rejects sync of these resources if the AppProject does not list `external-secrets` as a permitted destination, producing `namespace external-secrets is not permitted in project 'platform-local'`.
+- The gap existed in all four environment overlays and the bootstrap template, meaning it reproduced across every generated consumer and every environment.
+- No automated guard existed to catch AppProject destination gaps before reaching a live cluster.
+
+## Options Considered
+
+### Fix the AppProject gap
+- Option A: add `external-secrets` to `spec.destinations` in all AppProject overlays and the bootstrap template.
+- Option B: move all resources that target `external-secrets` out of platform manifests (remove the need for the destination entirely).
+
+## Recommended Option
+- Selected option: Option A
+- Rationale: Option B would require removing ESO-managed RBAC resources that are a legitimate and necessary part of the platform runtime. Option A is the minimal, correct fix — the AppProject policy was simply missing a namespace that is a genuine deployment target. The `namespaceResourceWhitelist` already bounds which resource kinds can be deployed in any listed namespace, so widening destinations does not materially increase the attack surface.
+
+## Consequences
+- **Positive**: `platform-local-core` sync no longer fails for resources in `external-secrets`; platform-local-core health signal improves once ArgoCD re-syncs.
+- **Positive**: Guard test in `infra-contract-test-fast` prevents future namespace destination gaps across all AppProject files.
+- **Neutral**: The `external-secrets` namespace is now a managed ArgoCD destination; the `namespaceResourceWhitelist` continues to restrict which resource kinds can be deployed there.
+- **Residual**: `platform-local-core` health may still show Degraded if optional-module ExternalSecrets (e.g. `postgres-runtime-credentials`) are NotReady because their source-secret fields are absent. This is tracked separately in issue #137.

--- a/infra/gitops/argocd/overlays/dev/appproject.yaml
+++ b/infra/gitops/argocd/overlays/dev/appproject.yaml
@@ -27,6 +27,8 @@ spec:
       server: https://kubernetes.default.svc
     - namespace: observability
       server: https://kubernetes.default.svc
+    - namespace: external-secrets
+      server: https://kubernetes.default.svc
   clusterResourceWhitelist:
     - group: ""
       kind: Namespace

--- a/infra/gitops/argocd/overlays/local/appproject.yaml
+++ b/infra/gitops/argocd/overlays/local/appproject.yaml
@@ -27,6 +27,8 @@ spec:
       server: https://kubernetes.default.svc
     - namespace: observability
       server: https://kubernetes.default.svc
+    - namespace: external-secrets
+      server: https://kubernetes.default.svc
   clusterResourceWhitelist:
     - group: ""
       kind: Namespace

--- a/infra/gitops/argocd/overlays/prod/appproject.yaml
+++ b/infra/gitops/argocd/overlays/prod/appproject.yaml
@@ -27,6 +27,8 @@ spec:
       server: https://kubernetes.default.svc
     - namespace: observability
       server: https://kubernetes.default.svc
+    - namespace: external-secrets
+      server: https://kubernetes.default.svc
   clusterResourceWhitelist:
     - group: ""
       kind: Namespace

--- a/infra/gitops/argocd/overlays/stage/appproject.yaml
+++ b/infra/gitops/argocd/overlays/stage/appproject.yaml
@@ -27,6 +27,8 @@ spec:
       server: https://kubernetes.default.svc
     - namespace: observability
       server: https://kubernetes.default.svc
+    - namespace: external-secrets
+      server: https://kubernetes.default.svc
   clusterResourceWhitelist:
     - group: ""
       kind: Namespace

--- a/scripts/bin/infra/contract_test_fast.sh
+++ b/scripts/bin/infra/contract_test_fast.sh
@@ -37,6 +37,7 @@ base_tests=(
   "tests/infra/test_state_artifact_contract.py"
   "tests/infra/test_root_dir_resolution.py"
   "tests/infra/test_optional_module_required_env_contract.py"
+  "tests/infra/test_tooling_contracts.py"
 )
 template_source_only_tests=(
   "tests/blueprint/test_upgrade_fixture_matrix.py"

--- a/scripts/templates/infra/bootstrap/infra/gitops/argocd/overlays/dev/appproject.yaml
+++ b/scripts/templates/infra/bootstrap/infra/gitops/argocd/overlays/dev/appproject.yaml
@@ -27,6 +27,8 @@ spec:
       server: https://kubernetes.default.svc
     - namespace: observability
       server: https://kubernetes.default.svc
+    - namespace: external-secrets
+      server: https://kubernetes.default.svc
   clusterResourceWhitelist:
     - group: ""
       kind: Namespace

--- a/scripts/templates/infra/bootstrap/infra/gitops/argocd/overlays/local/appproject.yaml
+++ b/scripts/templates/infra/bootstrap/infra/gitops/argocd/overlays/local/appproject.yaml
@@ -27,6 +27,8 @@ spec:
       server: https://kubernetes.default.svc
     - namespace: observability
       server: https://kubernetes.default.svc
+    - namespace: external-secrets
+      server: https://kubernetes.default.svc
   clusterResourceWhitelist:
     - group: ""
       kind: Namespace

--- a/scripts/templates/infra/bootstrap/infra/gitops/argocd/overlays/prod/appproject.yaml
+++ b/scripts/templates/infra/bootstrap/infra/gitops/argocd/overlays/prod/appproject.yaml
@@ -27,6 +27,8 @@ spec:
       server: https://kubernetes.default.svc
     - namespace: observability
       server: https://kubernetes.default.svc
+    - namespace: external-secrets
+      server: https://kubernetes.default.svc
   clusterResourceWhitelist:
     - group: ""
       kind: Namespace

--- a/scripts/templates/infra/bootstrap/infra/gitops/argocd/overlays/stage/appproject.yaml
+++ b/scripts/templates/infra/bootstrap/infra/gitops/argocd/overlays/stage/appproject.yaml
@@ -27,6 +27,8 @@ spec:
       server: https://kubernetes.default.svc
     - namespace: observability
       server: https://kubernetes.default.svc
+    - namespace: external-secrets
+      server: https://kubernetes.default.svc
   clusterResourceWhitelist:
     - group: ""
       kind: Namespace

--- a/specs/2026-04-22-issue-108-109-argocd-appproject-namespace-policy/architecture.md
+++ b/specs/2026-04-22-issue-108-109-argocd-appproject-namespace-policy/architecture.md
@@ -1,0 +1,42 @@
+# Architecture
+
+## Context
+- Work item:
+- Owner:
+- Date:
+
+## Stack and Execution Model
+- Backend stack profile:
+- Frontend stack profile:
+- Test automation profile:
+- Agent execution model:
+
+## Problem Statement
+- What needs to change and why:
+- Scope boundaries:
+- Out of scope:
+
+## Bounded Contexts and Responsibilities
+- Context A:
+- Context B:
+
+## High-Level Component Design
+- Domain layer:
+- Application layer:
+- Infrastructure adapters:
+- Presentation/API/workflow boundaries:
+
+## Integration and Dependency Edges
+- Upstream dependencies:
+- Downstream dependencies:
+- Data/API/event contracts touched:
+
+## Non-Functional Architecture Notes
+- Security:
+- Observability:
+- Reliability and rollback:
+- Monitoring/alerting:
+
+## Risks and Tradeoffs
+- Risk 1:
+- Tradeoff 1:

--- a/specs/2026-04-22-issue-108-109-argocd-appproject-namespace-policy/architecture.md
+++ b/specs/2026-04-22-issue-108-109-argocd-appproject-namespace-policy/architecture.md
@@ -1,42 +1,42 @@
 # Architecture
 
 ## Context
-- Work item:
-- Owner:
-- Date:
+- Work item: 2026-04-22-issue-108-109-argocd-appproject-namespace-policy
+- Owner: bonos
+- Date: 2026-04-22
 
 ## Stack and Execution Model
-- Backend stack profile:
-- Frontend stack profile:
-- Test automation profile:
-- Agent execution model:
+- Backend stack profile: n/a (no application code)
+- Frontend stack profile: n/a
+- Test automation profile: pytest unit tests in `tests/infra/test_tooling_contracts.py`; fast-lane via `make infra-contract-test-fast`
+- Agent execution model: SDD blueprint track; quality-hooks-fast + quality-hardening-review gates
 
 ## Problem Statement
-- What needs to change and why:
-- Scope boundaries:
-- Out of scope:
+- What needs to change and why: All four ArgoCD AppProject overlay files and the bootstrap template copy omitted `external-secrets` from `spec.destinations`. ArgoCD enforces this list as a deployment allowlist — any resource targeting a namespace not listed is rejected at sync time. ESO creates namespaced RBAC resources (Role, RoleBinding for TokenRequest) in the `external-secrets` namespace as part of its normal operation; without the destination entry those resources cannot sync, keeping `platform-local-core` in Degraded health.
+- Scope boundaries: additive YAML destination entry in five AppProject files; guard test in `test_tooling_contracts.py`; `test_tooling_contracts.py` added to `contract_test_fast.sh` base_tests array. No changes to `clusterResourceWhitelist` or `namespaceResourceWhitelist`.
+- Out of scope: optional-module ESO NotReady when modules are not seeded (cause #2 of #109, tracked in #137); AppProject changes for any other namespace.
 
 ## Bounded Contexts and Responsibilities
-- Context A:
-- Context B:
+- Context A — ArgoCD AppProject policy: `spec.destinations` is the allowlist that ArgoCD enforces for all sync operations. The platform AppProject is the sole policy boundary for all platform workloads across all environments.
+- Context B — External Secrets Operator (ESO): runs in the `external-secrets` namespace and creates namespaced RBAC resources there as part of its TokenRequest credential flow. These are legitimate blueprint-managed resources.
 
 ## High-Level Component Design
-- Domain layer:
-- Application layer:
-- Infrastructure adapters:
-- Presentation/API/workflow boundaries:
+- Domain layer: n/a
+- Application layer: n/a
+- Infrastructure adapters: five AppProject YAML files are the only changed artifacts. The `external-secrets` destination entry is additive — no existing entries are modified.
+- Presentation/API/workflow boundaries: `make infra-contract-test-fast` is the fast-lane quality gate. The new `AppProjectNamespacePolicyTests` class in `test_tooling_contracts.py` asserts the destination is present in all five files deterministically.
 
 ## Integration and Dependency Edges
-- Upstream dependencies:
-- Downstream dependencies:
-- Data/API/event contracts touched:
+- Upstream dependencies: ArgoCD reads AppProject resources from the cluster; the destination allowlist is evaluated at sync time against the resource's target namespace.
+- Downstream dependencies: ESO Role/RoleBinding resources in `external-secrets` namespace; any future blueprint-managed RBAC resources targeting that namespace.
+- Data/API/event contracts touched: `spec.destinations` list in `argoproj.io/v1alpha1/AppProject` — additive only.
 
 ## Non-Functional Architecture Notes
-- Security:
-- Observability:
-- Reliability and rollback:
-- Monitoring/alerting:
+- Security: no new resource kinds added to `namespaceResourceWhitelist`; the `external-secrets` namespace was already in scope via operator deployment, only the explicit destination entry was missing. Guard test prevents future regression.
+- Observability: guard failure message names the specific file and missing namespace, giving operators a precise remediation target without log trawling.
+- Reliability and rollback: change is additive — reverting means removing five destination entries. The guard test would then fail explicitly, signaling the regression.
+- Monitoring/alerting: n/a; change resolves continuous ArgoCD Degraded health on `platform-local-core` that would otherwise require manual investigation.
 
 ## Risks and Tradeoffs
-- Risk 1:
-- Tradeoff 1:
+- Risk 1: none material. The `external-secrets` namespace was always an intended deployment target; only the AppProject entry was absent.
+- Tradeoff 1: opted not to add a `namespaceResourceWhitelist` guard for Role/RoleBinding (they are already listed). Adding it would duplicate an existing guarantee without covering a new failure mode.

--- a/specs/2026-04-22-issue-108-109-argocd-appproject-namespace-policy/context_pack.md
+++ b/specs/2026-04-22-issue-108-109-argocd-appproject-namespace-policy/context_pack.md
@@ -1,14 +1,14 @@
 # Work Item Context Pack
 
 ## Context Snapshot
-- Work item:
+- Work item: 2026-04-22-issue-108-109-argocd-appproject-namespace-policy
 - Track: blueprint
-- SPEC_READY:
-- ADR path:
-- ADR status:
+- SPEC_READY: true
+- ADR path: docs/blueprint/architecture/decisions/ADR-20260422-issue-108-109-argocd-appproject-namespace-policy.md
+- ADR status: accepted
 
 ## Guardrail Controls
-- Applicable control IDs:
+- Applicable control IDs: SDD-C-005, SDD-C-007, SDD-C-009, SDD-C-012
 
 ## Required Commands
 - `make quality-sdd-check`

--- a/specs/2026-04-22-issue-108-109-argocd-appproject-namespace-policy/context_pack.md
+++ b/specs/2026-04-22-issue-108-109-argocd-appproject-namespace-policy/context_pack.md
@@ -1,0 +1,32 @@
+# Work Item Context Pack
+
+## Context Snapshot
+- Work item:
+- Track: blueprint
+- SPEC_READY:
+- ADR path:
+- ADR status:
+
+## Guardrail Controls
+- Applicable control IDs:
+
+## Required Commands
+- `make quality-sdd-check`
+- `make quality-sdd-check-all`
+- `make quality-hooks-run`
+- `make quality-hardening-review`
+- `make infra-validate`
+- `make docs-build`
+- `make docs-smoke`
+- `make spec-pr-context`
+
+## Artifact Index
+- `architecture.md`
+- `spec.md`
+- `plan.md`
+- `tasks.md`
+- `traceability.md`
+- `graph.json`
+- `evidence_manifest.json`
+- `pr_context.md`
+- `hardening_review.md`

--- a/specs/2026-04-22-issue-108-109-argocd-appproject-namespace-policy/evidence_manifest.json
+++ b/specs/2026-04-22-issue-108-109-argocd-appproject-namespace-policy/evidence_manifest.json
@@ -1,0 +1,40 @@
+{
+  "manifest_version": 1,
+  "work_item": "2026-04-22-issue-108-109-argocd-appproject-namespace-policy",
+  "generated_by": "spec-evidence-manifest",
+  "generated_at_utc": "2026-04-22T15:20:00Z",
+  "files": [
+    {
+      "path": "infra/gitops/argocd/overlays/local/appproject.yaml",
+      "sha256": "118c1fa1df31992ae183fec531c1b8f56cfc7e20b739ef4966ec1f1c1d30a338"
+    },
+    {
+      "path": "infra/gitops/argocd/overlays/dev/appproject.yaml",
+      "sha256": "8b579dc12809ecaa1e27937222af669a9510800d0ef745c97fb566fb86dd27f6"
+    },
+    {
+      "path": "infra/gitops/argocd/overlays/stage/appproject.yaml",
+      "sha256": "2ba8e9e0b780fe42f1d013c28c36d32c258afaef1bceaba6ac088303f5a95a70"
+    },
+    {
+      "path": "infra/gitops/argocd/overlays/prod/appproject.yaml",
+      "sha256": "d59a78c3f8956e0162d44ec379620ef21ec011244a47d417a6dc36f2f14e94e1"
+    },
+    {
+      "path": "scripts/templates/infra/bootstrap/infra/gitops/argocd/overlays/local/appproject.yaml",
+      "sha256": "118c1fa1df31992ae183fec531c1b8f56cfc7e20b739ef4966ec1f1c1d30a338"
+    },
+    {
+      "path": "tests/infra/test_tooling_contracts.py",
+      "sha256": "7d1374f3fdd3a2d83da4e320d79e81e6767d9d587c741129e929ba54d73e0bbe"
+    },
+    {
+      "path": "scripts/bin/infra/contract_test_fast.sh",
+      "sha256": "d23e6a95b962ad323a291d889bb27a7a1dac6cd12aa09fb17b6a85bdcd19ee9c"
+    },
+    {
+      "path": "docs/blueprint/architecture/decisions/ADR-20260422-issue-108-109-argocd-appproject-namespace-policy.md",
+      "sha256": "ea30bf2e024e77f5fff32a594cd069e48ad68a81bf9858ea9242c58e5bed7578"
+    }
+  ]
+}

--- a/specs/2026-04-22-issue-108-109-argocd-appproject-namespace-policy/evidence_manifest.json
+++ b/specs/2026-04-22-issue-108-109-argocd-appproject-namespace-policy/evidence_manifest.json
@@ -25,8 +25,20 @@
       "sha256": "118c1fa1df31992ae183fec531c1b8f56cfc7e20b739ef4966ec1f1c1d30a338"
     },
     {
+      "path": "scripts/templates/infra/bootstrap/infra/gitops/argocd/overlays/dev/appproject.yaml",
+      "sha256": "8b579dc12809ecaa1e27937222af669a9510800d0ef745c97fb566fb86dd27f6"
+    },
+    {
+      "path": "scripts/templates/infra/bootstrap/infra/gitops/argocd/overlays/stage/appproject.yaml",
+      "sha256": "2ba8e9e0b780fe42f1d013c28c36d32c258afaef1bceaba6ac088303f5a95a70"
+    },
+    {
+      "path": "scripts/templates/infra/bootstrap/infra/gitops/argocd/overlays/prod/appproject.yaml",
+      "sha256": "d59a78c3f8956e0162d44ec379620ef21ec011244a47d417a6dc36f2f14e94e1"
+    },
+    {
       "path": "tests/infra/test_tooling_contracts.py",
-      "sha256": "7d1374f3fdd3a2d83da4e320d79e81e6767d9d587c741129e929ba54d73e0bbe"
+      "sha256": "0cd1098ed546efd14d92f0985436eef2ffd623429c0cf2103e5649416bebe658"
     },
     {
       "path": "scripts/bin/infra/contract_test_fast.sh",

--- a/specs/2026-04-22-issue-108-109-argocd-appproject-namespace-policy/graph.json
+++ b/specs/2026-04-22-issue-108-109-argocd-appproject-namespace-policy/graph.json
@@ -1,0 +1,29 @@
+{
+  "graph_version": 1,
+  "work_item": "2026-04-22-issue-108-109-argocd-appproject-namespace-policy",
+  "nodes": [
+    {"id": "FR-001", "type": "requirement", "summary": "ALL AppProject overlays and bootstrap template MUST include external-secrets in spec.destinations"},
+    {"id": "FR-002", "type": "requirement", "summary": "infra-contract-test-fast MUST include a guard test failing when any AppProject overlay is missing external-secrets"},
+    {"id": "FR-003", "type": "requirement", "summary": "Guard MUST check all four environment overlays and bootstrap template AppProject file"},
+    {"id": "NFR-SEC-001", "type": "requirement", "summary": "Adding external-secrets destination MUST NOT expand namespaceResourceWhitelist or clusterResourceWhitelist"},
+    {"id": "NFR-OPS-001", "type": "requirement", "summary": "Guard failure message MUST identify the specific AppProject file and missing namespace"},
+    {"id": "AC-001", "type": "acceptance", "summary": "All five AppProject files contain namespace: external-secrets under spec.destinations"},
+    {"id": "AC-002", "type": "acceptance", "summary": "make infra-contract-test-fast passes with guard green"},
+    {"id": "AC-003", "type": "acceptance", "summary": "Guard fails when external-secrets removed from any AppProject destinations (regression guard)"},
+    {"id": "AC-004", "type": "acceptance", "summary": "make infra-validate passes after fix"},
+    {"id": "AC-005", "type": "acceptance", "summary": "Issue #108 sync failure resolves at next ArgoCD re-sync"},
+    {"id": "AC-006", "type": "acceptance", "summary": "Issue #109 Degraded health from AppProject namespace gap resolves at next ArgoCD re-sync"}
+  ],
+  "edges": [
+    {"from": "FR-001", "to": "AC-001", "relation": "validated_by"},
+    {"from": "FR-001", "to": "AC-005", "relation": "validated_by"},
+    {"from": "FR-001", "to": "AC-006", "relation": "validated_by"},
+    {"from": "FR-002", "to": "AC-002", "relation": "validated_by"},
+    {"from": "FR-002", "to": "AC-003", "relation": "validated_by"},
+    {"from": "FR-003", "to": "AC-001", "relation": "validated_by"},
+    {"from": "FR-003", "to": "AC-002", "relation": "validated_by"},
+    {"from": "NFR-SEC-001", "to": "AC-001", "relation": "constrains"},
+    {"from": "NFR-OPS-001", "to": "AC-002", "relation": "constrains"},
+    {"from": "NFR-OPS-001", "to": "AC-003", "relation": "constrains"}
+  ]
+}

--- a/specs/2026-04-22-issue-108-109-argocd-appproject-namespace-policy/hardening_review.md
+++ b/specs/2026-04-22-issue-108-109-argocd-appproject-namespace-policy/hardening_review.md
@@ -1,0 +1,19 @@
+# Hardening Review
+
+## Repository-Wide Findings Fixed
+- Finding 1: All four ArgoCD AppProject overlay files and the bootstrap template copy were missing `external-secrets` in `spec.destinations`, blocking ArgoCD from syncing RBAC resources (Role, RoleBinding) that the External Secrets Operator creates in the `external-secrets` namespace. Added the missing destination entry to all five files.
+
+## Observability and Diagnostics Changes
+- Metrics/logging/tracing updates: None. No new metrics or log lines introduced.
+- Operational diagnostics updates: Guard test failure message explicitly names the missing namespace and the offending file(s), giving operators a precise remediation target.
+
+## Architecture and Code Quality Compliance
+- SOLID / Clean Architecture / Clean Code / DDD checks: Change is minimal — additive YAML entries only, no logic changes. Guard test class is co-located in `test_tooling_contracts.py` following established pattern.
+- Test-automation and pyramid checks: New unit-level guard test added in `AppProjectNamespacePolicyTests`. Test covers all five AppProject files deterministically. `test_tooling_contracts.py` added to `base_tests` in `contract_test_fast.sh` so it runs in both `template-source` and `generated-consumer` modes.
+- Documentation/diagram/CI/skill consistency checks: ADR written at `docs/blueprint/architecture/decisions/ADR-20260422-issue-108-109-argocd-appproject-namespace-policy.md`. Traceability matrix complete. `AGENTS.decisions.md` updated.
+
+## Test isolation fix
+- `profile_module_enablement_contract` in `test_tooling_contracts.py` now explicitly sets `ROOT_DIR` to the temp repo root so that `profile.sh` resolves the patched contract from the temp dir, not from `ROOT_DIR` inherited from the `make infra-contract-test-fast` process environment.
+
+## Proposals Only (Not Implemented)
+- Proposal 1: Extend guard to also verify `namespaceResourceWhitelist` covers `Role` and `RoleBinding` kinds. Deferred — current whitelist already includes those kinds; adding a second assertion would duplicate an existing guarantee without catching a new failure mode.

--- a/specs/2026-04-22-issue-108-109-argocd-appproject-namespace-policy/plan.md
+++ b/specs/2026-04-22-issue-108-109-argocd-appproject-namespace-policy/plan.md
@@ -1,0 +1,92 @@
+# Implementation Plan — ArgoCD AppProject Namespace Policy Gap (#108 / #109)
+
+## Implementation Start Gate
+
+SPEC_READY=true. All inputs resolved. Implementation may proceed.
+
+## Slice 1 — Guard test (red)
+
+Add a failing test class `AppProjectNamespacePolicyTests` to
+`tests/infra/test_tooling_contracts.py` that asserts `external-secrets` is present in the
+`spec.destinations` list of every AppProject overlay file (local, dev, stage, prod) and the
+bootstrap template copy. The test reads each YAML file with PyYAML and checks the destinations
+list. Test must fail before the manifest fix.
+
+Files touched: `tests/infra/test_tooling_contracts.py`
+
+## Slice 2 — Manifest fix (green)
+
+Add an `external-secrets` destination entry to `spec.destinations` in all five AppProject files:
+
+1. `infra/gitops/argocd/overlays/local/appproject.yaml`
+2. `infra/gitops/argocd/overlays/dev/appproject.yaml`
+3. `infra/gitops/argocd/overlays/stage/appproject.yaml`
+4. `infra/gitops/argocd/overlays/prod/appproject.yaml`
+5. `scripts/templates/infra/bootstrap/infra/gitops/argocd/overlays/local/appproject.yaml`
+
+Each entry follows the existing pattern:
+```yaml
+- namespace: external-secrets
+  server: https://kubernetes.default.svc
+```
+
+No changes to `namespaceResourceWhitelist` or `clusterResourceWhitelist`.
+
+Files touched: the five AppProject YAML files listed above.
+
+## Slice 3 — ADR and governance
+
+Write ADR at
+`docs/blueprint/architecture/decisions/ADR-20260422-issue-108-109-argocd-appproject-namespace-policy.md`.
+
+Update `AGENTS.decisions.md` with the rationale. Update `AGENTS.backlog.md` to mark #108 and
+#109 done.
+
+## Validation
+
+- `make infra-contract-test-fast` — must include new guard tests, all green
+- `make infra-validate` — must pass
+- `make quality-hooks-fast` — must pass
+
+## App Onboarding Contract (Normative)
+- Required minimum make targets (all unaffected by this work item):
+  - `apps-bootstrap`
+  - `apps-smoke`
+  - `backend-test-unit`
+  - `backend-test-integration`
+  - `backend-test-contracts`
+  - `backend-test-e2e`
+  - `touchpoints-test-unit`
+  - `touchpoints-test-integration`
+  - `touchpoints-test-contracts`
+  - `touchpoints-test-e2e`
+  - `test-unit-all`
+  - `test-integration-all`
+  - `test-contracts-all`
+  - `test-e2e-all-local`
+  - `infra-port-forward-start`
+  - `infra-port-forward-stop`
+  - `infra-port-forward-cleanup`
+- App onboarding impact: no-impact
+- Notes: no app delivery scope affected; all targets above remain functional
+
+## Documentation Plan (Document Phase)
+- Blueprint docs updates: ADR at `docs/blueprint/architecture/decisions/ADR-20260422-issue-108-109-argocd-appproject-namespace-policy.md`; `AGENTS.decisions.md`
+- Consumer docs updates: none (static manifest fix; no consumer-facing behavior change)
+- Mermaid diagrams updated: none
+- Docs validation commands:
+  - `make quality-hooks-fast`
+  - `make infra-validate`
+
+## Publish Preparation
+- PR context: `specs/2026-04-22-issue-108-109-argocd-appproject-namespace-policy/pr_context.md`
+- Hardening review: `specs/2026-04-22-issue-108-109-argocd-appproject-namespace-policy/hardening_review.md`
+
+## Risk / Rollback
+
+**Risk**: Widening AppProject destinations to `external-secrets` allows Argo to manage resources
+in that namespace. The `namespaceResourceWhitelist` already covers all intended resource kinds;
+no new kinds are added, so the attack surface is unchanged.
+
+**Rollback**: Remove the `external-secrets` destination entries from the five YAML files. No
+cluster state migration required.

--- a/specs/2026-04-22-issue-108-109-argocd-appproject-namespace-policy/pr_context.md
+++ b/specs/2026-04-22-issue-108-109-argocd-appproject-namespace-policy/pr_context.md
@@ -1,0 +1,35 @@
+# PR Context
+
+## Summary
+- Work item: Issue #108 + #109 — ArgoCD AppProject namespace policy gap
+- Objective: Add `external-secrets` to `spec.destinations` in all ArgoCD AppProject overlays and the bootstrap template copy; add a guard test in `infra-contract-test-fast` to prevent regression; fix test isolation so the guard test passes when run in the full fast-lane suite.
+- Scope boundaries: Destination list expansion only — no changes to `clusterResourceWhitelist` or `namespaceResourceWhitelist`. Issue #109 cause #2 (optional-module ESOs NotReady when not seeded) deferred to #137.
+
+## Requirement Coverage
+- Requirement IDs covered: FR-001, FR-002, FR-003, NFR-SEC-001, NFR-OPS-001
+- Acceptance criteria covered: AC-001, AC-002, AC-003, AC-004, AC-005, AC-006
+- Contract surfaces changed: `spec.destinations` in five AppProject YAML files; `base_tests` array in `contract_test_fast.sh`; new test class in `test_tooling_contracts.py`
+
+## Key Reviewer Files
+- Primary files to review first:
+  - `infra/gitops/argocd/overlays/*/appproject.yaml` (four overlay files)
+  - `scripts/templates/infra/bootstrap/infra/gitops/argocd/overlays/local/appproject.yaml`
+  - `tests/infra/test_tooling_contracts.py` — `AppProjectNamespacePolicyTests` class (end of file)
+  - `scripts/bin/infra/contract_test_fast.sh` — `base_tests` array
+- High-risk files: None. The AppProject YAML changes are additive; no existing entries were modified.
+
+## Validation Evidence
+- Required commands executed:
+  - `make infra-contract-test-fast` → 94 passed, 2 subtests passed
+  - `make quality-hooks-fast` → success
+  - `make quality-hardening-review` → success
+- Result summary: All gates green. Guard test `test_all_appproject_overlays_include_external_secrets_destination` passes. Test isolation fix confirmed: `test_profile_uses_generated_repo_contract_when_module_env_is_unset` passes in both isolation and full-suite execution.
+- Artifact references: `specs/2026-04-22-issue-108-109-argocd-appproject-namespace-policy/evidence_manifest.json`
+
+## Risk and Rollback
+- Main risks: None material. The change adds a destination entry that was always intended to be present. The `namespaceResourceWhitelist` already covers the resource kinds ESO creates there.
+- Rollback strategy: Revert the five AppProject YAML files. The guard test and `contract_test_fast.sh` change can remain (guard would then fail, signaling the regression explicitly).
+
+## Deferred Proposals
+- Proposal 1 (not implemented): Guard `namespaceResourceWhitelist` for Role/RoleBinding presence. Deferred — current whitelist already includes those kinds.
+- Issue #109 cause #2 (not implemented): Optional-module ESOs NotReady when modules are not seeded. Tracked in #137.

--- a/specs/2026-04-22-issue-108-109-argocd-appproject-namespace-policy/spec.md
+++ b/specs/2026-04-22-issue-108-109-argocd-appproject-namespace-policy/spec.md
@@ -1,0 +1,78 @@
+# Specification
+
+## Spec Readiness Gate (Blocking)
+- SPEC_READY: true
+- Open questions count: 0
+- Unresolved alternatives count: 0
+- Unresolved TODO markers count: 0
+- Pending assumptions count: 0
+- Open clarification markers count: 0
+- Product sign-off: approved
+- Architecture sign-off: approved
+- Security sign-off: approved
+- Operations sign-off: approved
+- Missing input blocker token: none
+- ADR path: docs/blueprint/architecture/decisions/ADR-20260422-issue-108-109-argocd-appproject-namespace-policy.md
+- ADR status: approved
+
+## Applicable Guardrail Controls (Normative)
+- Applicable control IDs: SDD-C-005, SDD-C-007, SDD-C-009, SDD-C-012, SDD-C-013
+- Control exception rationale: none
+
+## Implementation Stack Profile (Normative)
+- Backend stack profile: none
+- Frontend stack profile: none
+- Test automation profile: pytest_vitest_playwright_pact
+- Agent execution model: single-agent
+- Managed service preference: stackit-managed-first
+- Managed service exception rationale: none (manifest and test change only; no managed service involved)
+- Runtime profile: local-first-docker-desktop-kubernetes
+- Local Kubernetes context policy: docker-desktop-preferred
+- Local provisioning stack: crossplane-plus-helm
+- Runtime identity baseline: eso-plus-argocd-plus-keycloak
+- Local-first exception rationale: none (static YAML manifest fix; no local runtime execution required)
+
+## Objective
+- Business outcome: ArgoCD AppProject `platform-local` (and all environment variants) MUST permit the `external-secrets` namespace as a deployment destination so platform and consumer-extended manifests targeting that namespace can sync without policy errors.
+- Success metric: `platform-local-core` sync no longer fails with "namespace external-secrets is not permitted in project 'platform-local'"; `infra-contract-test-fast` guard fails if the namespace is ever removed.
+
+## Normative Requirements
+
+### Functional Requirements (Normative)
+
+#### AppProject namespace policy fix (#108)
+- FR-001 ALL AppProject overlays (local, dev, stage, prod) and the bootstrap template copy MUST include `external-secrets` under `spec.destinations` targeting `https://kubernetes.default.svc`.
+- FR-002 `infra-contract-test-fast` MUST include a guard test that fails when any AppProject overlay or the bootstrap template is missing `external-secrets` from its destinations list.
+- FR-003 The guard MUST check all four environment overlays (local, dev, stage, prod) and the bootstrap template AppProject file.
+
+### Non-Functional Requirements (Normative)
+- NFR-SEC-001 Adding `external-secrets` to destinations MUST NOT expand `namespaceResourceWhitelist` or `clusterResourceWhitelist` with new resource kinds.
+- NFR-OPS-001 Guard test failure message MUST identify the specific AppProject file path and the missing namespace.
+
+## Acceptance Criteria (Normative)
+- AC-001 All five AppProject files (four overlays + bootstrap template) contain `namespace: external-secrets` under `spec.destinations`.
+- AC-002 `make infra-contract-test-fast` passes with the new guard test green.
+- AC-003 Guard test fails (regression guard) when `external-secrets` is removed from any AppProject destinations list.
+- AC-004 `make infra-validate` passes after the fix.
+- AC-005 Issue #108 sync failure (`namespace external-secrets is not permitted`) is resolved at next ArgoCD re-sync.
+- AC-006 Issue #109 Degraded health caused by the AppProject namespace policy gap resolves at next ArgoCD re-sync after fix is deployed. (Residual Degraded health from optional-module ExternalSecrets NotReady is tracked separately in issue #137.)
+
+## Informative Notes (Non-Normative)
+- Context: the `external-secrets` namespace is managed by the external-secrets operator (ESO) itself. Platform and consumer-extended manifests deploy namespaced RBAC resources there (e.g. Role/RoleBinding for ESO TokenRequest). These resources are legitimate deployment targets that the AppProject policy MUST explicitly allow.
+- Tradeoffs: widening the AppProject destinations to include `external-secrets` allows ArgoCD to manage resources in that namespace. The `namespaceResourceWhitelist` already restricts which resource kinds can be deployed; no new kinds are added by this change, so the additional blast radius is bounded.
+- Issue #109 relationship: fixing the AppProject namespace gap resolves the Degraded health signal caused by sync failures. Residual Degraded health from optional-module ExternalSecrets being NotReady (e.g. postgres-runtime-credentials when Postgres is not seeded) is a separate root cause tracked in issue #137.
+
+## Explicit Exclusions
+- Expanding `namespaceResourceWhitelist` with new resource kinds for `external-secrets`
+- Optional-module ExternalSecret conditional deployment (postgres-runtime-credentials etc.) — issue #137
+- Changes to `clusterResourceWhitelist`
+
+## Blueprint Upstream Defect Escalation (Normative)
+- Upstream issue URL: none (this IS the upstream fix)
+- Temporary workaround path: none
+- Replacement trigger: none
+- Workaround review date: none
+
+## Out of Scope
+- Optional-module ExternalSecret conditional deployment (`postgres-runtime-credentials` NotReady when Postgres not seeded) — tracked in issue #137.
+- Expanding `namespaceResourceWhitelist` with new resource kinds for `external-secrets`.

--- a/specs/2026-04-22-issue-108-109-argocd-appproject-namespace-policy/tasks.md
+++ b/specs/2026-04-22-issue-108-109-argocd-appproject-namespace-policy/tasks.md
@@ -1,0 +1,44 @@
+# Tasks
+
+## Gate Checks (Required Before Implementation)
+- [x] G-001 Confirm `SPEC_READY=true` in `spec.md`
+- [x] G-002 Confirm open questions and unresolved alternatives are `0`
+- [x] G-003 Confirm required sign-offs are approved
+- [x] G-004 Confirm `Applicable Guardrail Controls` section includes `SDD-C-###` IDs
+- [x] G-005 Confirm `Implementation Stack Profile` section is fully populated
+
+## Slice 1 — Guard test (red)
+- [x] T-101 Add failing guard tests in `tests/infra/test_tooling_contracts.py` class `AppProjectNamespacePolicyTests`: assert `external-secrets` is present in destinations of all four overlay AppProject files and the bootstrap template copy
+
+## Slice 2 — Manifest fix (green)
+- [x] T-001 Add `external-secrets` destination to `infra/gitops/argocd/overlays/local/appproject.yaml`
+- [x] T-002 Add `external-secrets` destination to `infra/gitops/argocd/overlays/dev/appproject.yaml`
+- [x] T-003 Add `external-secrets` destination to `infra/gitops/argocd/overlays/stage/appproject.yaml`
+- [x] T-004 Add `external-secrets` destination to `infra/gitops/argocd/overlays/prod/appproject.yaml`
+- [x] T-005 Add `external-secrets` destination to `scripts/templates/infra/bootstrap/infra/gitops/argocd/overlays/local/appproject.yaml`
+- [x] T-102 Confirm guard tests pass after manifest fix
+
+## Slice 3 — ADR, governance, publish
+- [x] T-006 Write ADR at `docs/blueprint/architecture/decisions/ADR-20260422-issue-108-109-argocd-appproject-namespace-policy.md`
+- [x] T-007 Update `AGENTS.decisions.md`
+- [x] T-008 Update `AGENTS.backlog.md`: mark #108, #109 items done
+
+## Validation and Release Readiness
+- [x] T-201 Run `make infra-contract-test-fast` — green (94 passed, 2 subtests passed)
+- [x] T-202 Run `make quality-hooks-fast` — green
+- [x] T-203 Run `make infra-validate` — green
+- [x] T-204 Attach test output evidence to `traceability.md`
+- [x] T-205 Run `make quality-hardening-review` — green
+
+## Publish
+- [x] P-001 Update `hardening_review.md`
+- [x] P-002 Update `pr_context.md`
+- [ ] P-003 Open PR referencing issues #108 and #109
+
+## App Onboarding Minimum Targets (Normative)
+No app delivery scope affected; all targets below remain unaffected by this work item.
+- [x] A-001 `apps-bootstrap` and `apps-smoke` — unaffected
+- [x] A-002 `backend-test-unit`, `backend-test-integration`, `backend-test-contracts`, `backend-test-e2e` — unaffected
+- [x] A-003 `touchpoints-test-unit`, `touchpoints-test-integration`, `touchpoints-test-contracts`, `touchpoints-test-e2e` — unaffected
+- [x] A-004 `test-unit-all`, `test-integration-all`, `test-contracts-all`, `test-e2e-all-local` — unaffected
+- [x] A-005 `infra-port-forward-start`, `infra-port-forward-stop`, `infra-port-forward-cleanup` — unaffected

--- a/specs/2026-04-22-issue-108-109-argocd-appproject-namespace-policy/traceability.md
+++ b/specs/2026-04-22-issue-108-109-argocd-appproject-namespace-policy/traceability.md
@@ -1,0 +1,46 @@
+# Traceability Matrix
+
+## Requirement-to-Delivery Mapping
+
+| Requirement ID | Control IDs | Design Element | Implementation Path(s) | Test Evidence | Documentation Evidence | Operational Evidence |
+|---|---|---|---|---|---|---|
+| FR-001 | SDD-C-005, SDD-C-007 | `external-secrets` destination in all AppProject overlays | `infra/gitops/argocd/overlays/*/appproject.yaml` (×4), `scripts/templates/infra/bootstrap/.../appproject.yaml` | `AppProjectNamespacePolicyTests` | ADR | ArgoCD sync result |
+| FR-002 | SDD-C-005, SDD-C-012 | Guard test class `AppProjectNamespacePolicyTests` | `tests/infra/test_tooling_contracts.py` | guard fails before fix, passes after | — | `make infra-contract-test-fast` |
+| FR-003 | SDD-C-005, SDD-C-012 | Guard covers all five AppProject files | `tests/infra/test_tooling_contracts.py` | `AppProjectNamespacePolicyTests` | — | `make infra-contract-test-fast` |
+| NFR-SEC-001 | SDD-C-009 | no new resource kinds in whitelist | `infra/gitops/argocd/overlays/*/appproject.yaml` | test suite clean | — | — |
+| NFR-OPS-001 | SDD-C-012 | assertFalse message names file and namespace | `tests/infra/test_tooling_contracts.py` | guard failure message | — | `make infra-contract-test-fast` |
+| AC-001 | SDD-C-012 | five AppProject files contain external-secrets destination | five AppProject YAML files | guard test | — | — |
+| AC-002 | SDD-C-012 | infra-contract-test-fast passes | test suite | 94 passed, 2 subtests passed | — | `make infra-contract-test-fast` |
+| AC-003 | SDD-C-012 | guard fails when external-secrets removed | `tests/infra/test_tooling_contracts.py` | guard pre-fix failure confirmed | — | — |
+| AC-004 | SDD-C-012 | infra-validate passes | `scripts/bin/infra/validate.sh` | `make infra-validate` | — | `make infra-validate` |
+| AC-005 | SDD-C-007 | AppProject namespace policy resolved | five AppProject YAML files | guard green | ADR | ArgoCD sync |
+| AC-006 | SDD-C-007 | platform-local-core health resolves | five AppProject YAML files | — | — | ArgoCD health check |
+
+## Graph Linkage
+- Graph file: `graph.json`
+- Every `FR-###`, `NFR-*-###`, and `AC-###` listed in this file MUST have a corresponding node in `graph.json`.
+- Node IDs referenced:
+  - FR-001, FR-002, FR-003
+  - NFR-SEC-001, NFR-OPS-001
+  - AC-001, AC-002, AC-003, AC-004, AC-005, AC-006
+
+## Validation Summary
+- Required bundles executed: all green
+- Result summary:
+  - `python3 -m pytest tests/infra/test_tooling_contracts.py::AppProjectNamespacePolicyTests -v` → 1 passed (guard red before fix, green after)
+  - `make infra-contract-test-fast` → 94 passed, 2 subtests passed
+  - `make infra-validate` → contract validation passed
+  - `make quality-hooks-fast` → pass
+  - `make quality-hardening-review` → pass
+- Documentation validation:
+  - `make quality-hooks-fast` → pass
+  - `make infra-validate` → pass
+
+## Evidence Manifest
+- Manifest file: `evidence_manifest.json`
+- Context export: `context_pack.md`
+- PR context export: `pr_context.md`
+- Hardening review export: `hardening_review.md`
+
+## Open Risks and Follow-Ups
+- Follow-up 1: optional-module ExternalSecrets (postgres-runtime-credentials, etc.) deployed unconditionally from platform base may still show NotReady when the module is not seeded, keeping platform-local-core Health: Degraded. Tracked in issue #137.

--- a/specs/2026-04-22-issue-108-109-argocd-appproject-namespace-policy/traceability.md
+++ b/specs/2026-04-22-issue-108-109-argocd-appproject-namespace-policy/traceability.md
@@ -4,12 +4,12 @@
 
 | Requirement ID | Control IDs | Design Element | Implementation Path(s) | Test Evidence | Documentation Evidence | Operational Evidence |
 |---|---|---|---|---|---|---|
-| FR-001 | SDD-C-005, SDD-C-007 | `external-secrets` destination in all AppProject overlays | `infra/gitops/argocd/overlays/*/appproject.yaml` (×4), `scripts/templates/infra/bootstrap/.../appproject.yaml` | `AppProjectNamespacePolicyTests` | ADR | ArgoCD sync result |
+| FR-001 | SDD-C-005, SDD-C-007 | `external-secrets` destination in all AppProject overlays | `infra/gitops/argocd/overlays/*/appproject.yaml` (×4), `scripts/templates/infra/bootstrap/.../appproject.yaml` (×4) | `AppProjectNamespacePolicyTests` | ADR | ArgoCD sync result |
 | FR-002 | SDD-C-005, SDD-C-012 | Guard test class `AppProjectNamespacePolicyTests` | `tests/infra/test_tooling_contracts.py` | guard fails before fix, passes after | — | `make infra-contract-test-fast` |
 | FR-003 | SDD-C-005, SDD-C-012 | Guard covers all five AppProject files | `tests/infra/test_tooling_contracts.py` | `AppProjectNamespacePolicyTests` | — | `make infra-contract-test-fast` |
 | NFR-SEC-001 | SDD-C-009 | no new resource kinds in whitelist | `infra/gitops/argocd/overlays/*/appproject.yaml` | test suite clean | — | — |
 | NFR-OPS-001 | SDD-C-012 | assertFalse message names file and namespace | `tests/infra/test_tooling_contracts.py` | guard failure message | — | `make infra-contract-test-fast` |
-| AC-001 | SDD-C-012 | five AppProject files contain external-secrets destination | five AppProject YAML files | guard test | — | — |
+| AC-001 | SDD-C-012 | eight AppProject files contain external-secrets destination | four live overlays + four bootstrap template overlays | guard test | — | — |
 | AC-002 | SDD-C-012 | infra-contract-test-fast passes | test suite | 94 passed, 2 subtests passed | — | `make infra-contract-test-fast` |
 | AC-003 | SDD-C-012 | guard fails when external-secrets removed | `tests/infra/test_tooling_contracts.py` | guard pre-fix failure confirmed | — | — |
 | AC-004 | SDD-C-012 | infra-validate passes | `scripts/bin/infra/validate.sh` | `make infra-validate` | — | `make infra-validate` |

--- a/tests/infra/test_tooling_contracts.py
+++ b/tests/infra/test_tooling_contracts.py
@@ -2239,6 +2239,9 @@ class AppProjectNamespacePolicyTests(unittest.TestCase):
         "infra/gitops/argocd/overlays/stage/appproject.yaml",
         "infra/gitops/argocd/overlays/prod/appproject.yaml",
         "scripts/templates/infra/bootstrap/infra/gitops/argocd/overlays/local/appproject.yaml",
+        "scripts/templates/infra/bootstrap/infra/gitops/argocd/overlays/dev/appproject.yaml",
+        "scripts/templates/infra/bootstrap/infra/gitops/argocd/overlays/stage/appproject.yaml",
+        "scripts/templates/infra/bootstrap/infra/gitops/argocd/overlays/prod/appproject.yaml",
     ]
     _REQUIRED_NAMESPACE = "external-secrets"
 

--- a/tests/infra/test_tooling_contracts.py
+++ b/tests/infra/test_tooling_contracts.py
@@ -971,7 +971,10 @@ printf 'postgres=%s\\n' "$(is_module_enabled postgres && echo true || echo false
 printf 'public_endpoints=%s\\n' "$(is_module_enabled public-endpoints && echo true || echo false)"
 printf 'enabled_modules=%s\\n' "$(enabled_modules_csv)"
 """
-        result = run(["bash", "-lc", script], env)
+        effective_env = {"ROOT_DIR": str(repo_root)}
+        if env:
+            effective_env.update(env)
+        result = run(["bash", "-lc", script], effective_env)
         if result.returncode != 0:
             raise AssertionError(result.stdout + result.stderr)
         return result.stdout + result.stderr
@@ -2221,6 +2224,46 @@ class PlatformPythonHelperGuardTests(unittest.TestCase):
         result = run(["python3", "scripts/bin/quality/check_infra_shell_source_graph.py"])
         self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
         self.assertIn("quality-infra-shell-source-graph-check", result.stdout)
+
+
+class AppProjectNamespacePolicyTests(unittest.TestCase):
+    """Guard: all ArgoCD AppProject overlays MUST include external-secrets in destinations.
+
+    FR-002, FR-003: infra-contract-test-fast must fail when any AppProject overlay is
+    missing external-secrets from its spec.destinations list.
+    """
+
+    _APPPROJECT_PATHS = [
+        "infra/gitops/argocd/overlays/local/appproject.yaml",
+        "infra/gitops/argocd/overlays/dev/appproject.yaml",
+        "infra/gitops/argocd/overlays/stage/appproject.yaml",
+        "infra/gitops/argocd/overlays/prod/appproject.yaml",
+        "scripts/templates/infra/bootstrap/infra/gitops/argocd/overlays/local/appproject.yaml",
+    ]
+    _REQUIRED_NAMESPACE = "external-secrets"
+
+    def _destination_namespaces(self, appproject_path: Path) -> list[str]:
+        import yaml as _yaml
+        doc = _yaml.safe_load(appproject_path.read_text())
+        destinations = doc.get("spec", {}).get("destinations", [])
+        return [d.get("namespace", "") for d in destinations]
+
+    def test_all_appproject_overlays_include_external_secrets_destination(self) -> None:
+        """T-101: every AppProject file must allow external-secrets as a destination namespace."""
+        missing: list[str] = []
+        for rel in self._APPPROJECT_PATHS:
+            path = REPO_ROOT / rel
+            self.assertTrue(path.is_file(), msg=f"AppProject file not found: {rel}")
+            namespaces = self._destination_namespaces(path)
+            if self._REQUIRED_NAMESPACE not in namespaces:
+                missing.append(rel)
+        self.assertFalse(
+            missing,
+            msg=(
+                f"AppProject files missing '{self._REQUIRED_NAMESPACE}' in spec.destinations: "
+                + ", ".join(missing)
+            ),
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Fixes #108 — `external-secrets` namespace was missing from `spec.destinations` in all four ArgoCD AppProject overlay files and the bootstrap template copy, blocking ESO-managed RBAC resources from syncing
- Partially fixes #109 — resolves cause #1 (AppProject sync blocking); cause #2 (optional-module ESOs NotReady when modules are not seeded) is tracked separately in #137
- Adds `AppProjectNamespacePolicyTests` guard in `test_tooling_contracts.py` to prevent regression
- Adds `test_tooling_contracts.py` to `base_tests` in `contract_test_fast.sh` so the guard runs in both `template-source` and `generated-consumer` modes
- Fixes test isolation: `profile_module_enablement_contract` now passes `ROOT_DIR` pointing to the temp repo root so `profile.sh` resolves the patched contract rather than inheriting `ROOT_DIR` from the `make` process environment

## Test plan
- [x] `make infra-contract-test-fast` → 94 passed, 2 subtests passed
- [x] `make quality-hooks-fast` → pass
- [x] `make quality-hardening-review` → pass
- [x] `make infra-validate` → contract validation passed
- [x] Guard test `test_all_appproject_overlays_include_external_secrets_destination` passes after fix; would fail before fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)