### PR TITLE
chore: mark dns module ✅ in issue #248 backlog (PR #306 merged)

### DIFF
--- a/AGENTS.backlog.md
+++ b/AGENTS.backlog.md
@@ -59,7 +59,7 @@ To introduce a new tag, append a row here in the same commit that uses it.
 
 ### P2 — Platform modules
 
-- [ ] Issue #248 remaining modules — STACKIT-managed service candidates (kms ✅, secrets-manager ✅ PR #305, dns SPEC_READY PR #306, public-endpoints ✅ PR #307, observability ✅ PR #308, workflows, identity-aware-proxy). Gate on #295 removed — architecture decision recorded in `AGENTS.decisions.md`: OM is consumer/product-owned and not a blueprint module candidate.
+- [ ] Issue #248 remaining modules — STACKIT-managed service candidates (kms ✅, secrets-manager ✅ PR #305, dns ✅ PR #306, public-endpoints ✅ PR #307, observability ✅ PR #308, workflows, identity-aware-proxy). Gate on #295 removed — architecture decision recorded in `AGENTS.decisions.md`: OM is consumer/product-owned and not a blueprint module candidate.
 - [ ] Issue #171 — managed-cache module: STACKIT Managed Redis as a first-class optional module (Helm/ArgoCD-managed, provider-backed via STACKIT Terraform).
 - [ ] Issue #172 — platform-email module: Helm/ArgoCD-managed Postal for transactional email as an optional module.
 


### PR DESCRIPTION
Housekeeping — updates the issue #248 module tracking line in AGENTS.backlog.md: `dns SPEC_READY PR #306` → `dns ✅ PR #306` following the merge of PR #306.