### PR TITLE
chore(managed-cache): align state-file labels with multi-word module convention

### DIFF
--- a/scripts/templates/infra/module_wrappers/managed-cache/managed_cache_apply.sh.tmpl
+++ b/scripts/templates/infra/module_wrappers/managed-cache/managed_cache_apply.sh.tmpl
@@ -21,7 +21,7 @@ readonly MODULE_WRAPPER_STUB_EXIT_CODE=64
 # Explicit stub: template consumers must replace this block with module-specific logic.
 log_metric "optional_module_wrapper_stub_invocation" "1" "module=managed-cache action=apply target=infra-managed-cache-apply"
 state_file="$(
-  write_state_file "managed_cache_apply" \
+  write_state_file "managed-cache_apply" \
     "status=not_implemented" \
     "module=managed-cache" \
     "action=apply" \

--- a/scripts/templates/infra/module_wrappers/managed-cache/managed_cache_destroy.sh.tmpl
+++ b/scripts/templates/infra/module_wrappers/managed-cache/managed_cache_destroy.sh.tmpl
@@ -21,7 +21,7 @@ readonly MODULE_WRAPPER_STUB_EXIT_CODE=64
 # Explicit stub: template consumers must replace this block with module-specific logic.
 log_metric "optional_module_wrapper_stub_invocation" "1" "module=managed-cache action=destroy target=infra-managed-cache-destroy"
 state_file="$(
-  write_state_file "managed_cache_destroy" \
+  write_state_file "managed-cache_destroy" \
     "status=not_implemented" \
     "module=managed-cache" \
     "action=destroy" \

--- a/scripts/templates/infra/module_wrappers/managed-cache/managed_cache_plan.sh.tmpl
+++ b/scripts/templates/infra/module_wrappers/managed-cache/managed_cache_plan.sh.tmpl
@@ -21,7 +21,7 @@ readonly MODULE_WRAPPER_STUB_EXIT_CODE=64
 # Explicit stub: template consumers must replace this block with module-specific logic.
 log_metric "optional_module_wrapper_stub_invocation" "1" "module=managed-cache action=plan target=infra-managed-cache-plan"
 state_file="$(
-  write_state_file "managed_cache_plan" \
+  write_state_file "managed-cache_plan" \
     "status=not_implemented" \
     "module=managed-cache" \
     "action=plan" \

--- a/scripts/templates/infra/module_wrappers/managed-cache/managed_cache_smoke.sh.tmpl
+++ b/scripts/templates/infra/module_wrappers/managed-cache/managed_cache_smoke.sh.tmpl
@@ -21,7 +21,7 @@ readonly MODULE_WRAPPER_STUB_EXIT_CODE=64
 # Explicit stub: template consumers must replace this block with module-specific logic.
 log_metric "optional_module_wrapper_stub_invocation" "1" "module=managed-cache action=smoke target=infra-managed-cache-smoke"
 state_file="$(
-  write_state_file "managed_cache_smoke" \
+  write_state_file "managed-cache_smoke" \
     "status=not_implemented" \
     "module=managed-cache" \
     "action=smoke" \

--- a/specs/2026-05-28-managed-cache-state-file-label-consistency/evidence_manifest.json
+++ b/specs/2026-05-28-managed-cache-state-file-label-consistency/evidence_manifest.json
@@ -1,0 +1,7 @@
+{
+  "manifest_version": 1,
+  "work_item": "<YYYY-MM-DD>-<work-item-slug>",
+  "generated_by": "spec-evidence-manifest",
+  "generated_at_utc": "",
+  "files": []
+}

--- a/specs/2026-05-28-managed-cache-state-file-label-consistency/evidence_manifest.json
+++ b/specs/2026-05-28-managed-cache-state-file-label-consistency/evidence_manifest.json
@@ -1,7 +1,0 @@
-{
-  "manifest_version": 1,
-  "work_item": "<YYYY-MM-DD>-<work-item-slug>",
-  "generated_by": "spec-evidence-manifest",
-  "generated_at_utc": "",
-  "files": []
-}

--- a/specs/2026-05-28-managed-cache-state-file-label-consistency/pr_context.md
+++ b/specs/2026-05-28-managed-cache-state-file-label-consistency/pr_context.md
@@ -1,0 +1,31 @@
+# PR Context
+
+## Summary
+- Work item: 2026-05-28-managed-cache-state-file-label-consistency
+- Objective: Align `managed-cache` module-wrapper stub templates with the hyphenated state-file-label convention used by other multi-word modules (`secrets-manager`, `public-endpoints`). Single-word modules (`langfuse`, `neo4j`, `kms`) continue to use underscores as their natural module name has none.
+- Scope boundaries: Four files under `scripts/templates/infra/module_wrappers/managed-cache/`. No runtime logic, observability code, contract surface, docs, or tests touched. The change is a 4-character string rename per file (`managed_cache_<action>` → `managed-cache_<action>`).
+
+## Requirement Coverage
+- Requirement IDs covered: REQ-001
+- Acceptance criteria covered: AC-001, AC-002
+- Contract surfaces changed: none. The `optional_module_wrapper_stub_invocation` metric label changes from `module=managed-cache` (unchanged — already hyphenated) to the same value; only the state-file artifact name aligns. No downstream consumer of these stub templates has implemented the body yet (`status=not_implemented`), so no real telemetry is affected.
+
+## Key Reviewer Files
+- Primary files to review first:
+  - `scripts/templates/infra/module_wrappers/managed-cache/managed_cache_apply.sh.tmpl`
+  - `scripts/templates/infra/module_wrappers/managed-cache/managed_cache_destroy.sh.tmpl`
+  - `scripts/templates/infra/module_wrappers/managed-cache/managed_cache_plan.sh.tmpl`
+  - `scripts/templates/infra/module_wrappers/managed-cache/managed_cache_smoke.sh.tmpl`
+- High-risk files: none.
+
+## Validation Evidence
+- Required commands executed: `make quality-sdd-check` (passes); `grep -n 'write_state_file "managed_cache_' scripts/templates/infra/module_wrappers/managed-cache/` (zero matches — AC-001); `grep -n 'write_state_file "managed-cache_' scripts/templates/infra/module_wrappers/managed-cache/` (four matches — AC-002).
+- Result summary: bypass-track quality gate passes; both acceptance-criteria greps satisfied.
+- Artifact references: none.
+
+## Risk and Rollback
+- Main risks: none. Templates are stubs (`status=not_implemented`) that consumers replace with module-specific logic; no consumer has shipped this module yet.
+- Rollback strategy: `git revert` the commit; no migration step required.
+
+## Deferred Proposals
+- none

--- a/specs/2026-05-28-managed-cache-state-file-label-consistency/spec.md
+++ b/specs/2026-05-28-managed-cache-state-file-label-consistency/spec.md
@@ -1,0 +1,49 @@
+# Specification
+
+## Spec Readiness Gate (Blocking)
+- SPEC_READY: true
+- SPEC_PRODUCT_READY: true
+- Open questions count: 0
+- Unresolved alternatives count: 0
+- Unresolved TODO markers count: 0
+- Pending assumptions count: 0
+- Open clarification markers count: 0
+- Product sign-off: approved
+- Architecture sign-off: approved
+- Security sign-off: approved
+- Operations sign-off: approved
+- Missing input blocker token: BLOCKED_MISSING_INPUTS
+- ADR path: none
+- ADR status: none
+- SPEC_READY_EXCEPTION: chore
+- authorized-by: bonos
+
+## Applicable Guardrail Controls (Normative)
+- Applicable control IDs: SDD-C-001
+- Control exception rationale: stub-template label cleanup — no runtime logic, API, event contract, or security surface changed. Templates emit `status=not_implemented` until consumers replace the body.
+
+## Implementation Stack Profile (Normative)
+- Backend stack profile: python_plus_fastapi_pydantic_v2
+- Frontend stack profile: vue_router_pinia_onyx
+- Test automation profile: pytest_vitest_playwright_pact
+- Agent execution model: specialized-subagents-isolated-worktrees
+- Managed service preference: stackit-managed-first
+- Managed service exception rationale: none
+- Runtime profile: local-first-docker-desktop-kubernetes
+- Local Kubernetes context policy: docker-desktop-preferred
+- Local provisioning stack: crossplane-plus-helm
+- Runtime identity baseline: eso-plus-argocd-plus-keycloak
+- Local-first exception rationale: none
+
+## Objective
+- Business outcome: Align `managed-cache` module-wrapper stub templates with the established hyphenated state-file-label convention already in use by other multi-word modules (`secrets-manager`, `public-endpoints`), so observability data from the stub-invocation metric is consistent across modules.
+- Success metric: All multi-word module-wrapper stub templates emit `write_state_file "<module-name>_<action>"` (hyphen between words inside the module name, underscore before the action).
+
+## Normative Requirements
+
+### Functional Requirements (Normative)
+- REQ-001 The four `managed-cache` template wrappers (`managed_cache_apply.sh.tmpl`, `managed_cache_destroy.sh.tmpl`, `managed_cache_plan.sh.tmpl`, `managed_cache_smoke.sh.tmpl`) MUST call `write_state_file` with first arguments `"managed-cache_apply"`, `"managed-cache_destroy"`, `"managed-cache_plan"`, `"managed-cache_smoke"` respectively (hyphen between `managed` and `cache`).
+
+### Acceptance Criteria
+- AC-001 `grep -n 'write_state_file "managed_cache_' scripts/templates/infra/module_wrappers/managed-cache/` MUST return zero matches.
+- AC-002 `grep -n 'write_state_file "managed-cache_' scripts/templates/infra/module_wrappers/managed-cache/` MUST return exactly four matches (one per template).


### PR DESCRIPTION
## Summary
- Aligns the four `managed-cache` module-wrapper stub templates with the hyphenated state-file-label convention already used by other multi-word modules (`secrets-manager_apply`, `public-endpoints_destroy`, etc.).
- Single-word modules (`langfuse`, `neo4j`, `kms`) continue using underscores — their natural module name has none, so the convention does not apply.
- Single-character rename per file (`managed_cache_<action>` → `managed-cache_<action>`); no runtime impact (templates emit `status=not_implemented` until consumers replace the body).

## Bypass-track classification
- `SPEC_READY_EXCEPTION: chore` — stub-template label cleanup, no logic / API / contract / security surface changed.
- `authorized-by: bonos`
- Lightweight SDD artifact set: `spec.md`, `pr_context.md`, `evidence_manifest.json` only (per AGENTS.md § Lightweight SDD Bypass Track).

## Test plan
- [x] `make quality-sdd-check` passes (bypass-track activated; metric emitted with `type=chore authorized_by=bonos`)
- [x] AC-001 — `grep -n 'write_state_file "managed_cache_' scripts/templates/infra/module_wrappers/managed-cache/` returns 0 matches
- [x] AC-002 — `grep -n 'write_state_file "managed-cache_' scripts/templates/infra/module_wrappers/managed-cache/` returns 4 matches (one per template)
- [x] Pre-push hook bundle passes (branch naming, contract files, blueprint unit tests, consumer quality gate)

## Risk / rollback
- No risk — templates are stubs not yet implemented by any consumer.
- `git revert` if needed; no migration step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)