### PR TITLE
fix(issue-189): wire prune-glob enforcement into pipeline Stage 9 and residual report

### DIFF
--- a/.agents/skills/blueprint-consumer-upgrade/SKILL.md
+++ b/.agents/skills/blueprint-consumer-upgrade/SKILL.md
@@ -145,6 +145,13 @@ Keycloak is not an optional module. It is always rendered in `infra/gitops/argoc
   exit signals a behavioral regression and the upgrade MUST NOT be declared complete until it is resolved.
   The symbol resolver suppresses case-label alternation tokens (`token|)`) and bare-word elements inside
   `local`/`declare`/`readonly`/`typeset` array blocks (`var=(`) to prevent false positives.
+- Treat prune-glob violations as blocking — `make blueprint-upgrade-consumer-validate` (called in
+  pipeline Stage 9) exits non-zero when files matching `source_artifact_prune_globs_on_init` are present
+  in the consumer repo. The canonical prune globs are:
+    - `specs/[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]-*` — blueprint work-item spec directories
+    - `docs/blueprint/architecture/decisions/ADR-*.md` — blueprint-internal ADR documents
+  Remove any matching files before re-running the pipeline or postcheck. Violations also appear in
+  `artifacts/blueprint/upgrade-residual.md` with a prescribed **Remove** action.
 - Preserve consumer-owned files; do not force overwrite unless the user explicitly asks.
 - Keep source and ref pinned for the whole run (`BLUEPRINT_UPGRADE_SOURCE` + `BLUEPRINT_UPGRADE_REF`).
 - Safe-to-continue contract: proceed only when `make blueprint-upgrade-consumer-postcheck` exits `0` AND `make blueprint-upgrade-fresh-env-gate` exits `0`. Both must pass before the upgrade is declared complete.

--- a/scripts/bin/blueprint/upgrade_consumer_pipeline.sh
+++ b/scripts/bin/blueprint/upgrade_consumer_pipeline.sh
@@ -166,7 +166,7 @@ log_info "[PIPELINE] Stage 8: complete"
 # ---------------------------------------------------------------------------
 # Stage 9 — Gate chain
 # ---------------------------------------------------------------------------
-log_info "[PIPELINE] Stage 9: starting — gate chain (infra-validate + quality-hooks-run)"
+log_info "[PIPELINE] Stage 9: starting — gate chain (infra-validate + quality-hooks-run + blueprint-upgrade-consumer-validate)"
 stage9_rc=0
 make -C "$ROOT_DIR" infra-validate || stage9_rc=$?
 if [[ "$stage9_rc" -ne 0 ]]; then
@@ -177,6 +177,13 @@ else
   if [[ "$stage9_rc" -ne 0 ]]; then
     pipeline_exit=$stage9_rc
     log_error "[PIPELINE] Stage 9: quality-hooks-run FAILED (exit $stage9_rc)"
+  else
+    # Run validate to scan for prune-glob violations; result surfaces in Stage 10 residual report.
+    make -C "$ROOT_DIR" blueprint-upgrade-consumer-validate || stage9_rc=$?
+    if [[ "$stage9_rc" -ne 0 ]]; then
+      pipeline_exit=$stage9_rc
+      log_error "[PIPELINE] Stage 9: blueprint-upgrade-consumer-validate FAILED (exit $stage9_rc) — prune-glob violations or merge markers detected; see artifacts/blueprint/upgrade_validate.json"
+    fi
   fi
 fi
 # Stage 10 (residual report) is always executed via the EXIT trap above.

--- a/scripts/lib/blueprint/upgrade_residual_report.py
+++ b/scripts/lib/blueprint/upgrade_residual_report.py
@@ -1,7 +1,7 @@
 """Stage 10: Residual report generator for the scripted upgrade pipeline.
 
 Always emitted — even on partial failure — via the pipeline's EXIT trap.
-Aggregates JSON artifacts from Stages 3, 5, 7 plus the reconcile report
+Aggregates JSON artifacts from Stages 3, 5, 7, 9 plus the reconcile report
 and a pyramid gap scan to produce artifacts/blueprint/upgrade-residual.md.
 
 Every item in the report includes a prescribed action (FR-016).
@@ -22,6 +22,7 @@ from pathlib import Path
 _CONTRACT_DECISIONS = "artifacts/blueprint/contract_resolve_decisions.json"
 _RECONCILE_REPORT = "artifacts/blueprint/upgrade/upgrade_reconcile_report.json"
 _DOC_CHECK = "artifacts/blueprint/doc_target_check.json"
+_VALIDATE_REPORT = "artifacts/blueprint/upgrade_validate.json"
 _RESIDUAL_MD = "artifacts/blueprint/upgrade-residual.md"
 _PYRAMID_CONTRACT = "scripts/lib/quality/test_pyramid_contract.json"
 
@@ -87,6 +88,7 @@ def generate_residual_report(repo_root: Path, pipeline_exit: int = 0) -> None:
     decisions = _load_json_safe(repo_root / _CONTRACT_DECISIONS)
     reconcile = _load_json_safe(repo_root / _RECONCILE_REPORT)
     doc_check = _load_json_safe(repo_root / _DOC_CHECK)
+    validate = _load_json_safe(repo_root / _VALIDATE_REPORT)
     pyramid_gaps = _scan_pyramid_gaps(repo_root)
 
     dropped_required = decisions.get("dropped_required_files", [])
@@ -95,6 +97,10 @@ def generate_residual_report(repo_root: Path, pipeline_exit: int = 0) -> None:
         (reconcile.get("buckets") or {}).get("consumer_owned_manual_review", [])
     )
     missing_targets = doc_check.get("missing_targets", [])
+    prune_glob_check = validate.get("prune_glob_check", {})
+    prune_glob_violations: list[dict] = prune_glob_check.get("violations", [])
+    if not isinstance(prune_glob_violations, list):
+        prune_glob_violations = []
 
     lines: list[str] = [
         "# Upgrade Residual Report",
@@ -179,6 +185,29 @@ def generate_residual_report(repo_root: Path, pipeline_exit: int = 0) -> None:
             lines.append(f"- `make {target}` — **Add**: declare `{target}` in the appropriate `.mk` file with a `.PHONY` entry.")
     else:
         lines.append("_None — all make targets referenced in docs are declared._")
+    lines.append("")
+
+    # Prune-glob violations: files matching source_artifact_prune_globs_on_init that must be removed
+    lines += [
+        "## Prune-Glob Violations — Blueprint-Internal Files in Consumer Repo",
+        "",
+    ]
+    if prune_glob_violations:
+        lines.append(
+            "The following files match `source_artifact_prune_globs_on_init` and must not exist "
+            "in generated-consumer repos. Remove them before re-running "
+            "`make blueprint-upgrade-consumer-postcheck`."
+        )
+        lines.append("")
+        for entry in prune_glob_violations:
+            path = entry.get("path", str(entry)) if isinstance(entry, dict) else str(entry)
+            matched = entry.get("matched_glob", "") if isinstance(entry, dict) else ""
+            if matched:
+                lines.append(f"- `{path}` (matches `{matched}`) — **Remove**: delete this file; it is a blueprint-internal artifact forbidden in consumer repos.")
+            else:
+                lines.append(f"- `{path}` — **Remove**: delete this file; it is a blueprint-internal artifact forbidden in consumer repos.")
+    else:
+        lines.append("_None — no files matching prune globs were found in the working tree._")
     lines.append("")
 
     # FR-018: Pyramid classification gaps

--- a/scripts/lib/blueprint/upgrade_residual_report.py
+++ b/scripts/lib/blueprint/upgrade_residual_report.py
@@ -88,6 +88,7 @@ def generate_residual_report(repo_root: Path, pipeline_exit: int = 0) -> None:
     decisions = _load_json_safe(repo_root / _CONTRACT_DECISIONS)
     reconcile = _load_json_safe(repo_root / _RECONCILE_REPORT)
     doc_check = _load_json_safe(repo_root / _DOC_CHECK)
+    validate_report_exists = (repo_root / _VALIDATE_REPORT).exists()
     validate = _load_json_safe(repo_root / _VALIDATE_REPORT)
     pyramid_gaps = _scan_pyramid_gaps(repo_root)
 
@@ -98,6 +99,8 @@ def generate_residual_report(repo_root: Path, pipeline_exit: int = 0) -> None:
     )
     missing_targets = doc_check.get("missing_targets", [])
     prune_glob_check = validate.get("prune_glob_check", {})
+    prune_glob_scan_ran = validate_report_exists and bool(prune_glob_check)
+    prune_glob_status = prune_glob_check.get("status", "")
     prune_glob_violations: list[dict] = prune_glob_check.get("violations", [])
     if not isinstance(prune_glob_violations, list):
         prune_glob_violations = []
@@ -192,7 +195,15 @@ def generate_residual_report(repo_root: Path, pipeline_exit: int = 0) -> None:
         "## Prune-Glob Violations — Blueprint-Internal Files in Consumer Repo",
         "",
     ]
-    if prune_glob_violations:
+    if not prune_glob_scan_ran:
+        lines.append(
+            "_Scan not run — `upgrade_validate.json` was not produced. "
+            "Stage 9 may have failed before `make blueprint-upgrade-consumer-validate` executed. "
+            "Re-run the pipeline or run `make blueprint-upgrade-consumer-validate` directly to check._"
+        )
+    elif prune_glob_status == "skipped":
+        lines.append("_Skipped — repo is not a generated-consumer; prune-glob check does not apply._")
+    elif prune_glob_violations:
         lines.append(
             "The following files match `source_artifact_prune_globs_on_init` and must not exist "
             "in generated-consumer repos. Remove them before re-running "

--- a/tests/blueprint/test_upgrade_pipeline.py
+++ b/tests/blueprint/test_upgrade_pipeline.py
@@ -1158,18 +1158,21 @@ class TestResidualReportPruneGlobViolations(unittest.TestCase):
             # When no violations, should say none or just not list any paths
             self.assertNotIn("ADR-", report)
 
-    def test_residual_report_works_when_validate_report_absent(self) -> None:
+    def test_residual_report_shows_scan_not_run_when_validate_report_absent(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             repo = Path(tmpdir)
             _write_decisions_json(repo, {"dropped_required_files": [], "dropped_prune_globs": [], "kept_consumer_required_files": []})
             _write_reconcile_report(repo, [])
             _write_doc_check_warnings(repo, [])
-            # No upgrade_validate.json written
+            # No upgrade_validate.json written — simulates Stage 9 failure before validate ran
 
-            generate_residual_report(repo, pipeline_exit=0)
+            generate_residual_report(repo, pipeline_exit=1)
 
-            report_path = repo / "artifacts/blueprint/upgrade-residual.md"
-            self.assertTrue(report_path.exists())
+            report = (repo / "artifacts/blueprint/upgrade-residual.md").read_text(encoding="utf-8")
+            self.assertTrue((repo / "artifacts/blueprint/upgrade-residual.md").exists())
+            # Must NOT claim "no violations found" — scan did not run
+            self.assertNotIn("no files matching prune globs were found", report)
+            self.assertIn("Scan not run", report)
 
     def test_pipeline_stage9_calls_validate(self) -> None:
         script = _PIPELINE_SCRIPT.read_text(encoding="utf-8")

--- a/tests/blueprint/test_upgrade_pipeline.py
+++ b/tests/blueprint/test_upgrade_pipeline.py
@@ -1090,6 +1090,96 @@ class TestAllowDeletePropagation(unittest.TestCase):
         self.assertIn("allow_delete", script)
 
 
+class TestResidualReportPruneGlobViolations(unittest.TestCase):
+    """Stage 10 residual report must surface prune-glob violations from upgrade_validate.json."""
+
+    def _write_validate_report(self, repo: Path, violations: list[dict]) -> None:
+        path = repo / "artifacts/blueprint/upgrade_validate.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps({
+                "prune_glob_check": {
+                    "status": "failure" if violations else "ok",
+                    "globs_checked": 2,
+                    "violation_count": len(violations),
+                    "violations": violations,
+                    "remediation_hint": "Remove files listed under violations.",
+                }
+            }),
+            encoding="utf-8",
+        )
+
+    def test_prune_glob_violations_appear_in_residual_report(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = Path(tmpdir)
+            _write_decisions_json(repo, {"dropped_required_files": [], "dropped_prune_globs": [], "kept_consumer_required_files": []})
+            _write_reconcile_report(repo, [])
+            _write_doc_check_warnings(repo, [])
+            self._write_validate_report(repo, [
+                {"path": "docs/blueprint/architecture/decisions/ADR-001.md", "matched_glob": "docs/blueprint/architecture/decisions/ADR-*.md"},
+                {"path": "specs/2026-01-01-some-spec/spec.md", "matched_glob": "specs/[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]-*"},
+            ])
+
+            generate_residual_report(repo, pipeline_exit=0)
+
+            report = (repo / "artifacts/blueprint/upgrade-residual.md").read_text(encoding="utf-8")
+            self.assertIn("ADR-001.md", report)
+            self.assertIn("specs/2026-01-01-some-spec/spec.md", report)
+            self.assertIn("Remove", report)
+
+    def test_prune_glob_violations_have_prescribed_remove_action(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = Path(tmpdir)
+            _write_decisions_json(repo, {"dropped_required_files": [], "dropped_prune_globs": [], "kept_consumer_required_files": []})
+            _write_reconcile_report(repo, [])
+            _write_doc_check_warnings(repo, [])
+            self._write_validate_report(repo, [
+                {"path": "docs/blueprint/architecture/decisions/ADR-042.md", "matched_glob": "docs/blueprint/architecture/decisions/ADR-*.md"},
+            ])
+
+            generate_residual_report(repo, pipeline_exit=0)
+
+            report = (repo / "artifacts/blueprint/upgrade-residual.md").read_text(encoding="utf-8")
+            # Every violation must have a prescribed "Remove" action
+            self.assertIn("ADR-042.md", report)
+            self.assertIn("Remove", report)
+
+    def test_residual_report_omits_prune_glob_section_when_no_violations(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = Path(tmpdir)
+            _write_decisions_json(repo, {"dropped_required_files": [], "dropped_prune_globs": [], "kept_consumer_required_files": []})
+            _write_reconcile_report(repo, [])
+            _write_doc_check_warnings(repo, [])
+            self._write_validate_report(repo, [])
+
+            generate_residual_report(repo, pipeline_exit=0)
+
+            report = (repo / "artifacts/blueprint/upgrade-residual.md").read_text(encoding="utf-8")
+            # When no violations, should say none or just not list any paths
+            self.assertNotIn("ADR-", report)
+
+    def test_residual_report_works_when_validate_report_absent(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = Path(tmpdir)
+            _write_decisions_json(repo, {"dropped_required_files": [], "dropped_prune_globs": [], "kept_consumer_required_files": []})
+            _write_reconcile_report(repo, [])
+            _write_doc_check_warnings(repo, [])
+            # No upgrade_validate.json written
+
+            generate_residual_report(repo, pipeline_exit=0)
+
+            report_path = repo / "artifacts/blueprint/upgrade-residual.md"
+            self.assertTrue(report_path.exists())
+
+    def test_pipeline_stage9_calls_validate(self) -> None:
+        script = _PIPELINE_SCRIPT.read_text(encoding="utf-8")
+        self.assertIn(
+            "blueprint-upgrade-consumer-validate",
+            script,
+            "Stage 9 must call make blueprint-upgrade-consumer-validate so prune-glob violations block the pipeline",
+        )
+
+
 class TestNoConsumerSpecificHardcoding(unittest.TestCase):
     """NFR-OPS-001: no consumer-specific logic (names, module lists, skill dirs) in pipeline scripts."""
 


### PR DESCRIPTION
## Summary

Three gaps remained after PR #190 (prune-glob enforcement) was merged and PR #193 (scripted pipeline) rewrote the pipeline entry script and SKILL.md without preserving the prune-glob wiring:

- **Pipeline Stage 9** did not call `make blueprint-upgrade-consumer-validate`, so prune-glob violations from apply were invisible to the pipeline and only caught when the operator explicitly ran postcheck. Stage 9 now calls `blueprint-upgrade-consumer-validate` after `quality-hooks-run`.
- **Stage 10 residual report** (`upgrade_residual_report.py`) did not read `upgrade_validate.json`. It now loads `prune_glob_check.violations` and emits a **Prune-Glob Violations** section with a prescribed **Remove** action per file, matching FR-016 (every residual item has a prescribed action).
- **SKILL.md Required Checks** dropped step 7a from the pipeline rewrite. The section now explicitly lists the canonical glob patterns (`specs/YYYY-MM-DD-*` and `docs/blueprint/architecture/decisions/ADR-*.md`) and the Remove instruction.

5 new unit tests; 475 total blueprint tests pass; `make quality-hooks-fast` passes.

Closes #189.

## Test plan

- [x] `python3 -m pytest tests/blueprint/test_upgrade_pipeline.py::TestResidualReportPruneGlobViolations -v` — 5 tests pass
- [x] `python3 -m pytest tests/blueprint/ -q` — 475 tests, 0 failures
- [x] `make quality-hooks-fast` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)