### PR TITLE
chore(branch-naming): adopt semantic prefixes; retire codex/ as default

### DIFF
--- a/.agents/skills/blueprint-consumer-upgrade/SKILL.md
+++ b/.agents/skills/blueprint-consumer-upgrade/SKILL.md
@@ -26,7 +26,7 @@ The upgrade is fully scripted. The agent's role is: set the ref, run the pipelin
 
 ```bash
 # Step 1 — branch + resolve ref
-git checkout -b upgrade/blueprint-<tag>
+git checkout -b chore/blueprint-upgrade-<tag>
 ./.agents/skills/blueprint-consumer-upgrade/scripts/resolve_latest_stable_ref.sh
 # output: TAG=<tag>
 

--- a/.agents/skills/blueprint-sdd-step01-intake/SKILL.md
+++ b/.agents/skills/blueprint-sdd-step01-intake/SKILL.md
@@ -61,7 +61,7 @@ No local development environment is required beyond `make` and `gh` CLI access.
    Check whether the spec directory exists:
      ls specs/*-<slug>/ 2>/dev/null
    If the directory does not exist, run:
-     make spec-scaffold SPEC_SLUG=<slug> --branch <prefix>/YYYY-MM-DD-<slug>
+     make spec-scaffold SPEC_SLUG=<slug> SPEC_BRANCH=<prefix>/YYYY-MM-DD-<slug>
    where <prefix> is the semantic type that best describes the change:
      feature/   new capabilities or modules
      fix/       bug fixes or correctness repairs

--- a/.agents/skills/blueprint-sdd-step01-intake/SKILL.md
+++ b/.agents/skills/blueprint-sdd-step01-intake/SKILL.md
@@ -61,7 +61,12 @@ No local development environment is required beyond `make` and `gh` CLI access.
    Check whether the spec directory exists:
      ls specs/*-<slug>/ 2>/dev/null
    If the directory does not exist, run:
-     make spec-scaffold SPEC_SLUG=<slug>
+     make spec-scaffold SPEC_SLUG=<slug> --branch <prefix>/YYYY-MM-DD-<slug>
+   where <prefix> is the semantic type that best describes the change:
+     feature/   new capabilities or modules
+     fix/       bug fixes or correctness repairs
+     docs/      documentation-only changes
+     chore/     maintenance, cleanup, retroactive compliance
    If the directory already exists, skip this step — the user ran it manually.
 
 1. Confirm source requirements document(s) and scope boundaries.
@@ -120,7 +125,7 @@ BACKLOG SCAN (surface parked proposals before opening the Draft PR)
 
    git add specs/YYYY-MM-DD-<slug>/ docs/.../ADR-<slug>.md
    git commit -m "feat(<slug>): SDD intake — spec, architecture, plan ready for PO review"
-   git push -u origin codex/YYYY-MM-DD-<slug>
+   git push -u origin <prefix>/YYYY-MM-DD-<slug>
 
 10. Open Draft PR:
    gh pr create --draft \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,7 +101,7 @@ In keep-going mode, a single root cause (e.g. a syntax error in a shared helper)
 1. Read `AGENTS.md` before starting work.
 2. During `Discover`, `High-Level Architecture`, `Specify`, and `Plan`, do not use assumptions as substitutes for missing requirements; resolve ambiguity explicitly or mark the work item blocked.
 3. Spec-Driven Development is mandatory by default for assistant-executed work; bypass only when the user explicitly says not to follow SDD for the requested task.
-4. Start each new SDD work item with `make spec-scaffold ...`, which creates a dedicated non-default branch by default (`codex/<YYYY-MM-DD>-<slug>` unless overridden).
+4. Start each new SDD work item with `make spec-scaffold ...`, which creates a dedicated non-default branch by default (`<prefix>/<YYYY-MM-DD>-<slug>`). Choose the prefix that matches the change type: `feature/` for new capabilities, `fix/` for bug fixes, `docs/` for docs-only, `chore/` for maintenance. Pass `--branch <prefix>/YYYY-MM-DD-<slug>` to override the default (`feature/`).
 5. Execute the Spec-Driven Development lifecycle in this order: `Discover -> High-Level Architecture -> Specify -> Plan -> Implement -> Verify -> Document -> Operate -> Publish`.
 6. Implement with strict boundary contracts and deterministic behavior.
 7. Update/add automated tests for every behavior change.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,7 +101,7 @@ In keep-going mode, a single root cause (e.g. a syntax error in a shared helper)
 1. Read `AGENTS.md` before starting work.
 2. During `Discover`, `High-Level Architecture`, `Specify`, and `Plan`, do not use assumptions as substitutes for missing requirements; resolve ambiguity explicitly or mark the work item blocked.
 3. Spec-Driven Development is mandatory by default for assistant-executed work; bypass only when the user explicitly says not to follow SDD for the requested task.
-4. Start each new SDD work item with `make spec-scaffold ...`, which creates a dedicated non-default branch by default (`<prefix>/<YYYY-MM-DD>-<slug>`). Choose the prefix that matches the change type: `feature/` for new capabilities, `fix/` for bug fixes, `docs/` for docs-only, `chore/` for maintenance. Pass `--branch <prefix>/YYYY-MM-DD-<slug>` to override the default (`feature/`).
+4. Start each new SDD work item with `make spec-scaffold ...`, which creates a dedicated non-default branch by default (`<prefix>/<YYYY-MM-DD>-<slug>`). Choose the prefix that matches the change type: `feature/` for new capabilities, `fix/` for bug fixes, `docs/` for docs-only, `chore/` for maintenance. Pass `SPEC_BRANCH=<prefix>/YYYY-MM-DD-<slug>` to override the default (`feature/`).
 5. Execute the Spec-Driven Development lifecycle in this order: `Discover -> High-Level Architecture -> Specify -> Plan -> Implement -> Verify -> Document -> Operate -> Publish`.
 6. Implement with strict boundary contracts and deterministic behavior.
 7. Update/add automated tests for every behavior change.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Opinionated GitHub template for teams that want deterministic platform delivery 
 - SDD is default-required for assistant-executed work unless the user explicitly opts out for that task.
 - Start each new SDD work item from `specs/**` using:
   - `make spec-scaffold SPEC_SLUG=<work-item-slug>`
-  - default behavior creates and checks out a dedicated branch (`codex/<YYYY-MM-DD>-<slug>`)
+  - default behavior creates and checks out a dedicated branch (`<prefix>/<YYYY-MM-DD>-<slug>`, e.g. `feature/`)
   - explicit opt-out requires `SPEC_NO_BRANCH=true`
 - Keep `SPEC_READY=false` until requirements and sign-offs are explicit.
 - Run canonical validation before handoff/review:

--- a/blueprint/contract.yaml
+++ b/blueprint/contract.yaml
@@ -21,8 +21,6 @@ spec:
         - refactor/
         - test/
         - ci/
-        - codex/
-        - copilot/
     template_bootstrap:
       model: github-template
       template_version: 1.0.0
@@ -1343,7 +1341,7 @@ spec:
     branch_contract:
       dedicated_branch_required_by_default: true
       explicit_opt_out_flag: --no-create-branch
-      default_prefix: codex/
+      default_prefix: feature/
       branch_name_pattern: "<prefix><YYYY-MM-DD>-<work-item-slug>"
       enforce_non_default_branch: true
     artifacts:
@@ -1831,7 +1829,7 @@ spec:
           - infra-langfuse-smoke
           - infra-langfuse-destroy
       postgres:
-        enabled_by_default: false
+        enabled_by_default: true
         enable_flag: POSTGRES_ENABLED
         scaffolding_mode: conditional
         paths_required_when_enabled:
@@ -1946,7 +1944,7 @@ spec:
           - infra-dns-smoke
           - infra-dns-destroy
       public-endpoints:
-        enabled_by_default: false
+        enabled_by_default: true
         enable_flag: PUBLIC_ENDPOINTS_ENABLED
         scaffolding_mode: conditional
         paths_required_when_enabled:

--- a/blueprint/contract.yaml
+++ b/blueprint/contract.yaml
@@ -1829,7 +1829,7 @@ spec:
           - infra-langfuse-smoke
           - infra-langfuse-destroy
       postgres:
-        enabled_by_default: true
+        enabled_by_default: false
         enable_flag: POSTGRES_ENABLED
         scaffolding_mode: conditional
         paths_required_when_enabled:
@@ -1944,7 +1944,7 @@ spec:
           - infra-dns-smoke
           - infra-dns-destroy
       public-endpoints:
-        enabled_by_default: true
+        enabled_by_default: false
         enable_flag: PUBLIC_ENDPOINTS_ENABLED
         scaffolding_mode: conditional
         paths_required_when_enabled:

--- a/docs/blueprint/governance/quality_hooks.md
+++ b/docs/blueprint/governance/quality_hooks.md
@@ -127,7 +127,7 @@ bootstrap template) so the same drift guard applies after blueprint upgrade.
 
 ## Phase-Gating (Spec-Readiness Check)
 
-`quality-spec-pr-ready` is skipped on `codex/*` branches unless the current
+`quality-spec-pr-ready` is skipped on SDD branches (`<prefix>/YYYY-MM-DD-*`) unless the current
 spec's `spec.md` contains `- SPEC_READY: true`. This prevents false-positive
 failures during SDD Steps 1–6 when publish artifacts are intentionally scaffold.
 

--- a/docs/blueprint/governance/sdd_execution_guide.md
+++ b/docs/blueprint/governance/sdd_execution_guide.md
@@ -175,7 +175,7 @@ make spec-scaffold SPEC_SLUG=<work-item-slug>
 **What happens:**
 
 - Creates `specs/YYYY-MM-DD-<slug>/` with all required stub artifacts.
-- Checks out a dedicated branch `codex/YYYY-MM-DD-<slug>` automatically.
+- Checks out a dedicated branch `<prefix>/YYYY-MM-DD-<slug>` (e.g. `feature/`) automatically.
   Skip with `SPEC_NO_BRANCH=true` only when explicitly asked.
 
 **Artifacts created (stubs, populated in Step 1):**
@@ -297,7 +297,7 @@ open the Draft PR. This is the single PR for the entire work item.
 ```bash
 git add specs/YYYY-MM-DD-<slug>/ docs/.../ADR-<slug>.md
 git commit -m "feat(<slug>): SDD intake — spec, architecture, plan ready for PO review"
-git push -u origin codex/YYYY-MM-DD-<slug>
+git push -u origin <prefix>/YYYY-MM-DD-<slug>
 gh pr create --draft --title "feat(<slug>): ..." --body "..."
 ```
 

--- a/scripts/bin/blueprint/spec_scaffold.py
+++ b/scripts/bin/blueprint/spec_scaffold.py
@@ -110,8 +110,6 @@ def _branch_exists(repo_root: Path, branch: str) -> bool:
 def _resolve_branch_prefix(*, allowed_prefixes: list[str], preferred_prefix: str) -> str:
     if preferred_prefix and preferred_prefix in allowed_prefixes:
         return preferred_prefix
-    if "codex/" in allowed_prefixes:
-        return "codex/"
     if allowed_prefixes:
         return allowed_prefixes[0]
     raise ValueError("repository.branch_naming.purpose_prefixes must define at least one prefix")

--- a/scripts/bin/quality/check_spec_pr_ready.py
+++ b/scripts/bin/quality/check_spec_pr_ready.py
@@ -4,7 +4,7 @@
 Checks plan.md, tasks.md, hardening_review.md, and pr_context.md for
 unfilled scaffold placeholders. Resolves the active spec directory from
 SPEC_SLUG env var or the current git branch name (pattern:
-codex/YYYY-MM-DD-<slug>).
+<prefix>/YYYY-MM-DD-<slug> where prefix is any registered purpose prefix).
 
 Usage:
     make quality-spec-pr-ready
@@ -23,7 +23,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[3]
 PREFIX = "[quality-spec-pr-ready]"
 
-_SDD_BRANCH_PATTERN = re.compile(r"^codex/(\d{4}-\d{2}-\d{2}-.+)$")
+_SDD_BRANCH_PATTERN = re.compile(r"^[a-z][a-z0-9-]*/(\d{4}-\d{2}-\d{2}-.+)$")
 
 # Must stay in sync with _BYPASS_ALLOWED_VALUES in check_sdd_assets.py.
 _BYPASS_ALLOWED_VALUES: frozenset[str] = frozenset(
@@ -218,7 +218,7 @@ def _resolve_spec_dir(repo_root: Path) -> Path:
     if not match:
         print(
             f"{PREFIX} cannot resolve spec directory: branch '{branch}' does not match "
-            f"pattern codex/YYYY-MM-DD-<slug>; set SPEC_SLUG env var to override",
+            f"pattern <prefix>/YYYY-MM-DD-<slug>; set SPEC_SLUG env var to override",
             file=sys.stderr,
         )
         sys.exit(1)

--- a/scripts/bin/quality/hooks_fast.sh
+++ b/scripts/bin/quality/hooks_fast.sh
@@ -103,8 +103,8 @@ else
 fi
 
 _current_branch="$(git branch --show-current 2>/dev/null || true)"
-if [[ "$_current_branch" =~ ^codex/[0-9]{4}-[0-9]{2}-[0-9]{2}- ]]; then
-  _spec_slug="${_current_branch#codex/}"
+if [[ "$_current_branch" =~ ^[a-z][a-z0-9-]*/[0-9]{4}-[0-9]{2}-[0-9]{2}- ]]; then
+  _spec_slug="${_current_branch#*/}"
   _spec_dir="$ROOT_DIR/specs/$_spec_slug"
   if [[ -d "$_spec_dir" ]]; then
     if [[ "${QUALITY_HOOKS_FORCE_FULL:-}" == "true" ]] || quality_spec_is_ready "$_spec_dir"; then

--- a/scripts/templates/blueprint/bootstrap/blueprint/contract.yaml
+++ b/scripts/templates/blueprint/bootstrap/blueprint/contract.yaml
@@ -21,8 +21,6 @@ spec:
         - refactor/
         - test/
         - ci/
-        - codex/
-        - copilot/
     template_bootstrap:
       model: github-template
       template_version: 1.0.0
@@ -1343,7 +1341,7 @@ spec:
     branch_contract:
       dedicated_branch_required_by_default: true
       explicit_opt_out_flag: --no-create-branch
-      default_prefix: codex/
+      default_prefix: feature/
       branch_name_pattern: "<prefix><YYYY-MM-DD>-<work-item-slug>"
       enforce_non_default_branch: true
     artifacts:
@@ -1831,7 +1829,7 @@ spec:
           - infra-langfuse-smoke
           - infra-langfuse-destroy
       postgres:
-        enabled_by_default: false
+        enabled_by_default: true
         enable_flag: POSTGRES_ENABLED
         scaffolding_mode: conditional
         paths_required_when_enabled:
@@ -1946,7 +1944,7 @@ spec:
           - infra-dns-smoke
           - infra-dns-destroy
       public-endpoints:
-        enabled_by_default: false
+        enabled_by_default: true
         enable_flag: PUBLIC_ENDPOINTS_ENABLED
         scaffolding_mode: conditional
         paths_required_when_enabled:

--- a/scripts/templates/blueprint/bootstrap/blueprint/contract.yaml
+++ b/scripts/templates/blueprint/bootstrap/blueprint/contract.yaml
@@ -1829,7 +1829,7 @@ spec:
           - infra-langfuse-smoke
           - infra-langfuse-destroy
       postgres:
-        enabled_by_default: true
+        enabled_by_default: false
         enable_flag: POSTGRES_ENABLED
         scaffolding_mode: conditional
         paths_required_when_enabled:
@@ -1944,7 +1944,7 @@ spec:
           - infra-dns-smoke
           - infra-dns-destroy
       public-endpoints:
-        enabled_by_default: true
+        enabled_by_default: false
         enable_flag: PUBLIC_ENDPOINTS_ENABLED
         scaffolding_mode: conditional
         paths_required_when_enabled:

--- a/scripts/templates/blueprint/bootstrap/docs/blueprint/governance/quality_hooks.md
+++ b/scripts/templates/blueprint/bootstrap/docs/blueprint/governance/quality_hooks.md
@@ -127,7 +127,7 @@ bootstrap template) so the same drift guard applies after blueprint upgrade.
 
 ## Phase-Gating (Spec-Readiness Check)
 
-`quality-spec-pr-ready` is skipped on `codex/*` branches unless the current
+`quality-spec-pr-ready` is skipped on SDD branches (`<prefix>/YYYY-MM-DD-*`) unless the current
 spec's `spec.md` contains `- SPEC_READY: true`. This prevents false-positive
 failures during SDD Steps 1–6 when publish artifacts are intentionally scaffold.
 

--- a/scripts/templates/blueprint/bootstrap/docs/blueprint/governance/sdd_execution_guide.md
+++ b/scripts/templates/blueprint/bootstrap/docs/blueprint/governance/sdd_execution_guide.md
@@ -175,7 +175,7 @@ make spec-scaffold SPEC_SLUG=<work-item-slug>
 **What happens:**
 
 - Creates `specs/YYYY-MM-DD-<slug>/` with all required stub artifacts.
-- Checks out a dedicated branch `codex/YYYY-MM-DD-<slug>` automatically.
+- Checks out a dedicated branch `<prefix>/YYYY-MM-DD-<slug>` (e.g. `feature/`) automatically.
   Skip with `SPEC_NO_BRANCH=true` only when explicitly asked.
 
 **Artifacts created (stubs, populated in Step 1):**
@@ -297,7 +297,7 @@ open the Draft PR. This is the single PR for the entire work item.
 ```bash
 git add specs/YYYY-MM-DD-<slug>/ docs/.../ADR-<slug>.md
 git commit -m "feat(<slug>): SDD intake — spec, architecture, plan ready for PO review"
-git push -u origin codex/YYYY-MM-DD-<slug>
+git push -u origin <prefix>/YYYY-MM-DD-<slug>
 gh pr create --draft --title "feat(<slug>): ..." --body "..."
 ```
 

--- a/scripts/templates/consumer/init/.agents/skills/blueprint-consumer-upgrade/SKILL.md.tmpl
+++ b/scripts/templates/consumer/init/.agents/skills/blueprint-consumer-upgrade/SKILL.md.tmpl
@@ -8,7 +8,7 @@ description: Upgrade existing generated-consumer repositories from https://githu
 ## Workflow
 
 1. Verify the repo is a generated-consumer repo and the working tree is clean.
-2. Create a dedicated branch (`codex/...`) for the upgrade.
+2. Create a dedicated branch (`chore/blueprint-upgrade-<tag>`) for the upgrade.
 3. Resolve the latest stable tag from `https://github.com/sbonoc/stackit-platform-blueprint` unless the user pins a specific ref.
 4. Run consumer-seed resync in inspect mode, then safe-apply mode.
 5. Run upgrade preflight and review manual actions before apply mode.
@@ -25,7 +25,7 @@ Use these commands from the consumer repo root.
 
 ```bash
 # 0) branch + clean working tree
-git checkout -b codex/upgrade-blueprint-<tag-or-date>
+git checkout -b chore/blueprint-upgrade-<tag>
 git status --short
 
 # 1) resolve latest stable tag from fixed source

--- a/scripts/templates/consumer/init/.agents/skills/blueprint-sdd-step01-intake/SKILL.md.tmpl
+++ b/scripts/templates/consumer/init/.agents/skills/blueprint-sdd-step01-intake/SKILL.md.tmpl
@@ -116,7 +116,7 @@ BACKLOG SCAN (surface parked proposals before opening the Draft PR)
 
    git add specs/YYYY-MM-DD-<slug>/ docs/.../ADR-<slug>.md
    git commit -m "feat(<slug>): SDD intake — spec, architecture, plan ready for PO review"
-   git push -u origin codex/YYYY-MM-DD-<slug>
+   git push -u origin <prefix>/YYYY-MM-DD-<slug>
 
 10. Open Draft PR:
    gh pr create --draft \

--- a/scripts/templates/consumer/init/AGENTS.md.tmpl
+++ b/scripts/templates/consumer/init/AGENTS.md.tmpl
@@ -35,7 +35,7 @@ New cross-cutting concerns MUST be recorded in `north_star.md` and the appropria
 1. Read `AGENTS.md` before starting work.
 2. During `Discover`, `High-Level Architecture`, `Specify`, and `Plan`, do not use assumptions as substitutes for missing requirements; resolve ambiguity explicitly or mark the work item blocked.
 3. Spec-Driven Development is mandatory by default for assistant-executed work; bypass only when the user explicitly says not to follow SDD for the requested task.
-4. Start each new SDD work item with `make spec-scaffold ...`, which creates a dedicated non-default branch by default (`codex/<YYYY-MM-DD>-<slug>` unless overridden).
+4. Start each new SDD work item with `make spec-scaffold ...`, which creates a dedicated non-default branch by default (`<prefix>/<YYYY-MM-DD>-<slug>`). Choose the prefix that matches the change type: `feature/` for new capabilities, `fix/` for bug fixes, `docs/` for docs-only, `chore/` for maintenance. Pass `--branch <prefix>/YYYY-MM-DD-<slug>` to override the default (`feature/`).
 5. Execute the Spec-Driven Development lifecycle in order: `Discover -> High-Level Architecture -> Specify -> Plan -> Implement -> Verify -> Document -> Operate -> Publish`.
 6. Change code, tests, docs, and contract-adjacent files together.
 7. Keep platform-owned work in `make/platform.mk`, `make/platform/*.mk`, `scripts/bin/platform/**`, `scripts/lib/platform/**`, `apps/**`, and `docs/platform/**`.

--- a/scripts/templates/consumer/init/AGENTS.md.tmpl
+++ b/scripts/templates/consumer/init/AGENTS.md.tmpl
@@ -35,7 +35,7 @@ New cross-cutting concerns MUST be recorded in `north_star.md` and the appropria
 1. Read `AGENTS.md` before starting work.
 2. During `Discover`, `High-Level Architecture`, `Specify`, and `Plan`, do not use assumptions as substitutes for missing requirements; resolve ambiguity explicitly or mark the work item blocked.
 3. Spec-Driven Development is mandatory by default for assistant-executed work; bypass only when the user explicitly says not to follow SDD for the requested task.
-4. Start each new SDD work item with `make spec-scaffold ...`, which creates a dedicated non-default branch by default (`<prefix>/<YYYY-MM-DD>-<slug>`). Choose the prefix that matches the change type: `feature/` for new capabilities, `fix/` for bug fixes, `docs/` for docs-only, `chore/` for maintenance. Pass `--branch <prefix>/YYYY-MM-DD-<slug>` to override the default (`feature/`).
+4. Start each new SDD work item with `make spec-scaffold ...`, which creates a dedicated non-default branch by default (`<prefix>/<YYYY-MM-DD>-<slug>`). Choose the prefix that matches the change type: `feature/` for new capabilities, `fix/` for bug fixes, `docs/` for docs-only, `chore/` for maintenance. Pass `SPEC_BRANCH=<prefix>/YYYY-MM-DD-<slug>` to override the default (`feature/`).
 5. Execute the Spec-Driven Development lifecycle in order: `Discover -> High-Level Architecture -> Specify -> Plan -> Implement -> Verify -> Document -> Operate -> Publish`.
 6. Change code, tests, docs, and contract-adjacent files together.
 7. Keep platform-owned work in `make/platform.mk`, `make/platform/*.mk`, `scripts/bin/platform/**`, `scripts/lib/platform/**`, `apps/**`, and `docs/platform/**`.

--- a/scripts/templates/consumer/init/specs/README.md.tmpl
+++ b/scripts/templates/consumer/init/specs/README.md.tmpl
@@ -25,7 +25,7 @@ specs/<YYYY-MM-DD>-<work-item-slug>/
 1. SDD is default-required unless the user explicitly opts out for the current task.
 2. Scaffold the work item with dedicated branch creation:
    - `make spec-scaffold SPEC_SLUG=<work-item-slug> [SPEC_TRACK=blueprint|consumer]`
-   - default branch shape: `codex/<YYYY-MM-DD>-<work-item-slug>`
+   - default branch shape: `<prefix>/<YYYY-MM-DD>-<work-item-slug>` (e.g. `feature/`)
    - explicit opt-out: `SPEC_NO_BRANCH=true`
 3. Pick the template pack:
    - Blueprint maintainer work: `.spec-kit/templates/blueprint/*`

--- a/specs/2026-05-21-branch-naming-semantic/pr_context.md
+++ b/specs/2026-05-21-branch-naming-semantic/pr_context.md
@@ -1,0 +1,35 @@
+# PR Context
+
+## Summary
+Refactoring of the branch naming convention. `codex/` was hardwired as the default prefix for all AI-driven SDD branches, replacing semantic information (what the change is) with actor information (who created it). This PR restores the github-flow semantic model by making `feature/` the default and retiring `codex/`/`copilot/` from the registered prefix list (compat shim kept so old consumer branches remain valid). Also fixes `upgrade/` in the consumer upgrade skill, which was unregistered and would have failed `infra-validate --branch-only`.
+
+## Requirement and Contract Coverage
+
+| Requirement | Implementation | Evidence |
+|---|---|---|
+| REQ-001 — semantic prefix required | `blueprint/contract.yaml` + bootstrap mirror: removed `codex/`, `copilot/`; `default_prefix: feature/` | AC-001: `test_scaffold_creates_dedicated_branch_by_default` passes with `feature/` branch |
+| REQ-002 — compat shim retained | `validate_contract.py:51` `COMPAT_BRANCH_PURPOSE_PREFIXES` unchanged | `infra-validate` passes on main branch (passive check) |
+| REQ-003 — default prefix is `feature/` | `blueprint/contract.yaml:default_prefix: feature/` | AC-001 |
+| REQ-004 — no hardcoded `codex/` in scaffold | `spec_scaffold.py:_resolve_branch_prefix()` — hardcoded fallback removed | AC-003: 3 spec_scaffold tests pass |
+| REQ-005 — upgrade skill uses `chore/` | `blueprint-consumer-upgrade/SKILL.md` command sequence updated | `quality-hooks-fast` pass |
+
+## Key Reviewer Files
+- `blueprint/contract.yaml` — `purpose_prefixes` and `default_prefix` change
+- `scripts/bin/blueprint/spec_scaffold.py` — `_resolve_branch_prefix()` — 2 lines removed
+- `AGENTS.md` step 4 — updated default branch example
+- `.agents/skills/blueprint-sdd-step01-intake/SKILL.md` — AUTO-SCAFFOLD block updated
+- `.agents/skills/blueprint-consumer-upgrade/SKILL.md` — `upgrade/` → `chore/` in command sequence
+- `tests/blueprint/test_spec_scaffold.py` — expected branch name updated from `codex/` to `feature/`
+
+## Validation Evidence
+- `python3 -m pytest tests/blueprint/test_spec_scaffold.py -x -q` — 3 passed
+- `make quality-hooks-fast` — all 10 checks pass (shellcheck, quality-sdd-check-all, quality-docs-check-changed, infra-validate, infra-contract-test-fast, and 5 others)
+- No behaviour change: `validate_contract.py` compat shim unchanged; existing `codex/` and `copilot/` branches on consumer repos continue to pass `infra-validate --branch-only`
+
+## Risk and Rollback
+- Risk: very low — no runtime, infra, or application code changed. Only tooling convention and documentation updated.
+- Rollback: revert the commit. Restore `codex/` and `copilot/` to `purpose_prefixes` in both contracts, restore `default_prefix: codex/`, restore the `codex/`-first fallback in `_resolve_branch_prefix()`.
+- Consumer impact: none — the compat shim in `validate_contract.py` ensures old `codex/` branches on all consumer repos remain valid.
+
+## Deferred Proposals (Not Implemented)
+- none

--- a/specs/2026-05-21-branch-naming-semantic/pr_context.md
+++ b/specs/2026-05-21-branch-naming-semantic/pr_context.md
@@ -14,12 +14,17 @@ Refactoring of the branch naming convention. `codex/` was hardwired as the defau
 | REQ-005 — upgrade skill uses `chore/` | `blueprint-consumer-upgrade/SKILL.md` command sequence updated | `quality-hooks-fast` pass |
 
 ## Key Reviewer Files
-- `blueprint/contract.yaml` — `purpose_prefixes` and `default_prefix` change
-- `scripts/bin/blueprint/spec_scaffold.py` — `_resolve_branch_prefix()` — 2 lines removed
-- `AGENTS.md` step 4 — updated default branch example
-- `.agents/skills/blueprint-sdd-step01-intake/SKILL.md` — AUTO-SCAFFOLD block updated
-- `.agents/skills/blueprint-consumer-upgrade/SKILL.md` — `upgrade/` → `chore/` in command sequence
-- `tests/blueprint/test_spec_scaffold.py` — expected branch name updated from `codex/` to `feature/`
+- Primary files to review first:
+  - `blueprint/contract.yaml` — `purpose_prefixes` and `default_prefix` change
+  - `scripts/bin/blueprint/spec_scaffold.py` — `_resolve_branch_prefix()` — hardcoded `codex/` fallback removed
+  - `scripts/bin/quality/hooks_fast.sh` — publish-gate branch pattern widened
+  - `scripts/bin/quality/check_spec_pr_ready.py` — `_SDD_BRANCH_PATTERN` widened
+- Supporting files:
+  - `AGENTS.md` step 4 — updated default branch example and `SPEC_BRANCH=` syntax
+  - `.agents/skills/blueprint-sdd-step01-intake/SKILL.md` — AUTO-SCAFFOLD block updated
+  - `.agents/skills/blueprint-consumer-upgrade/SKILL.md` — `upgrade/` → `chore/` in command sequence
+  - `tests/blueprint/test_spec_scaffold.py` — expected branch name updated from `codex/` to `feature/`
+  - `tests/blueprint/test_spec_pr_ready.py` — branch pattern test extended for all semantic prefixes
 
 ## Validation Evidence
 - `python3 -m pytest tests/blueprint/test_spec_scaffold.py -x -q` — 3 passed

--- a/specs/2026-05-21-branch-naming-semantic/spec.md
+++ b/specs/2026-05-21-branch-naming-semantic/spec.md
@@ -1,0 +1,54 @@
+# Specification
+
+## Spec Readiness Gate (Blocking)
+- SPEC_READY: true
+- SPEC_PRODUCT_READY: true
+- Open questions count: 0
+- Unresolved alternatives count: 0
+- Unresolved TODO markers count: 0
+- Pending assumptions count: 0
+- Open clarification markers count: 0
+- Product sign-off: bonos
+- Architecture sign-off: bonos
+- Security sign-off: N/A — no runtime or security surface changed
+- Operations sign-off: N/A — no operational surface changed
+- Missing input blocker token: none
+- ADR path: none — refactor of tooling convention; no new architecture decision required
+- ADR status: N/A
+- SPEC_READY_EXCEPTION: refactor
+- authorized-by: bonos
+
+## Applicable Guardrail Controls (Normative)
+- Applicable control IDs: SDD-C-001, SDD-C-002
+- Control exception rationale: SDD-C-003 through SDD-C-021 not applicable — no new feature, no new API surface, no new runtime behaviour.
+
+## Implementation Stack Profile (Normative)
+- Backend stack profile: N/A — tooling / governance files only
+- Frontend stack profile: N/A
+- Test automation profile: pytest (spec_scaffold unit tests updated)
+- Managed-service profile: N/A
+- Local-first profile: N/A
+
+## Work Item Summary
+- Slug: branch-naming-semantic
+- Type: refactor
+- Issue: N/A (emerged from post-merge review in session)
+- Scope: `blueprint/contract.yaml`, `scripts/bin/blueprint/spec_scaffold.py`, `AGENTS.md`, skill runbooks, test
+
+## Problem Statement
+`codex/` was hardwired as the default branch prefix for all AI-driven SDD work items, regardless of whether the change was a feature, fix, refactor, or chore. This replaced semantic information (what the change is) with actor information (who created the branch), making the branch list unreadable at a glance and inconsistent with the github-flow model declared in the contract.
+
+Additionally, `upgrade/` was used in `blueprint-consumer-upgrade/SKILL.md` but was not registered in `purpose_prefixes`, meaning upgrade branches would fail `infra-validate --branch-only`.
+
+## Requirements (Normative)
+- REQ-001: Branch names MUST use a semantic purpose prefix that matches the change type (`feature/`, `fix/`, `docs/`, `chore/`, `refactor/`, etc.).
+- REQ-002: `codex/` and `copilot/` MUST be retained in `validate_contract.py`'s compat shim so existing consumer repos with old branches continue to pass infra-validate.
+- REQ-003: The default prefix for auto-generated SDD branches MUST be `feature/`.
+- REQ-004: `spec_scaffold.py` MUST NOT hardcode `codex/` as a preferred fallback; it MUST honour `default_prefix` from the contract, then fall back to `allowed_prefixes[0]`.
+- REQ-005: `blueprint-consumer-upgrade/SKILL.md` MUST use `chore/blueprint-upgrade-<tag>` instead of `upgrade/blueprint-<tag>`.
+
+## Acceptance Criteria (Normative)
+- AC-001: `make spec-scaffold SPEC_SLUG=<slug>` creates a branch with prefix `feature/` when no `--branch` override is given.
+- AC-002: `infra-validate --branch-only` MUST pass on branches with any registered semantic prefix.
+- AC-003: `tests/blueprint/test_spec_scaffold.py` passes with the updated expected branch name (`feature/...`).
+- AC-004: `quality-hooks-fast` exits 0 after all changes.

--- a/specs/README.md
+++ b/specs/README.md
@@ -25,7 +25,7 @@ specs/<YYYY-MM-DD>-<work-item-slug>/
 1. SDD is default-required unless the user explicitly opts out for the current task.
 2. Scaffold the work item with dedicated branch creation:
    - `make spec-scaffold SPEC_SLUG=<work-item-slug> [SPEC_TRACK=blueprint|consumer]`
-   - default branch shape: `codex/<YYYY-MM-DD>-<work-item-slug>`
+   - default branch shape: `<prefix>/<YYYY-MM-DD>-<work-item-slug>` (e.g. `feature/`)
    - explicit opt-out: `SPEC_NO_BRANCH=true`
 3. Pick the template pack:
    - Blueprint maintainer work: `.spec-kit/templates/blueprint/*`

--- a/tests/blueprint/test_spec_pr_ready.py
+++ b/tests/blueprint/test_spec_pr_ready.py
@@ -800,19 +800,23 @@ class BranchResolutionTests(unittest.TestCase):
                     os.environ["SPEC_SLUG"] = old_slug
 
     def test_sdd_branch_pattern_resolves_spec_dir(self) -> None:
-        """Verify the SDD branch regex matches correctly."""
-        import re
+        """Verify the SDD branch regex matches semantic-prefix and legacy codex/ branches."""
         pattern = _checker._SDD_BRANCH_PATTERN
+        # legacy codex/ prefix still accepted
         m = pattern.match("codex/2026-04-22-quality-spec-pr-ready-publish-gate")
         self.assertIsNotNone(m)
         self.assertEqual(m.group(1), "2026-04-22-quality-spec-pr-ready-publish-gate")
+        # new semantic prefixes
+        for prefix in ("feature", "fix", "chore", "docs", "refactor"):
+            m = pattern.match(f"{prefix}/2026-05-21-some-slug")
+            self.assertIsNotNone(m, msg=f"prefix '{prefix}/' should match")
+            self.assertEqual(m.group(1), "2026-05-21-some-slug")
 
     def test_non_sdd_branch_does_not_match_pattern(self) -> None:
-        import re
         pattern = _checker._SDD_BRANCH_PATTERN
         self.assertIsNone(pattern.match("main"))
-        self.assertIsNone(pattern.match("feature/something"))
-        self.assertIsNone(pattern.match("codex/not-date-prefixed"))
+        self.assertIsNone(pattern.match("feature/something"))       # no date component
+        self.assertIsNone(pattern.match("codex/not-date-prefixed"))  # no date component
 
 
 class ArchitectureCheckTests(unittest.TestCase):

--- a/tests/blueprint/test_spec_scaffold.py
+++ b/tests/blueprint/test_spec_scaffold.py
@@ -65,14 +65,14 @@ class SpecScaffoldBranchingTests(unittest.TestCase):
             self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
             self.assertEqual(
                 self._current_branch(repo_root),
-                "codex/2026-04-17-runtime-identity-contract",
+                "feature/2026-04-17-runtime-identity-contract",
             )
             self.assertTrue(
                 (repo_root / "specs/2026-04-17-runtime-identity-contract/spec.md").is_file(),
                 msg=result.stdout + result.stderr,
             )
             self.assertIn(
-                "active SDD branch: codex/2026-04-17-runtime-identity-contract",
+                "active SDD branch: feature/2026-04-17-runtime-identity-contract",
                 result.stdout,
             )
 


### PR DESCRIPTION
## Summary
Refactors the branch naming convention so purpose prefixes are semantic (`feature/`, `fix/`, `docs/`, `chore/`) rather than actor-based (`codex/`). `codex/` was hardwired as the default for all AI-driven SDD branches, hiding the nature of a change behind who created it. This PR restores the github-flow semantic model across the contract, scaffold tooling, AGENTS.md, and all skill runbooks. Also fixes `upgrade/` in the consumer upgrade skill, which was unregistered and would fail `infra-validate --branch-only`. The `codex/` and `copilot/` prefixes are retained in the `validate_contract.py` compat shim so existing consumer branches remain valid.

Spec: `specs/2026-05-21-branch-naming-semantic/` (`SPEC_READY_EXCEPTION: refactor`, authorized-by: bonos)

## Requirement and Contract Coverage

| Requirement | Implementation | Evidence |
|---|---|---|
| REQ-001 — semantic prefix required | `blueprint/contract.yaml` + bootstrap mirror: removed `codex/`, `copilot/` from `purpose_prefixes`; `default_prefix: feature/` | `test_scaffold_creates_dedicated_branch_by_default` passes with `feature/` branch |
| REQ-002 — compat shim retained | `validate_contract.py:51` `COMPAT_BRANCH_PURPOSE_PREFIXES` unchanged | `infra-validate` passess; `test_branch_naming_compat_accepts_codex_prefix_for_legacy_contract` passes |
| REQ-003 — default prefix is `feature/` | `blueprint/contract.yaml:default_prefix: feature/` | `test_scaffold_creates_dedicated_branch_by_default` passes |
| REQ-004 — no hardcoded `codex/` in scaffold | `spec_scaffold.py:_resolve_branch_prefix()` — 2-line hardcoded fallback removed | 3 spec_scaffold tests pass |
| REQ-005 — upgrade skill uses `chore/` | `blueprint-consumer-upgrade/SKILL.md` command sequence updated | pre-push hooks pass |

## Key Reviewer Files
- `blueprint/contract.yaml` — `purpose_prefixes` (removed `codex/`, `copilot/`) and `default_prefix: feature/`
- `scripts/bin/blueprint/spec_scaffold.py` — `_resolve_branch_prefix()` — hardcoded `codex/`-first fallback removed (2 lines)
- `AGENTS.md` step 4 — semantic prefix selection rule documented
- `.agents/skills/blueprint-sdd-step01-intake/SKILL.md` — AUTO-SCAFFOLD block updated with prefix selection guidance
- `.agents/skills/blueprint-consumer-upgrade/SKILL.md` — `upgrade/` → `chore/blueprint-upgrade-<tag>`
- `tests/blueprint/test_spec_scaffold.py` — expected default branch updated to `feature/`

## Validation Evidence
- `python3 -m pytest tests/blueprint/test_spec_scaffold.py -x -q` — 3 passed
- `python3 -m pytest tests/blueprint/test_tooling_contracts.py tests/blueprint/test_optional_runtime_contract_validation.py tests/blueprint/test_quality_contracts.py -q` — all pass
- `git push` pre-push hook suite — all 13 checks pass (blueprint unit test suite + consumer pre-push quality gate)
- `make quality-sdd-check-all` — passes; bypass track metric emitted: `type=refactor authorized_by=bonos`

## Risk and Rollback
- Risk: very low — no runtime, infra, or application code changed. Tooling convention and documentation only. Consumer repos with old `codex/` branches are unaffected (compat shim retained).
- Rollback: revert commits on this branch. Restore `codex/` and `copilot/` to `purpose_prefixes`, restore `default_prefix: codex/`, restore the `codex/`-first fallback in `_resolve_branch_prefix()`.

## Deferred Proposals (Not Implemented)
- none