### PR TITLE
chore: add release/ to allowed branch purpose_prefixes

### DIFF
--- a/blueprint/contract.yaml
+++ b/blueprint/contract.yaml
@@ -16,6 +16,7 @@ spec:
         - feature/
         - fix/
         - hotfix/
+        - release/
         - chore/
         - docs/
         - refactor/

--- a/scripts/templates/blueprint/bootstrap/blueprint/contract.yaml
+++ b/scripts/templates/blueprint/bootstrap/blueprint/contract.yaml
@@ -16,6 +16,7 @@ spec:
         - feature/
         - fix/
         - hotfix/
+        - release/
         - chore/
         - docs/
         - refactor/


### PR DESCRIPTION
## Summary

- Adds `release/` to `purpose_prefixes` in `blueprint/contract.yaml` and its bootstrap template mirror
- Required to allow `release/v1.12.x` (and future patch release branches) to pass the branch-naming pre-push hook
- Both source and template updated atomically to avoid bootstrap template drift check failure

## Test plan

- [x] Bootstrap template drift check passes (pre-commit hook verified)
- [x] All 1476 unit tests pass (pre-push verified)
- No functional change — governance config only

🤖 Generated with [Claude Code](https://claude.com/claude-code)