### PR TITLE
chore: mark issue-248 identity-aware-proxy done in backlog

### DIFF
--- a/AGENTS.backlog.md
+++ b/AGENTS.backlog.md
@@ -68,7 +68,7 @@ To introduce a new tag, append a row here in the same commit that uses it.
 
 ### P2 — Platform modules
 
-- [ ] Issue #248 remaining modules — STACKIT-managed service candidates (kms ✅, secrets-manager ✅ PR #305, dns ✅ PR #306, public-endpoints ✅ PR #307, observability ✅ PR #308, workflows ✅ PR #314 + local lane ✅ PR #316, identity-aware-proxy). Gate on #295 removed — architecture decision recorded in `AGENTS.decisions.md`: OM is consumer/product-owned and not a blueprint module candidate.
+- [x] Issue #248 remaining modules — STACKIT-managed service candidates (kms ✅, secrets-manager ✅ PR #305, dns ✅ PR #306, public-endpoints ✅ PR #307, observability ✅ PR #308, workflows ✅ PR #314 + local lane ✅ PR #316, identity-aware-proxy ✅ PR #318). Gate on #295 removed — architecture decision recorded in `AGENTS.decisions.md`: OM is consumer/product-owned and not a blueprint module candidate. Issue #248 fully closed.
 - [ ] Issue #171 — managed-cache module: STACKIT Managed Redis as a first-class optional module (Helm/ArgoCD-managed, provider-backed via STACKIT Terraform).
 - [ ] Issue #172 — platform-email module: Helm/ArgoCD-managed Postal for transactional email as an optional module.
 


### PR DESCRIPTION
## Summary

- Marks `identity-aware-proxy` as `[x]` in `AGENTS.backlog.md` (PR #318 merged 2026-05-21).
- Updates the issue #248 umbrella entry to reflect all 11 modules are now complete and issue #248 is fully closed.

Closes #248.

## Sign-off

Grant each sign-off by leaving a PR comment with the **exact** phrase below:

| Role | Exact PR comment phrase |
|---|---|
| Product | `SPEC_PRODUCT_READY: approved` |
| Architecture | `ARCHITECTURE_SIGNOFF: approved` |
| Security | `SECURITY_SIGNOFF: approved` |
| Operations | `OPERATIONS_SIGNOFF: approved` |