### PR TITLE
chore: mark workflows done in backlog; commit stale issue-295 manifest

### DIFF
--- a/AGENTS.backlog.md
+++ b/AGENTS.backlog.md
@@ -59,7 +59,7 @@ To introduce a new tag, append a row here in the same commit that uses it.
 
 ### P2 — Platform modules
 
-- [ ] Issue #248 remaining modules — STACKIT-managed service candidates (kms ✅, secrets-manager ✅ PR #305, dns ✅ PR #306, public-endpoints ✅ PR #307, observability ✅ PR #308, workflows, identity-aware-proxy). Gate on #295 removed — architecture decision recorded in `AGENTS.decisions.md`: OM is consumer/product-owned and not a blueprint module candidate.
+- [ ] Issue #248 remaining modules — STACKIT-managed service candidates (kms ✅, secrets-manager ✅ PR #305, dns ✅ PR #306, public-endpoints ✅ PR #307, observability ✅ PR #308, workflows ✅ PR #314, identity-aware-proxy). Gate on #295 removed — architecture decision recorded in `AGENTS.decisions.md`: OM is consumer/product-owned and not a blueprint module candidate.
 - [ ] Issue #171 — managed-cache module: STACKIT Managed Redis as a first-class optional module (Helm/ArgoCD-managed, provider-backed via STACKIT Terraform).
 - [ ] Issue #172 — platform-email module: Helm/ArgoCD-managed Postal for transactional email as an optional module.
 

--- a/specs/2026-05-15-issue-295-remove-om-baseline/evidence_manifest.json
+++ b/specs/2026-05-15-issue-295-remove-om-baseline/evidence_manifest.json
@@ -1,0 +1,23 @@
+{
+  "manifest_version": 1,
+  "work_item": "specs/2026-05-15-issue-295-remove-om-baseline",
+  "generated_by": "spec-evidence-manifest",
+  "generated_at_utc": "2026-05-15T14:38:44Z",
+  "files": [
+    {
+      "path": "specs/2026-05-15-issue-295-remove-om-baseline/evidence_manifest.json",
+      "sha256": "130eac8680e45d75e11a0170eba9fe141404056e4597c4bd4ce46db6b6c2845e",
+      "bytes": 581
+    },
+    {
+      "path": "specs/2026-05-15-issue-295-remove-om-baseline/pr_context.md",
+      "sha256": "c90c418b0ca66c8e04592be2a39d61a84f56d541c2108e21bacf6922bbc655e1",
+      "bytes": 1765
+    },
+    {
+      "path": "specs/2026-05-15-issue-295-remove-om-baseline/spec.md",
+      "sha256": "7ad7db0d92f39e7744821806e5da593ccd815287c3af3b6ad583e7cd708d1b38",
+      "bytes": 3227
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- `AGENTS.backlog.md`: marks `workflows ✅ PR #314` — `identity-aware-proxy` is now the only remaining module in issue #248
- `specs/2026-05-15-issue-295-remove-om-baseline/evidence_manifest.json`: commits leftover untracked spec artifact from the issue-295 work item (PR already merged; manifest was generated but never committed)

## Test plan
- [ ] No functional changes — backlog tracking update and stale artifact cleanup only
- [ ] Pre-push gates passed (unit tests, infra-validate, quality hooks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)